### PR TITLE
Translate disaggregation filters/columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ test.prep:
 	cp tests/_config.yml starter
 	# Copy all the theme files into the starter.
 	cp -r -t starter/ _includes _layouts assets
+	# Copy any custom data into the starter.
+	cp -r tests/data starter/
 	# Add a second language.
 	cd starter && python scripts/batch/add_language.py es
 	# Build the Jekyll site.

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -311,7 +311,7 @@ var indicatorView = function (model, options) {
               text.push('<li data-datasetindex="' + datasetIndex + '">');
               text.push('<span class="swatch' + (dataset.borderDash ? ' dashed' : '') + '" style="background-color: ' + dataset.backgroundColor + '">');
               text.push('</span>');
-              text.push(dataset.label);
+              text.push(translations.t(dataset.label));
               text.push('</li>');
             });
 
@@ -421,7 +421,7 @@ var indicatorView = function (model, options) {
 
   this.toCsv = function (tableData) {
     var lines = [],
-    headings = _.map(tableData.headings, function(heading) { return '"' + heading + '"'; });
+    headings = _.map(tableData.headings, function(heading) { return '"' + translations.t(heading) + '"'; });
 
     lines.push(headings.join(','));
 
@@ -487,7 +487,6 @@ var indicatorView = function (model, options) {
     }, table = $(el).find('table');
 
     datatables_options.aaSorting = [];
-
     table.DataTable(datatables_options);
 
     setDataTableWidth(table);
@@ -577,7 +576,7 @@ var indicatorView = function (model, options) {
 
       var getHeading = function(heading, index) {
         var span = '<span class="sort" />';
-        var span_heading = '<span>' + heading + '</span>';
+        var span_heading = '<span>' + translations.t(heading) + '</span>';
         return (!index || heading.toLowerCase() == 'units') ? span_heading + span : span + span_heading;
       };
 

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -487,6 +487,7 @@ var indicatorView = function (model, options) {
     }, table = $(el).find('table');
 
     datatables_options.aaSorting = [];
+
     table.DataTable(datatables_options);
 
     setDataTableWidth(table);

--- a/_includes/components/fields-template.html
+++ b/_includes/components/fields-template.html
@@ -1,7 +1,7 @@
 <script type="text/template" id="item_template">
   <% _.each(series, function(seriesItem) { %>
     <div class="variable-selector<% if(allowedFields.indexOf(seriesItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=seriesItem.field%>">
-      <button class='accessBtn' tabindex='0'><h5><%=seriesItem.field%><i class="fa fa-chevron-down"></i></h5></button>
+      <button class='accessBtn' tabindex='0'><h5><%=translations.t(seriesItem.field)%><i class="fa fa-chevron-down"></i></h5></button>
       <div class="bar">
         <div class="selected"></div>
       </div>
@@ -11,11 +11,11 @@
           <button data-type="clear">{{ t.indicator.clear_all }}</button>
         </div>
         <% _.each(seriesItem.values, function(item) { %>
-          <label><input type="checkbox" value="<%=item.value%>" data-field="<%=seriesItem.field%>" /><%=item.value%></label>
+          <label><input type="checkbox" value="<%=item.value%>" data-field="<%=seriesItem.field%>" /><%=translations.t(item.value)%></label>
         <% }); %>
       </div>
-      
-      <% if(allowedFields.indexOf(seriesItem.field) == -1) { %> 
+
+      <% if(allowedFields.indexOf(seriesItem.field) == -1) { %>
         <div class="variable-hint">
           {%- capture var_hint_replacement -%}
             {% raw %}<%= _.findWhere(edges, { To: seriesItem.field }).From %>{% endraw %}

--- a/_includes/components/headline.html
+++ b/_includes/components/headline.html
@@ -1,23 +1,23 @@
-{% capture headline_name %}{{page.indicator | slugify }}{% endcapture %} 
-{% assign sdg_headline_data = site.data.headlines[headline_name] %} 
+{% capture headline_name %}{{page.indicator | slugify }}{% endcapture %}
+{% assign sdg_headline_data = site.data.headlines[headline_name] %}
 
 <div id="headlineTable">
-  
+
   <div id="datatables">
-    
+
     <a href="{{ site.remotedatabaseurl }}/headline/{{ page.indicator | slugify }}.csv" class="btn btn-primary btn-download" download="{{ dataset_name }}.csv" tabindex="0" role="button">{{ t.indicator.download_headline }}</a>
-    
+
     <a href="{{ site.remotedatabaseurl }}/data/{{ page.indicator | slugify }}.csv" class="btn btn-primary btn-download" style='float:left;margin-right:1em' download='{{ dataset_name }}.csv' tabindex='0' role='button'>{{ t.indicator.download_source }}</a>
-    
+
     <h3>Headline data</h3>
     <table class="table-responsive table table-hover dataTable no-footer" role="grid">
       <caption>{{ page.graph_title }}</caption>
       <thead>
         {% for column in sdg_headline_data[0] %}
         {% if forloop.last %}
-        <th scope="col" class="table-value">{{ column[0] }}</th>
+        <th scope="col" class="table-value">{{ column[0] | t }}</th>
         {% else %}
-        <th scope="col">{{ column[0] }}</th>
+        <th scope="col">{{ column[0] | t }}</th>
         {% endif %}
         {% endfor %}
       </thead>
@@ -28,7 +28,7 @@
           {% if forloop.last %}
           <td class="table-value">{{ cell[1] }}</td>
           {% else %}
-          <td>{{ cell[1] }}</td>    
+          <td>{{ cell[1] }}</td>
           {% endif %}
           {% endfor %}
         </tr>
@@ -36,20 +36,20 @@
       </tbody>
     </table>
   </div>
-  
+
   <div id="datatableFooter">
     {% if page.source_organisation_1.size %}
-    <p>{{ t.indicator.source }}: {{ page.source_organisation_1 }}</p>
+    <p>{{ t.indicator.source }}: {{ page.source_organisation_1 | t }}</p>
     {% endif %}
     {% if page.national_geographical_coverage.size %}
-    <p>{{ t.indicator.geographical_area }}: {{ page.national_geographical_coverage }}</p>
+    <p>{{ t.indicator.geographical_area }}: {{ page.national_geographical_coverage | t }}</p>
     {% endif %}
     {% if page.computation_units.size %}
-    <p>{{ t.indicator.unit_of_measurement }}: {{ page.computation_units }}</p>
+    <p>{{ t.indicator.unit_of_measurement }}: {{ page.computation_units | t }}</p>
     {% endif %}
     {% if page.data_footnote.size %}
-    <p>{{ t.indicator.footnote }}: {{ page.data_footnote }}</p>
+    <p>{{ t.indicator.footnote }}: {{ page.data_footnote | t }}</p>
     {% endif %}
   </div>
-  
+
 </div>

--- a/_includes/components/units-template.html
+++ b/_includes/components/units-template.html
@@ -2,7 +2,7 @@
   <% if(units.length) { %>
     <h5>{{ t.indicator.units_type }}</h5>
     <% _.each(units, function(unitsItem, index) { %>
-      <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <% if(!index) { %>checked="checked"<% } %> /> <%=unitsItem%></label>
+      <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <% if(!index) { %>checked="checked"<% } %> /> <%=translations.t(unitsItem)%></label>
     <% }); %>
   <% } %>
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
     <head>
-        <script>var translations = {};</script>
+        {% include multilingual-js-base.html %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
         <!-- Basic Page Needs
         ================================================== -->

--- a/_includes/multilingual-js-base.html
+++ b/_includes/multilingual-js-base.html
@@ -1,0 +1,44 @@
+<script>
+// JavaScript container for translation data.
+var translations = {
+  //Javascript version of the "t" filter from jekyll-open-sdg-plugins.
+  t: function(key) {
+
+    if (!key || typeof key !== 'string') {
+      return '';
+    }
+
+    // The majority of uses of this function are to translate disaggregation
+    // data. To spare data providers of needing to enter "data." in front of
+    // their disaggregation data, we do it for them here.
+    var originalKey = key;
+    if (!key.includes('.')) {
+      key = 'data.' + key.toLowerCase();
+    }
+
+    var drilled = this;
+    var levelsDrilled = 0;
+    var levels = key.split('.');
+
+    for (var level in levels) {
+      // If we have drilled down to soon, abort.
+      if (typeof drilled !== 'object') {
+        break;
+      }
+
+      if (levels[level] in drilled) {
+        drilled = drilled[levels[level]];
+        levelsDrilled += 1;
+      }
+    }
+
+    // If we didn't drill the right number of levels, return the original string.
+    if (levels.length != levelsDrilled) {
+      return originalKey;
+    }
+
+    // Otherwise we must have drilled all the way.
+    return drilled;
+  },
+};
+</script>

--- a/_includes/multilingual-js-base.html
+++ b/_includes/multilingual-js-base.html
@@ -12,7 +12,7 @@ var translations = {
     // data. To spare data providers of needing to enter "data." in front of
     // their disaggregation data, we do it for them here.
     var originalKey = key;
-    if (!key.includes('.')) {
+    if (!key.includes('.') && this.data) {
       key = 'data.' + key.toLowerCase();
     }
 

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -5,6 +5,7 @@
 {% include components/fields-template.html %}
 {% include components/units-template.html %}
 {% include multilingual-js.html key="indicator" %}
+{% include multilingual-js.html key="data" %}
 
 <div class="heading indicator goal-{{ goal_number }}">
   <div class="container">

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -22,7 +22,7 @@ Note that the [open-sdg-site-starter](https://github.com/open-sdg/open-sdg-site-
 There are 4 requirements for adding a new language to the platform
 
 1. Make sure that the new language is implemented in the [SDG Translations project](https://open-sdg.github.io/sdg-translations). If it is not, you can fork that repository and implement the language yourself.
-2. Make sure that translated goal icons have been created. These are typically included in the SDG Translations implementation mentioned above.
+2. Make sure that translated goal icons have been created. These are should be included in the SDG Translations implementation mentioned above.
 3. Add the new language in the 'languages' list in your `_config.yml` file.
 4. Add new subdirectories for the translated goals, indicators, and pages, and populate them with content. NOTE: The [open-sdg-site-starter](https://github.com/open-sdg/open-sdg-site-starter) ships with a script to do this for you.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -7,13 +7,13 @@ This platform is designed to be multilingual, and leverages the translations bei
 In order to compile the platform in multiple languages, Jekyll needs the translations themselves. This platform leverages translations from [this project](https://open-sdg.github.io/sdg-translations).
 
 > An important note about the sdg-translation project: Each translation receives
-> a "key" which can uniquely identify it. This is important to the mechanism for
-> using these translations throughout this platform.
+> a "translation key" which can uniquely identify it. This is important to the
+> mechanism for using these translations throughout this platform.
 
 There are 2 ways to get this translation data into Jekyll.
 
 1. Manually copy the [translations folder](https://github.com/open-sdg/sdg-translations/tree/develop/translations) into your [data folder](https://jekyllrb.com/docs/datafiles/).
-2. (Recommended) Use a Jekyll plugin, such as [Jekyll Get](https://github.com/18F/jekyll-get), to pull in the [json data](https://open-sdg.github.io/sdg-translations/translations.json) at build time.
+2. (Recommended) Use a Jekyll plugin, such as [Jekyll Get JSON](https://github.com/brockfanning/jekyll-get-json), to pull in the [json data](https://open-sdg.github.io/sdg-translations/translations.json) at build time.
 
 Note that the [open-sdg-site-starter](https://github.com/open-sdg/open-sdg-site-starter) comes pre-configured to use approach #2 above.
 
@@ -22,7 +22,7 @@ Note that the [open-sdg-site-starter](https://github.com/open-sdg/open-sdg-site-
 There are 4 requirements for adding a new language to the platform
 
 1. Make sure that the new language is implemented in the [SDG Translations project](https://open-sdg.github.io/sdg-translations). If it is not, you can fork that repository and implement the language yourself.
-2. Make sure that translated goal icons have been created in this platform. These can be found [here](https://github.com/open-sdg/open-sdg/tree/master/assets/img/goals) and [here](https://github.com/open-sdg/open-sdg/tree/master/assets/img/high-contrast/goals) (high-contrast versions).
+2. Make sure that translated goal icons have been created. These are typically included in the SDG Translations implementation mentioned above.
 3. Add the new language in the 'languages' list in your `_config.yml` file.
 4. Add new subdirectories for the translated goals, indicators, and pages, and populate them with content. NOTE: The [open-sdg-site-starter](https://github.com/open-sdg/open-sdg-site-starter) ships with a script to do this for you.
 
@@ -34,15 +34,91 @@ When writing Jekyll templates for this platform, there should never be any direc
 
 Instead, you should see something like this:
 
-`<h1>{{ t.general.sdg }}</h1>
+`<h1>{{ t.general.sdg }}</h1>`
 
 The `t` variable contains a nested structure of translation values, corresponding to the folder structure of the [sdg-translations](https://github.com/open-sdg/sdg-translations) repository. In the example above, the "general" refers to [this file](https://github.com/open-sdg/sdg-translations/blob/develop/translations/en/general.yml), and the "sdg" refers to [that line within the file](https://github.com/open-sdg/sdg-translations/blob/develop/translations/en/general.yml#L5).
 
 Jekyll will display translated text according to the "language" specified in the "front matter" of the current document.
 
+## Translating variables in Jekyll templates
+
+Sometimes you may need to translate something that exists as a Liquid variable in a Jekyll template. This can be accomplished using the "t" filter, that is provided by the [jekyll-open-sdg-plugins](https://github.com/open-sdg/jekyll-open-sdg-plugins) Ruby gem. A contrived example of how this works is as follows:
+
+```
+{% assign foo = "general.sdg" %}
+<h1>{{ foo | t }}</h1>
+```
+
+## Translating indicator metadata
+
+There are two methods available for translating metadata. Both are equally valid, and you are free to use one or both, depending on your preferences.
+
+### 1. Translating indicator metadata via subfolders
+
+Using this approach, for each language (other than the default language) you will create a subfolder inside the `meta` folder of your data repository, containing corresponding versions of each indicator. For example:
+
+```lang-none
+meta
+└─1-1-1.md (this contains the metadata in your default language)
+└─es
+  └─1-1-1.md (this contains any Spanish translations of the metadata)
+└─fr
+  └─1-1-1.md (this contains any French translations of the metadata)
+```
+
+NOTE: The translated versions in the subfolders need not contain every metadata field. They only need to contain the fields that you want translated.
+
+### 2. Translating indicator metadata via translation keys
+
+Using this approach, you put "translation keys" directly into the indicator metadata. For example, instead of:
+
+```lang-yaml
+un_custodian_agency: UN Habitat
+```
+
+You might do:
+
+```lang-yaml
+un_custodian_agency: agencies.un_habitat
+```
+
+Assuming that `agencies.un_habitat` refers to an actual key in your SDG Translations data, this will translate the field according to that data.
+
+## Translation in Javascript
+
+There is a global object `translations` available to your Javascript. It can be used similarly to the `t` variable in Liquid templates. For example:
+
+`var translatedText = translations.general.sdg;`
+
+It also includes a function `t()` which can be used similarly to the `t` Liquid filter. For example:
+
+```
+var translationKey = 'general.sdg';
+var translatedText = translations.t(translationKey);
+```
+
+NOTE: In contrast to Jekyll, any translation keys you will need in Javascript need to be "imported" before they can be used. The mechanism for importing translating keys is the Jekyll include `multilingual-js.html`. You can use this to import an entire translation group. For example, this is how you can import all the translation keys in the "general" group:
+
+```
+{% include multilingual-js.html key="general" %}
+```
+
+## Translating data disaggregations and columns
+
+To translate the disaggregations and columns in your data (such as "Age", "Sex", "Female", etc.) you will need to make sure that the disaggregation values in your CSV files correspond to translation keys. For example, instead of a column called `Sex` you could call it `data.sex`. Assuming that `data.sex` refers to an actual key in your SDG Translations data, this will translate the disaggregation according to that data.
+
+Similarly, instead of a values like `Female`, you could use `data.female` to correspond to a translation by that key.
+
+> NOTE: There is a shortcut available here. Because data disaggregations/columns
+> will almost always refer to the `data` group, you can actually leave the `data.`
+> off. Additionally, the capitalization does not matter. So for example, the
+> columns/values `Sex` and `Female` would work fine, assuming that `data.sex`
+> and `data.female` were valid translation keys. Behind the scenes, `Sex` gets
+> converted to `data.sex` and `Female` gets converted to `data.female`, etc.
+
 ## Available translation-related variables
 
-In addition to the `t` variable for displaying translations, there are 3 other variables of general use:
+In addition to the `t` variable for displaying translations, there are 3 other Liquid variables of general use:
 
 * `default_language`: The 2-letter code for the default language
 * `current_language`: The 2-letter code for the current language

--- a/tests/data/translations/en/data.yml
+++ b/tests/data/translations/en/data.yml
@@ -1,0 +1,2 @@
+a: A
+group: Group

--- a/tests/data/translations/es/data.yml
+++ b/tests/data/translations/es/data.yml
@@ -1,0 +1,2 @@
+a: A-translated
+group: Group-translated

--- a/tests/features/Disaggregation.feature
+++ b/tests/features/Disaggregation.feature
@@ -8,13 +8,13 @@ Feature: Disaggregation
     Given I am on "/1-1-1"
     And I wait 3 seconds
 
-  Scenario: The disaggregation filters affect the chart
+  Scenario: The disaggregation filters add lines to the chart
     Then I should see 1 "chart legend item" element
     And I click on "the filter drop-down button"
     And I click on "the first filter option"
     Then I should see 2 "chart legend item" elements
 
-  Scenario: The disaggregation filters affect the table
+  Scenario: The disaggregation filters add columns to the table
     And I click on "the Table tab"
     Then I should see 2 "data table column" elements
     And I click on "the filter drop-down button"

--- a/tests/features/Disaggregation.feature
+++ b/tests/features/Disaggregation.feature
@@ -8,17 +8,31 @@ Feature: Disaggregation
     Given I am on "/1-1-1"
     And I wait 3 seconds
 
-  Scenario: The disaggregation filters in the left sidebar work properly
-    Given I am on "/1-1-1"
-    Then I should see a "disaggregation filter" element
+  Scenario: The disaggregation filters affect the chart
+    Then I should see 1 "chart legend item" element
     And I click on "the filter drop-down button"
-    Then I should see "Select all"
-    And I should see "Clear all"
     And I click on "the first filter option"
-    Then I should see a "second item in the legend" element
+    Then I should see 2 "chart legend item" elements
 
-  Scenario: The disaggregation filters in the left sidebar are translated
-    Given I am on "/1-1-1"
+  Scenario: The disaggregation filters affect the table
+    And I click on "the Table tab"
+    Then I should see 2 "data table column" elements
+    And I click on "the filter drop-down button"
+    And I click on "the first filter option"
+    Then I should see 3 "data table column" elements
+
+  Scenario: The disaggregation filter select/clear buttons work
+    And I click on "the filter drop-down button"
+    And I click on "the 'Select all' button"
+    Then I should see 3 "chart legend item" elements
+    And I click on "the 'Clear all' button"
+    Then I should see 1 "chart legend item" element
+    And I click on "the 'Select all' button"
+    Then I should see 3 "chart legend item" elements
+    And I click on "the 'Clear selections' button"
+    And I should see 1 "chart legend item" element
+
+  Scenario: The disaggregation filters are translated
     And I click on "the language toggle dropdown"
     And I follow "the first language option"
     And I click on "the filter drop-down button"
@@ -27,3 +41,17 @@ Feature: Disaggregation
     And I should see "Limpiar todo"
     And I should see "Group-translated"
     And I should see "A-translated"
+
+  Scenario: The chart legend items are translated
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    And I click on "the filter drop-down button"
+    And I click on "the first filter option"
+    Then I should see "A-translated" in the "chart legend" element
+
+  Scenario: The table columns are translated
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    And I click on "the filter drop-down button"
+    And I click on "the first filter option"
+    Then I should see "A-translated" in the "data table" element

--- a/tests/features/Disaggregation.feature
+++ b/tests/features/Disaggregation.feature
@@ -1,0 +1,29 @@
+Feature: Disaggregation
+
+  As a site visitor
+  I need to be able to disaggregate the indicator data
+  So that I can gain a more detailed understanding of SDG progress
+
+  Background:
+    Given I am on "/1-1-1"
+    And I wait 3 seconds
+
+  Scenario: The disaggregation filters in the left sidebar work properly
+    Given I am on "/1-1-1"
+    Then I should see a "disaggregation filter" element
+    And I click on "the filter drop-down button"
+    Then I should see "Select all"
+    And I should see "Clear all"
+    And I click on "the first filter option"
+    Then I should see a "second item in the legend" element
+
+  Scenario: The disaggregation filters in the left sidebar are translated
+    Given I am on "/1-1-1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    And I click on "the filter drop-down button"
+    Then I should see "Borrar selecciones"
+    And I should see "Seleccionar todo"
+    And I should see "Limpiar todo"
+    And I should see "Group-translated"
+    And I should see "A-translated"

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -23,6 +23,10 @@ const driver = new mink.Mink({
     "the first language option": ".nav .language-options a:first-child",
     "goal status": ".goal .frame",
     "the search box": ".navbar #indicator_search",
+    "disaggregation filter": ".variable-selector",
+    "the filter drop-down button": ".variable-selector .accessBtn",
+    "the first filter option": ".variable-selector .variable-options label",
+    "second item in the legend": "#legend li[data-datasetindex='1']",
   }
 });
 

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -23,10 +23,15 @@ const driver = new mink.Mink({
     "the first language option": ".nav .language-options a:first-child",
     "goal status": ".goal .frame",
     "the search box": ".navbar #indicator_search",
-    "disaggregation filter": ".variable-selector",
     "the filter drop-down button": ".variable-selector .accessBtn",
     "the first filter option": ".variable-selector .variable-options label",
-    "second item in the legend": "#legend li[data-datasetindex='1']",
+    "chart legend": "#legend li",
+    "chart legend item": "#legend li",
+    "data table": "#selectionsTable",
+    "data table column": "#selectionsTable th",
+    "the 'Select all' button": "button[data-type='select']",
+    "the 'Clear all' button": "button[data-type='clear']",
+    "the 'Clear selections' button": "button#clear",
   }
 });
 


### PR DESCRIPTION
This allows for the translation of the disaggregation data columns/values, including the filters on the left, the columns of the data tables, the CSV exports, and the chart legends.

For indicators this depends on the translation keys being in a "data" translation group. I've started an [issue](https://github.com/open-sdg/sdg-translations/issues/70) in the SDG Translations project to do some translating of common disaggregation-related words.

This has a breaking change in the `head.html` include. If any implementer has overridden head.html then they will need to update it.

Also included are relevant documentation updates and Cucumber tests.

Fixes #5 