### PR TITLE
move indicator and multilingual variables to own files #64

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
     <head>
-        {%- include multilingual.html -%}
         <script>var translations = {};</script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
         <!-- Basic Page Needs
@@ -14,9 +13,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Title and meta description
         ================================================== -->
-        {% assign goal = site.goals | where: "sdg_goal", page.sdg_goal | first %}
         {% capture page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal.goal }} - {{ goal.short }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
         {% endcapture %}
         <title>{% if page.indicator %}{{ page_title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
         <meta name="description" content="">

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -1,0 +1,30 @@
+{%- comment -%}
+
+  Before we start the html we fetch the data and metadata for this page
+
+{%- endcomment -%}
+
+{% capture indicator_id %}{{page.indicator | slugify}}{% endcapture %}
+{% assign meta = site.data.meta[indicator_id] %}
+{%- if meta[current_language] -%}
+  {%- assign meta = meta[current_language] -%}
+{%- endif -%}
+{% assign headline = site.data.headline[indicator_id] %}
+
+{%- assign goal_number = meta.sdg_goal | downcase -%}
+{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
+{%- assign translated_goal = t.global_goals[goal_number] -%}
+{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
+{% capture goal_href %}{{ goal_uri }}{% endcapture %}
+{% capture goal_title %}{{ goal.title }}{% endcapture %}
+
+{% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
+  {% assign show_data = false %}
+{% else %}
+  {% assign show_data = true %}
+{% endif %}
+
+{% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
+
+{%- assign json_data = site.data[dataset_name] | jsonify -%}
+{%- assign translated_indicator = t.global_indicators[meta.indicator] -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 {{ content }}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container goal-tiles" role="main">

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 {% assign goal_number = page.sdg_goal %}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -1,38 +1,10 @@
+{%- include multilingual.html -%}
+{%- include indicator-variables.html -%}
 {% include head.html %}
 {% include header.html %}
 {% include components/fields-template.html %}
 {% include components/units-template.html %}
 {% include multilingual-js.html key="indicator" %}
-
-{% capture indicator_id %}{{page.indicator | slugify}}{% endcapture %}
-{% assign meta = site.data.meta[indicator_id] %}
-{%- if meta[current_language] -%}
-  {%- assign meta = meta[current_language] -%}
-{%- endif -%}
-{% assign headline = site.data.headline[indicator_id] %}
-
-{%- assign goal_number = meta.sdg_goal | downcase -%}
-{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
-{%- assign translated_goal = t.global_goals[goal_number] -%}
-{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
-
-{% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
-  {% assign show_data = false %}
-{% else %}
-  {% assign show_data = true %}
-{% endif %}
-
-{% capture goal_href %}{{ goal_uri }}{% endcapture %}
-{% capture goal_title %}{{ goal.title }}{% endcapture %}
-{% capture indicator_title %}{{ meta.title }}{% endcapture %}
-
-{% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
-
-{% assign sdg_indicator_data = site.data[dataset_name] %}
-{% assign indicator_metadata = sdg_indicators | where: "indicator_id", meta.indicator | first %}
-{% assign json_data = sdg_indicator_data | jsonify %}
-{%- assign indicator_number = meta.indicator -%}
-{%- assign translated_indicator = t.global_indicators[indicator_number] -%}
 
 <div class="heading indicator goal-{{ goal_number }}">
   <div class="container">
@@ -48,7 +20,7 @@
             <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
           </a>
         </h1>
-        <h2>{{ t.general.indicator }} {{ indicator_number }}: {{ translated_indicator.title }}</h2>
+        <h2>{{ t.general.indicator }} {{ meta.indicator }}: {{ translated_indicator.title }}</h2>
       </div>
     </div>
   </div>

--- a/_layouts/initiative.html
+++ b/_layouts/initiative.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container" role="main">

--- a/_layouts/initiatives.html
+++ b/_layouts/initiatives.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container" role="main">

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container reportingstatus" data-url="{{ site.baseurl }}/indicators.json">

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,3 +1,4 @@
+{%- include multilingual.html -%}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container search-results" role="main">


### PR DESCRIPTION
- This removes some unused variables from indicators.html
- Multilingual.html is not directly included in the head. It must be
added to the top of any layout now.
- Indicator variables move about the head.html include to fix #64
- layouts adjusted to directly include multilingual.

Replacing #65 