### PR TITLE
Switch to using the new 't' filter for menu item labels.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,20 +29,9 @@
       <ul class="nav navbar-nav menu-target contrast-switcher" id="menu">
         {%- if site.menu -%}
           {%- for item in site.menu -%}
-          {%- assign translation_keys = item.translation_key | split: "." -%}
-          {%- assign translated_item = false -%}
-          {%- for key in translation_keys -%}
-            {%- if t[key] -%}
-              {%- assign translated_item = t[key] -%}
-            {%- elsif translated_item[key] -%}
-              {%- assign translated_item = translated_item[key] -%}
-            {%- endif -%}
-          {%- endfor -%}
-          {%- if translated_item -%}
           <li class="nav-link {% if page.permalink == item.path %}active{% endif %}">
-            <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ translated_item }}</a>
+            <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ item.translation_key | t }}</a>
           </li>
-          {%- endif -%}
           {%- endfor -%}
         {%- endif -%}
         {%- if site.languages.size > 1 -%}

--- a/tests/features/Navigation.feature
+++ b/tests/features/Navigation.feature
@@ -1,0 +1,14 @@
+Feature: Navigation
+
+  As site visitor
+  I need navigation links across the top of the site
+  So that I can quickly get to the information I need
+
+  Background:
+    Given I am on the homepage
+
+  Scenario: All expected menu items are visible
+    Then I should see "Reporting Status"
+    And I should see "About"
+    And I should see "Guidance"
+    And I should see "FAQ"


### PR DESCRIPTION
This uses a new "t" Liquid filter provided by the jekyll-open-sdg-plugins Ruby Gem to translate the menu item labels, instead of the rather confusing Liquid code that's doing it now.

**This is a breaking change!** It requires sites to be loading the jekyll-open-sdg-plugins Ruby Gem.