### PR TITLE
Run country name/adjective through the "t" filter.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -4,10 +4,9 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     {% assign country_name = site.country.name | t %}
-    {% assign country_adjective = site.country.adjective | t %}
-    <h1>{{ t.frontpage.heading | replace: '%adjective', country_adjective }}</h1>
+    <h1>{{ t.frontpage.heading | replace: '%name', country_name }}</h1>
 
-    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%country_name', country_name }}</p>
+    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name }}</p>
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,9 +3,11 @@
 {% include header.html %}
 <div id="main-content" class="container goal-tiles" role="main">
 
-    <h1>{{site.country.name}} {{ t.frontpage.heading }}</h1>
+    {% assign country_name = site.country.name | t %}
+    {% assign country_adjective = site.country.adjective | t %}
+    <h1>{{ t.frontpage.heading | replace: '%adjective', country_adjective }}</h1>
 
-    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%country_name', site.country.name }}</p>
+    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%country_name', country_name }}</p>
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -135,8 +135,12 @@
             <div > <!-- formerly class="collapsible expanded" -->
               <!-- <h3 tabindex='0'>National Metadata</h3> -->
               <article>
-                <p>{{ t.indicator.national_metadata_blurb | replace: '%country_name', site.country.name | replace: '%country_adjective', site.country.adjective }}</p>
-                  {% include components/metadata.html scope='national' %}
+                <p>
+                  {% assign country_name = site.country.name | t %}
+                  {% assign country_adjective = site.country.adjective | t %}
+                  {{ t.indicator.national_metadata_blurb | replace: '%country_name', country_name | replace: '%country_adjective', country_adjective }}
+                </p>
+                {% include components/metadata.html scope='national' %}
               </article>
             </div>
           </div>


### PR DESCRIPTION
Also, include the country adjective IN the frontpage header, rather than putting them side by side.

This depends on https://github.com/open-sdg/sdg-translations/pull/56 so it should not be merged until that issue has been merged.

The "t" filter referenced here is provided by the jekyll-open-sdg-plugins Gem. If a site is missing that plugin, the "t" filter will do nothing (fail gracefully).

Fixes #62 