### PR TITLE
Run tag labels through the t filter

### DIFF
--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -63,7 +63,7 @@
               <ul class="tags">
               {% for tag in indicator.tags %}
                 {% assign tag_class = tag | slugify %}
-                <li class="tag-{{ tag_class }} warning">{{ tag }}</li>
+                <li class="tag-{{ tag_class }} warning">{{ tag | t }}</li>
               {% endfor %}
               </ul>
             {% endif %}


### PR DESCRIPTION
This allows for translated indicator tags. It relies on a Liquid filter "t" which is provided by the jekyll-open-sdg-plugins Ruby Gem. But the way Jekyll treats missing filters is to just fail gracefully, so if the filter is not there then nothing will change. So, this is not a breaking change.

Fixes #93 