### PR TITLE
Support for tagging indicators on goal pages

### DIFF
--- a/_includes/components/metadata.html
+++ b/_includes/components/metadata.html
@@ -24,6 +24,8 @@
               </a>
             {% endif %}
 
+          {% elsif indicator_metadata.field.element == 'multiselect' %}
+            {{ meta[indicator_metadata.name] | join: ", " }}
           {% else %}
             {{ meta[indicator_metadata.name] }}
           {% endif %}

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -30,20 +30,44 @@
 
     {% if indicator.reporting_status == 'notstarted' %}
       {% assign status_desc = t.status.exploring_data_sources %}
-      {% assign status_css = 'danger' %}          
+      {% assign status_css = 'danger' %}
     {% endif %}
     {% if indicator.reporting_status == 'inprogress' %}
       {% assign status_desc = t.status.statistics_in_progress %}
-      {% assign status_css = 'warning' %}          
+      {% assign status_css = 'warning' %}
     {% endif %}
     {% if indicator.reporting_status == 'complete' %}
       {% assign status_desc = t.status.reported_online %}
       {% assign status_css = 'success' %}
     {% endif %}
+    {% assign tag_classes = "" | split: "," %}
+    {% if indicator.tags %}
+      {% for tag in indicator.tags %}
+        {% assign tag_slug = "indicator-" | append: tag | slugify %}
+        {% assign tag_classes = tag_classes | push: tag_slug %}
+      {% endfor %}
+    {% endif %}
+    {% assign tag_classes = tag_classes | join: " " %}
 
     {% cycle 'add row' : '<div class="indicator-cards row no-gutters">', '', '', '' %}
-        <div class="col-md-6 col-lg-3">
-          <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator.indicator | slugify }}"><span>{{ indicator.indicator }}<span class="status {{ status_css }}">{{ status_desc }}</span></span> {{ translated_indicator.title }}</a>
+        <div class="col-md-6 col-lg-3 {{ tag_classes }}">
+          <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator.indicator | slugify }}">
+            <span>
+              {{ indicator.indicator }}
+              <span class="status {{ status_css }}">
+                {{ status_desc }}
+              </span>
+            </span>
+            {{ translated_indicator.title }}
+            {% if indicator.tags %}
+              <ul class="tags">
+              {% for tag in indicator.tags %}
+                {% assign tag_class = tag | slugify %}
+                <li class="tag-{{ tag_class }} warning">{{ tag }}</li>
+              {% endfor %}
+              </ul>
+            {% endif %}
+          </a>
         </div>
     {% cycle 'end row' : '', '', '', '</div>' %}
     {% endfor %}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -55,6 +55,18 @@ $collapsed-navbar-height: $navbar-height - 30;
       }
     }
 
+    .tags {
+      padding: 0;
+      margin: 6px 10px 0 0;
+      list-style-type: none;
+      li {
+        margin-right: 6px;
+        padding: 4px 6px;
+        display: inline;
+        border-radius: 10px;
+      }
+    }
+
     .match {
       display: inline;
       font-weight: normal;
@@ -1735,7 +1747,7 @@ body.contrast-high {
       a {
         color: white !important;
       }
-      span.status {
+      span.status, .tags li, {
         color: black !important;
       }
     }

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -61,6 +61,7 @@ The rest are optional fields (incl. data sources 2-6)
 | computation_disaggregation          | Disaggregation               |
 | comments_limitations                | Comments and limitations     |
 | admin_contact_details               | Contact details              |
+| tags                                | Tags shown under indicators  |
 
 ## Method of Computation Metadata
 


### PR DESCRIPTION
This adds support for an optional `tags` metadata field on indicators. The assumption here is that the `tags` field is an array of strings. The most common use-cases would probably be tags like "National" or "Local" to highlight the fact that certain indicators have been customised for a country or city.

Out of the box, the tags appear beneath the indicators on the goal pages, with yellow backgrounds. You can see a demo [here](http://brock.tips/sdg-site-maptest/no-poverty/). However the tags get unique HTML classes that would allow an implementation to customise the style (eg, the background color) per tag.

Also, the HTML element wrapping the whole indicator gets a unique class per tag, allowing custom styling of indicators having a certain tag. For example, a city implementation might give a light-green border around each indicator tagged "Local".

Since an array of strings is expected, the appropriate Prose.io element would be `multiselect`. You can see this in action [here](http://prose.io/#brockfanning/sdg-data-maptest/edit/develop/meta/1-1-1.md). This PR includes a slight tweak to the `metadata.html` file to properly display multiselect elements.

Fixes #67 