### PR TITLE
Add an optional layout for a grouped-by-target goal page

### DIFF
--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -1,0 +1,96 @@
+{%- include multilingual.html -%}
+{% include head.html %}
+{% include header.html %}
+{% assign goal_number = page.sdg_goal %}
+{% assign translated_goal = t.global_goals[goal_number] %}
+
+<div class="heading goal-{{page.sdg_goal}}">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-4 col-md-3 col-lg-2">
+        <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
+      </div>
+      <div class="col-xs-8 col-md-9 col-lg-10">
+        <h1>
+          <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
+        </h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="main-content" class="container goal-indicators goal-{{page.sdg_goal}} goal-by-target">
+
+  {{ content }}
+  {% include components/breadcrumb.html %}
+
+  <div class="visible-md-block visible-lg-block">
+    <div class="col-md-6">
+      <h4>{{ t.general.targets }}</h4>
+    </div>
+    <div class="col-md-6">
+      <h4>{{ t.general.indicators }}</h4>
+    </div>
+  </div>
+
+  {% assign goal_indicators = site.data.meta | where: 'sdg_goal', goal_number | sort: 'indicator_sort_order' | group_by: 'target_id' %}
+  {% for group in goal_indicators %}
+    {% assign target_id = group.name %}
+    {% assign translated_target = t.global_targets[target_id] %}
+    <div class="indicator-cards target col-md-6">
+      <span>
+        <label class="hidden-md hidden-lg">{{ t.general.target }}</label>
+        {{ target_id }}
+      </span>
+      {{ translated_target.title }}
+    </div>
+    <div class="indicator-cards col-md-6 row no-gutters">
+    {% for indicator in group.items %}
+      {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
+
+      {% if indicator.reporting_status == 'notstarted' %}
+        {% assign status_desc = t.status.exploring_data_sources %}
+        {% assign status_css = 'danger' %}
+      {% endif %}
+      {% if indicator.reporting_status == 'inprogress' %}
+        {% assign status_desc = t.status.statistics_in_progress %}
+        {% assign status_css = 'warning' %}
+      {% endif %}
+      {% if indicator.reporting_status == 'complete' %}
+        {% assign status_desc = t.status.reported_online %}
+        {% assign status_css = 'success' %}
+      {% endif %}
+      {% assign tag_classes = "" | split: "," %}
+      {% if indicator.tags %}
+        {% for tag in indicator.tags %}
+          {% assign tag_slug = "indicator-" | append: tag | slugify %}
+          {% assign tag_classes = tag_classes | push: tag_slug %}
+        {% endfor %}
+      {% endif %}
+      {% assign tag_classes = tag_classes | join: " " %}
+
+      <div class="col-md-12 {{ tag_classes }}">
+        <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator.indicator | slugify }}">
+          <span>
+            {{ indicator.indicator }}
+            <span class="status {{ status_css }}">
+              {{ status_desc }}
+            </span>
+          </span>
+          {{ translated_indicator.title }}
+          {% if indicator.tags %}
+            <ul class="tags">
+            {% for tag in indicator.tags %}
+              {% assign tag_class = tag | slugify %}
+              <li class="tag-{{ tag_class }} warning">{{ tag | t }}</li>
+            {% endfor %}
+            </ul>
+          {% endif %}
+        </a>
+      </div>
+    {% endfor %}
+    </div>
+	{% endfor %}
+</div>
+
+{% include footer.html %}

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -90,7 +90,7 @@
       </div>
     {% endfor %}
     </div>
-	{% endfor %}
+  {% endfor %}
 </div>
 
 {% include footer.html %}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1025,7 +1025,17 @@ h5 + .btn-download {
     margin: 2px 2px 0 0;
   }
   &.goal-indicators {
-    @include indicatorcards
+    @include indicatorcards;
+    &.goal-by-target {
+      .indicator-cards a {
+        padding: 0;
+        margin-bottom: 1.5rem;
+      }
+      .indicator-cards.target {
+        margin-bottom: 1.5rem;
+        clear: left;
+      }
+    }
   }
   .goal-indicators:after {
     content: "";

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -6,6 +6,21 @@ Jekyll configuration is stored at the root of the site repository in a YAML file
 
 The [site starter repository](https://github.com/open-sdg/open-sdg-site-starter) contains and [example config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml) with documentation of each of the platform-specific settings.
 
+## Optional features
+
+As with any Jekyll theme, Open SDG can be easily customised. The platform comes with some out-of-the-box optional features that can serve as examples of possible customisations.
+
+### Optional feature: Goal page layouts
+
+Open SDG includes two alternative [layouts](https://jekyllrb.com/docs/step-by-step/04-layouts/) for the 17 goal pages:
+
+1. [`goal`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal.html) - Indicators are displayed in a responsive grid
+1. [`goal-by-target`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal-by-target.html) - Targets on the left, and indicators on the right
+
+As with any Jekyll layout, you can use these by adjusting the [front matter](https://jekyllrb.com/docs/front-matter/) of the goal file. For example, to use the goal-by-target layout, you would need this in the goal's front matter:
+
+`layout: goal-by-target`
+
 ## Working with (remote) Jekyll themes
 
 This project (the repository you are reading currently) functions as a [Jekyll theme](https://jekyllrb.com/docs/themes/), which can most easily be used with the help of the [Remote Theme plugin](https://github.com/benbalter/jekyll-remote-theme). As with any Jekyll theme (and as can be seen in the [folder structure of this project](https://github.com/open-sdg/open-sdg)) the entirety of the theme is contained in these 3 folders:


### PR DESCRIPTION
This adds an optional goal layout for displaying targets in the left column and indicators in the right column.

Fixes #54 