### PR TITLE
Better character handling in search code

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -31,7 +31,7 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
     var results = [],
         that = this,
-        searchString = unescape(location.search.substring(1)).replace("q=", "");
+        searchString = decodeURIComponent(location.search.substring(1)).replace("q=", "");
 
     // we got here because of a redirect, so reinstate:
     this.inputElement.val(searchString);


### PR DESCRIPTION
This use decodeURIComponent instead of unescape. Apparently this handles non-latin characters better, as it fixes search for Armenian/Russian.

Fixes #115 