### PR TITLE
Translate the output of metadata fields

### DIFF
--- a/_includes/components/metadata.html
+++ b/_includes/components/metadata.html
@@ -13,7 +13,7 @@
           {% if indicator_metadata.name contains "_url" or indicator_metadata.name contains "_link" %}
             {% assign url_text_name = indicator_metadata.name | replace_first:'_url','_url_text'  %}
             {% assign url_text_name = url_text_name | replace_first:'_link','_link_text'  %}
-            {% assign url_text = meta[url_text_name] %}
+            {% assign url_text = meta[url_text_name] | t %}
             {% unless url_text %}
               {% assign url_text = 'Link' %}
             {% endunless %}
@@ -25,9 +25,11 @@
             {% endif %}
 
           {% elsif indicator_metadata.field.element == 'multiselect' %}
-            {{ meta[indicator_metadata.name] | join: ", " }}
+            {% for item in meta[indicator_metadata.name] %}
+              {{ item | t }}{% unless forloop.last %}, {% endunless %}
+            {% endfor %}
           {% else %}
-            {{ meta[indicator_metadata.name] }}
+            {{ meta[indicator_metadata.name] | t }}
           {% endif %}
         </td>
         </tr>


### PR DESCRIPTION
This change adds a new way to have multilingual metadata. First I'll describe the existing way:

The `meta` folder in the data repository can have subfolders for each language, and corresponding .md files can be put there to extend/override an indicator's metadata for that particular language. This is a fairly straightforward way to do it, and is great for translating one-off bits of text, like descriptions, keywords, etc.

The case where that is **not** great is for translating common words/phrases. If every single indicator needs "Office of Statistics" translated, it is a bit duplicative to have to copy/paste the translations of "Office of Statistics" for every single indicator.

Now I'll describe what this PR adds:

This PR offers a new option which works better in that use-case. Instead of making subfolders and extra files, and country could replace "Office of Statistics" with something like "custom.office_of_statistics". Then if they have a translation file (ala SDG Translations) called "custom.yml" which includes a key called "office_of_statistics", then the phrase will automatically get translated into all the languages.

So essentially this is a way to use the sdg-translations-style workflow instead of the metadata subfolders.

Note also that the "t" filter being used here fails gracefully -- if it does not exist, then behavior will be the same as before. (The "t" filter is part of the jekyll-open-sdg-plugins Gem.)