### PR TITLE
Improve hack for incompatibility betwen zoomShowHide and zoomSearch

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -44,7 +44,7 @@
   // Defaults for each map layer.
   var mapLayerDefaults = {
     min_zoom: 0,
-    max_zoom: 20,
+    max_zoom: 10,
     serviceUrl: '[replace me]',
     nameProperty: '[replace me]',
     idProperty: '[replace me]',
@@ -312,7 +312,7 @@
         // The search plugin messes up zoomShowHide, so we have to reset that
         // with this hacky method. Is there a better way?
         var zoom = plugin.map.getZoom();
-        plugin.map.setZoom(zoom + 1);
+        plugin.map.setZoom(plugin.options.maxZoom);
         plugin.map.setZoom(zoom);
 
         // The list of handlers to apply to each feature on a GeoJson layer.


### PR DESCRIPTION
This tweaks the hack that gets around a weird interaction between zoomShowHide and zoomSearch.

Also this updates the default max_zoom for layers to 10, as 20 is a ridiculously high zoom.

Fixes #103 