### PR TITLE
Allow configuration of tab for non-global metadata

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -113,7 +113,7 @@
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
           <li role="presentation" class="nav-item active">
-            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab">{{ t.indicator.national_metadata }}</a>
+            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab">{{ site.non_global_metadata | default: 'indicator.national_metadata' | t }}</a>
           </li>
           <li role="presentation" class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#globalmetadata" aria-controls="globalmetadata" role="tab">{{ t.indicator.global_metadata }}</a>


### PR DESCRIPTION
This will allow implementations to easily control the text of the non-global metadata tab. It includes a default of the translated text "National Metadata". Because of the default this is not a breaking change.

If this is merged then I'll add the `non_global_metadata` option to [this file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml), which is currently serving as our documentation of `_config.yml` options.

Fixes #52 