### PR TITLE
Allow any translation file for menu items - fixes #8

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,9 +29,20 @@
       <ul class="nav navbar-nav menu-target contrast-switcher" id="menu">
         {%- if site.menu -%}
           {%- for item in site.menu -%}
+          {%- assign translation_keys = item.translation_key | split: "." -%}
+          {%- assign translated_item = false -%}
+          {%- for key in translation_keys -%}
+            {%- if t[key] -%}
+              {%- assign translated_item = t[key] -%}
+            {%- elsif translated_item[key] -%}
+              {%- assign translated_item = translated_item[key] -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if translated_item -%}
           <li class="nav-link {% if page.permalink contains item.path %}active{% endif %}">
-            <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ t.menu[item.translation_key] }}</a>
+            <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ translated_item }}</a>
           </li>
+          {%- endif -%}
           {%- endfor -%}
         {%- else -%}
         <li {% if page.permalink contains "/reporting-status/" or page.permalink contains "/news" or page.permalink contains "/about" or page.layout=="post"  or page.permalink contains "/faq"  or page.permalink contains "/publications" or page.permalink contains "/guidance" %}class="nav-link"


### PR DESCRIPTION
This is a breaking change, so existing implementations will need to update their menu config. Instead of just having "reporting_status" (like before), it will need to say "menu.reporting_status".