### PR TITLE
Load Ruby Gem plugins for tests and configure data correctly

### DIFF
--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -10,7 +10,7 @@ environment: staging
 # Replace MY-GITHUB-ORG and OPEN-SDG-DATA-STARTER as needed.
 remotedatabaseurl: "https://open-sdg.github.io/open-sdg-data-testing/staging"
 
-jekyll_get_data:
+jekyll_get_json:
   - data: meta
     # Replace MY-GITHUB-ORG and OPEN-SDG-DATA-STARTER as needed.
     json: 'https://open-sdg.github.io/open-sdg-data-testing/staging/meta/all.json'
@@ -80,6 +80,10 @@ menu:
 languages:
   - en
   - es
+
+plugins:
+  - jekyll-open-sdg-plugins
+  - jekyll-get-json
 
 # This makes sure that all pages have a language.
 defaults:


### PR DESCRIPTION
This tweak is necessary for working tests, now that open-sdg-site-starter has switched to using some Ruby Gems for Jekyll plugins.