### PR TITLE
move data acquisition to top of layout fixes #64

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
     <head>
-        {%- include multilingual.html -%}
         <script>var translations = {};</script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
         <!-- Basic Page Needs

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,9 +14,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Title and meta description
         ================================================== -->
-        {% assign goal = site.goals | where: "sdg_goal", page.sdg_goal | first %}
         {% capture page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal.goal }} - {{ goal.short }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
         {% endcapture %}
         <title>{% if page.indicator %}{{ page_title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
         <meta name="description" content="">

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -3,7 +3,6 @@
   Before we start the html we fetch the data and metadata for this page
 
 {%- endcomment -%}
-{%- include multilingual.html -%}
 
 {% capture indicator_id %}{{page.indicator | slugify}}{% endcapture %}
 {% assign meta = site.data.meta[indicator_id] %}
@@ -16,15 +15,14 @@
 {%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
 {%- assign translated_goal = t.global_goals[goal_number] -%}
 {% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
+{% capture goal_href %}{{ goal_uri }}{% endcapture %}
+{% capture goal_title %}{{ goal.title }}{% endcapture %}
 
 {% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
   {% assign show_data = false %}
 {% else %}
   {% assign show_data = true %}
 {% endif %}
-
-{% capture goal_href %}{{ goal_uri }}{% endcapture %}
-{% capture goal_title %}{{ goal.title }}{% endcapture %}
 
 {% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
 

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -1,0 +1,36 @@
+{%- comment -%}
+
+  Before we start the html we fetch the data and metadata for this page
+
+{%- endcomment -%}
+{%- include multilingual.html -%}
+
+{% capture indicator_id %}{{page.indicator | slugify}}{% endcapture %}
+{% assign meta = site.data.meta[indicator_id] %}
+{%- if meta[current_language] -%}
+  {%- assign meta = meta[current_language] -%}
+{%- endif -%}
+{% assign headline = site.data.headline[indicator_id] %}
+
+{%- assign goal_number = meta.sdg_goal | downcase -%}
+{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
+{%- assign translated_goal = t.global_goals[goal_number] -%}
+{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
+
+{% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
+  {% assign show_data = false %}
+{% else %}
+  {% assign show_data = true %}
+{% endif %}
+
+{% capture goal_href %}{{ goal_uri }}{% endcapture %}
+{% capture goal_title %}{{ goal.title }}{% endcapture %}
+{% capture indicator_title %}{{ meta.title }}{% endcapture %}
+
+{% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
+
+{% assign sdg_indicator_data = site.data[dataset_name] %}
+{% assign indicator_metadata = sdg_indicators | where: "indicator_id", meta.indicator | first %}
+{% assign json_data = sdg_indicator_data | jsonify %}
+{%- assign indicator_number = meta.indicator -%}
+{%- assign translated_indicator = t.global_indicators[indicator_number] -%}

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -25,12 +25,8 @@
 
 {% capture goal_href %}{{ goal_uri }}{% endcapture %}
 {% capture goal_title %}{{ goal.title }}{% endcapture %}
-{% capture indicator_title %}{{ meta.title }}{% endcapture %}
 
 {% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
 
-{% assign sdg_indicator_data = site.data[dataset_name] %}
-{% assign indicator_metadata = sdg_indicators | where: "indicator_id", meta.indicator | first %}
-{% assign json_data = sdg_indicator_data | jsonify %}
-{%- assign indicator_number = meta.indicator -%}
-{%- assign translated_indicator = t.global_indicators[indicator_number] -%}
+{%- assign json_data = site.data[dataset_name] | jsonify -%}
+{%- assign translated_indicator = t.global_indicators[meta.indicator] -%}

--- a/_includes/multilingual.html
+++ b/_includes/multilingual.html
@@ -11,6 +11,7 @@
 {%- endcomment -%}
 {%- assign default_language = site.languages[0] -%}
 {%- assign current_language = page.language -%}
+
 {%- assign t = site.data.translations[current_language] -%}
 {%- if current_language == default_language -%}
   {%- assign baseurl_folder = '' -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 {{ content }}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container goal-tiles" role="main">

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 {% assign goal_number = page.sdg_goal %}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {%- include indicator-variables.html -%}
 {% include head.html %}
 {% include header.html %}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -1,38 +1,9 @@
+{%- include indicator-variables.html -%}
 {% include head.html %}
 {% include header.html %}
 {% include components/fields-template.html %}
 {% include components/units-template.html %}
 {% include multilingual-js.html key="indicator" %}
-
-{% capture indicator_id %}{{page.indicator | slugify}}{% endcapture %}
-{% assign meta = site.data.meta[indicator_id] %}
-{%- if meta[current_language] -%}
-  {%- assign meta = meta[current_language] -%}
-{%- endif -%}
-{% assign headline = site.data.headline[indicator_id] %}
-
-{%- assign goal_number = meta.sdg_goal | downcase -%}
-{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
-{%- assign translated_goal = t.global_goals[goal_number] -%}
-{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
-
-{% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
-  {% assign show_data = false %}
-{% else %}
-  {% assign show_data = true %}
-{% endif %}
-
-{% capture goal_href %}{{ goal_uri }}{% endcapture %}
-{% capture goal_title %}{{ goal.title }}{% endcapture %}
-{% capture indicator_title %}{{ meta.title }}{% endcapture %}
-
-{% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
-
-{% assign sdg_indicator_data = site.data[dataset_name] %}
-{% assign indicator_metadata = sdg_indicators | where: "indicator_id", meta.indicator | first %}
-{% assign json_data = sdg_indicator_data | jsonify %}
-{%- assign indicator_number = meta.indicator -%}
-{%- assign translated_indicator = t.global_indicators[indicator_number] -%}
 
 <div class="heading indicator goal-{{ goal_number }}">
   <div class="container">

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -19,7 +19,7 @@
             <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
           </a>
         </h1>
-        <h2>{{ t.general.indicator }} {{ indicator_number }}: {{ translated_indicator.title }}</h2>
+        <h2>{{ t.general.indicator }} {{ meta.indicator }}: {{ translated_indicator.title }}</h2>
       </div>
     </div>
   </div>

--- a/_layouts/initiative.html
+++ b/_layouts/initiative.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container" role="main">

--- a/_layouts/initiatives.html
+++ b/_layouts/initiatives.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container" role="main">

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container reportingstatus" data-url="{{ site.baseurl }}/indicators.json">

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container search-results" role="main">

--- a/docs/automation/github.md
+++ b/docs/automation/github.md
@@ -1,0 +1,16 @@
+<h1>Github and automated tests</h1>
+
+Whatever service you choose for automation, you will need to enable the "hooks" in your Github repositories so that the automated testing will happen. The goal is for automated tests to run every time a "pull request" is created. This way, if the pull request would have broken something, you will know in advance.
+
+The procedure is the same for both the site repository and the data repository:
+
+1. Go to the repository in Github
+1. Click the "Settings" tab
+1. Click the "Branches" sidebar item
+1. Make sure the "default" branch is: `develop`
+1. Under "Branch protection rules" click "Add rule"
+1. Under "Apply rule to" enter `develop`
+1. Check the box "Require status checks to pass before merging"
+1. Under "Status checks found in the last week for this repository" check the appropriate box.
+
+The last step above depends on your choice of automation service, but that is where you tell Github that some tests need to pass. Perform the steps above for both the site repository and the data repository.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,7 +19,7 @@ This part may be painful if you are not accustomed to command-line work. But don
 
 1. Open your operating system's Terminal application (use Git BASH, if on Windows).
 1. Create the SSH keys by entering this command (substituting a real email address):
-    `ssh-keygen -t rsa -b 4096 -C "my-email-address@example.com"`
+    `ssh-keygen -m pem -t rsa -b 4096 -C "my-email-address@example.com"`
     1. When prompted "Enter file in which to save the key", enter `my-site-key`
     1. When prompted "Enter passphrase", just hit `Enter`.
     1. When prompted "Enter same passphrase again", just hit `Enter` again.
@@ -40,6 +40,7 @@ Confirm that 4 files have been created:
     1. Click "Add deploy key"
     1. For "Title" enter anything, such as `CircleCI key`
     1. For "Key" paste in the contents of `my-site-key.pub` (created earlier)
+        * _Tip_: A quick way to see the contents of the file is to go back to the terminal and enter: `cat my-site-key.pub`. Drag-select this output to copy it into your clipboard.
     1. Check "Allow write access"
     1. Click "Add key"
     1. Select and copy the "Fingerprint" that appears (you may need to refresh the page)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -104,6 +104,7 @@ At this point, any new updates in the "develop" branches of the repositories wil
 
 ## Possible next steps?
 
-1. Add data and metadata to the data repository
-1. Tweak and customise the site repository as needed
-1. Set up the "master" branch to deploy to a separate "production" environment
+1. [Turn on automation in your repositories](../automation/github/)
+1. [Add data and metadata to the data repository](../making-updates/)
+1. [Tweak and customise the site repository as needed](../customisation/)
+1. [Set up the "master" branch to deploy to a separate "production" environment](../deployment/)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,7 +19,7 @@ This part may be painful if you are not accustomed to command-line work. But don
 
 1. Open your operating system's Terminal application (use Git BASH, if on Windows).
 1. Create the SSH keys by entering this command (substituting a real email address):
-    `ssh-keygen -m pem -t rsa -b 4096 -C "my-email-address@example.com"`
+    `ssh-keygen -t rsa -b 4096 -C "my-email-address@example.com"`
     1. When prompted "Enter file in which to save the key", enter `my-site-key`
     1. When prompted "Enter passphrase", just hit `Enter`.
     1. When prompted "Enter same passphrase again", just hit `Enter` again.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ pages:
         - CircleCI: automation/circle-ci.md
         - TravisCI: automation/travis-ci.md
         - Jenkins: automation/jenkins.md
+        - Github integration: automation/github.md
     - Hosting:
         - Github pages: hosting/github-pages.md
         - AWS S3: hosting/aws-s3.md


### PR DESCRIPTION
The indicator page has to get a lot of data that's been imported from the data sets and the metadata. This PR loads that data earlier so that the metadata about goals can be pulled through to the page head.