### PR TITLE
Two column goal pages, with targets on left

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test.prep:
 	cd tests && npm install
 
 test.serve:
-	# Serve the Jekyll site at http://127.0.0.1:4000/
+	# Serve the Jekyll site at http://127.0.0.1:4000/open-sdg-site-testing/
 	cd starter && bundle exec jekyll serve --detach --skip-initial-build
 
 test.html:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test.prep:
 	cd tests && npm install
 
 test.serve:
-	# Serve the Jekyll site at http://127.0.0.1:4000/open-sdg-site-testing/
+	# Serve the Jekyll site at http://127.0.0.1:4000/
 	cd starter && bundle exec jekyll serve --detach --skip-initial-build
 
 test.html:

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -24,57 +24,74 @@
   {{ content }}
   {% include components/breadcrumb.html %}
 
-  {% assign goal_indicators = site.data.meta | where: 'sdg_goal', page.sdg_goal | sort: 'indicator_sort_order' %}
-  {% for indicator in goal_indicators %}
-    {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
+  <div class="visible-md-block visible-lg-block">
+    <div class="col-md-6">
+      <h4>{{ t.general.targets }}</h4>
+    </div>
+    <div class="col-md-6">
+      <h4>{{ t.general.indicators }}</h4>
+    </div>
+  </div>
 
-    {% if indicator.reporting_status == 'notstarted' %}
-      {% assign status_desc = t.status.exploring_data_sources %}
-      {% assign status_css = 'danger' %}
-    {% endif %}
-    {% if indicator.reporting_status == 'inprogress' %}
-      {% assign status_desc = t.status.statistics_in_progress %}
-      {% assign status_css = 'warning' %}
-    {% endif %}
-    {% if indicator.reporting_status == 'complete' %}
-      {% assign status_desc = t.status.reported_online %}
-      {% assign status_css = 'success' %}
-    {% endif %}
-    {% assign tag_classes = "" | split: "," %}
-    {% if indicator.tags %}
-      {% for tag in indicator.tags %}
-        {% assign tag_slug = "indicator-" | append: tag | slugify %}
-        {% assign tag_classes = tag_classes | push: tag_slug %}
-      {% endfor %}
-    {% endif %}
-    {% assign tag_classes = tag_classes | join: " " %}
+  {% assign goal_indicators = site.data.meta | where: 'sdg_goal', goal_number | sort: 'indicator_sort_order' | group_by: 'target_id' %}
+  {% for group in goal_indicators %}
+    {% assign target_id = group.name %}
+    {% assign translated_target = t.global_targets[target_id] %}
+    <div class="indicator-cards target col-md-6">
+      <span>
+        <label class="hidden-md hidden-lg">{{ t.general.target }}</label>
+        {{ target_id }}
+      </span>
+      {{ translated_target.title }}
+    </div>
+    <div class="indicator-cards col-md-6 row no-gutters">
+    {% for indicator in group.items %}
 
-    {% cycle 'add row' : '<div class="indicator-cards row no-gutters">', '', '', '' %}
-        <div class="col-md-6 col-lg-3 {{ tag_classes }}">
-          <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator.indicator | slugify }}">
-            <span>
-              {{ indicator.indicator }}
-              <span class="status {{ status_css }}">
-                {{ status_desc }}
-              </span>
+      {% if indicator.reporting_status == 'notstarted' %}
+        {% assign status_desc = t.status.exploring_data_sources %}
+        {% assign status_css = 'danger' %}
+      {% endif %}
+      {% if indicator.reporting_status == 'inprogress' %}
+        {% assign status_desc = t.status.statistics_in_progress %}
+        {% assign status_css = 'warning' %}
+      {% endif %}
+      {% if indicator.reporting_status == 'complete' %}
+        {% assign status_desc = t.status.reported_online %}
+        {% assign status_css = 'success' %}
+      {% endif %}
+      {% assign tag_classes = "" | split: "," %}
+      {% if indicator.tags %}
+        {% for tag in indicator.tags %}
+          {% assign tag_slug = "indicator-" | append: tag | slugify %}
+          {% assign tag_classes = tag_classes | push: tag_slug %}
+        {% endfor %}
+      {% endif %}
+      {% assign tag_classes = tag_classes | join: " " %}
+
+      {% assign translated_indicator = t.global_indicators[indicator.indicator] %}
+
+      <div class="col-md-12 {{ tag_classes }}">
+        <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator.indicator | slugify }}">
+          <span>
+            {{ indicator.indicator }}
+            <span class="status {{ status_css }}">
+              {{ status_desc }}
             </span>
-            {{ translated_indicator.title }}
-            {% if indicator.tags %}
-              <ul class="tags">
-              {% for tag in indicator.tags %}
-                {% assign tag_class = tag | slugify %}
-                <li class="tag-{{ tag_class }} warning">{{ tag }}</li>
-              {% endfor %}
-              </ul>
-            {% endif %}
-          </a>
-        </div>
-    {% cycle 'end row' : '', '', '', '</div>' %}
+          </span>
+          {{ translated_indicator.title }}
+          {% if indicator.tags %}
+            <ul class="tags">
+            {% for tag in indicator.tags %}
+              {% assign tag_class = tag | slugify %}
+              <li class="tag-{{ tag_class }} warning">{{ tag }}</li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+        </a>
+      </div>
     {% endfor %}
-	 	{% assign last_row = goal_indicators.size | modulo:4 %}
-		{% if last_row != 0 %}
-			</div>
-		{% endif %}
+    </div>
+  {%- endfor -%}
 </div>
 
 {% include footer.html %}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1025,7 +1025,15 @@ h5 + .btn-download {
     margin: 2px 2px 0 0;
   }
   &.goal-indicators {
-    @include indicatorcards
+    @include indicatorcards;
+    .indicator-cards a {
+      padding: 0;
+      margin-bottom: 1.5rem;
+    }
+    .indicator-cards.target {
+      margin-bottom: 1.5rem;
+      clear: left;
+    }
   }
   .goal-indicators:after {
     content: "";

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -27,3 +27,27 @@ Feature: Goal page
       | /life-on-land                           | 14    |
       | /peace-and-justice-strong-institutions  | 23    |
       | /partnerships-for-the-goals             | 25    |
+
+  Scenario Outline: Goals show the correct number of targets
+    Given I am on "<PATH>"
+    Then I should see <TOTAL> "goal target" elements
+
+    Examples:
+      | PATH                                    | TOTAL |
+      | /no-poverty                             | 8     |
+      | /zero-hunger                            | 8     |
+      | /good-health-and-well-being             | 13    |
+      | /quality-education                      | 10    |
+      | /gender-equality                        | 9     |
+      | /clean-water-and-sanitation             | 8     |
+      | /affordable-and-clean-energy            | 5     |
+      | /decent-jobs-and-economic-growth        | 12    |
+      | /industry-innovation-and-infrastructure | 8     |
+      | /reduced-inequalities                   | 10    |
+      | /sustainable-cities-communities         | 10    |
+      | /responsible-consumption-and-production | 11    |
+      | /climate-action                         | 5     |
+      | /life-below-water                       | 10    |
+      | /life-on-land                           | 12    |
+      | /peace-and-justice-strong-institutions  | 12    |
+      | /partnerships-for-the-goals             | 19    |

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -34,7 +34,7 @@ Feature: Goal page
 
     Examples:
       | PATH                                    | TOTAL |
-      | /no-poverty                             | 8     |
+      | /no-poverty                             | 7     |
       | /zero-hunger                            | 8     |
       | /good-health-and-well-being             | 13    |
       | /quality-education                      | 10    |
@@ -48,6 +48,6 @@ Feature: Goal page
       | /responsible-consumption-and-production | 11    |
       | /climate-action                         | 5     |
       | /life-below-water                       | 10    |
-      | /life-on-land                           | 12    |
+      | /life-on-land                           | 13    |
       | /peace-and-justice-strong-institutions  | 12    |
       | /partnerships-for-the-goals             | 19    |

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -16,7 +16,7 @@ const driver = new mink.Mink({
     "the National metadata tab": ".nav-tabs .nav-link[href='#metadata']",
     "the Sources metadata tab": ".nav-tabs .nav-link[href='#sources']",
     "goal indicator": ".indicator-cards > div",
-    "goal target": ".indicators-cards.target",
+    "goal target": ".indicator-cards.target",
     "the high-contrast button": ".nav .contrast-high a",
     "goal icon": ".goal-tiles a img",
     "high-contrast goal icon": ".goal-tiles a img[src*='high-contrast']",

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -16,6 +16,7 @@ const driver = new mink.Mink({
     "the National metadata tab": ".nav-tabs .nav-link[href='#metadata']",
     "the Sources metadata tab": ".nav-tabs .nav-link[href='#sources']",
     "goal indicator": ".indicator-cards > div",
+    "goal target": ".indicators-cards.target",
     "the high-contrast button": ".nav .contrast-high a",
     "goal icon": ".goal-tiles a img",
     "high-contrast goal icon": ".goal-tiles a img[src*='high-contrast']",


### PR DESCRIPTION
This is one approach to integrating targets into the platform - by changing the goal pages from a grid layout to a two-column layout, with targets on the left and indicators on the right. This is what it would look like:
![two-column-goals-uk](https://user-images.githubusercontent.com/1319083/51998748-aadf3e00-24d2-11e9-8043-2673ddd5f379.png)

This is the kind of change that would probably warrant a major version bump, or at least a minor version bump, since it changes a layout and CSS. For example this could cause a problem for any site already overriding the goal.html layout, such as the UK's site.

This also depends on the latest sdg-translations build, for a translation of "Targets".

Fixes #54 