### PR TITLE
Avoid extra slashes in image paths

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -79,7 +79,7 @@ function imageFix(contrast) {
   } else {
     // Remove high-contrast
     _.each($('img[src*=high-contrast]'), function(goalImage){
-      $(goalImage).attr('src', $(goalImage).attr('src').replace('high-contrast', ''));
+      $(goalImage).attr('src', $(goalImage).attr('src').replace('high-contrast/', ''));
     })
   }
 };


### PR DESCRIPTION
This avoids the accumulation of slashes in the image paths when toggling back and forth from high-contrast mode.

Fixes #35 