### PR TITLE
Update changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 <h1>Change Log</h1>
 
+### 0.3.1
+
+Patch release with some accessibility and bug fixes.
+
+* Bugfix for page titles (#64)
+* Accessibility improvements for high contrast mode (#2) (#4)
+* Search queries now use a `?q=<search-term>` string for better GA compatibility (#81)
+
+Breaking changes: For any sites that have overridden the theme, they will need to add `{% include multilingual.html %}` at the top of each page as this has been moved out of `head.html`.
+
 ## 0.3.0
 
 * Changelog added (#47)


### PR DESCRIPTION
Getting prepared for a patch release. 

I've documented changes to the documentation, but I wonder if we really need this going forwards? The docs don't affect the theme and they are built separately for the readthedocs site.

We could consider only discussing code changes to keep it simpler.