### PR TITLE
Set scope=row on cells in the Year column

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -439,7 +439,7 @@ var indicatorView = function (model, options) {
   };
 
   var setDataTableWidth = function(table) {
-    table.find('th').each(function() {
+    table.find('thead th').each(function() {
       var textLength = $(this).text().length;
       for(var loop = 0; loop < view_obj._tableColumnDefs.length; loop++) {
         var def = view_obj._tableColumnDefs[loop];
@@ -458,7 +458,7 @@ var indicatorView = function (model, options) {
     table.removeAttr('style width');
 
     var totalWidth = 0;
-    table.find('th').each(function() {
+    table.find('thead th').each(function() {
       if($(this).data('width')) {
         totalWidth += $(this).data('width');
       } else {
@@ -592,7 +592,11 @@ var indicatorView = function (model, options) {
       table.data.forEach(function (data) {
         var row_html = '<tr>';
         table.headings.forEach(function (heading, index) {
-          row_html += '<td' + (!index || heading.toLowerCase() == 'units' ? '' : ' class="table-value"') + '>' + (data[index] ? data[index] : '-') + '</td>';
+          // For accessibility set the Year column to a "row" scope th.
+          var isYear = (index == 0 || heading.toLowerCase() == 'year');
+          var cell_prefix = (isYear) ? '<th scope="row"' : '<td';
+          var cell_suffix = (isYear) ? '</th>' : '</td>';
+          row_html += cell_prefix + (!index || heading.toLowerCase() == 'units' ? '' : ' class="table-value"') + '>' + (data[index] ? data[index] : '-') + cell_suffix;
         });
         row_html += '</tr>';
         currentTable.find('tbody').append(row_html);

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -594,9 +594,10 @@ var indicatorView = function (model, options) {
         table.headings.forEach(function (heading, index) {
           // For accessibility set the Year column to a "row" scope th.
           var isYear = (index == 0 || heading.toLowerCase() == 'year');
+          var isUnits = (heading.toLowerCase() == 'units');
           var cell_prefix = (isYear) ? '<th scope="row"' : '<td';
           var cell_suffix = (isYear) ? '</th>' : '</td>';
-          row_html += cell_prefix + (!index || heading.toLowerCase() == 'units' ? '' : ' class="table-value"') + '>' + (data[index] ? data[index] : '-') + cell_suffix;
+          row_html += cell_prefix + (isYear || isUnits ? '' : ' class="table-value"') + '>' + (data[index] ? data[index] : '-') + cell_suffix;
         });
         row_html += '</tr>';
         currentTable.find('tbody').append(row_html);

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1086,7 +1086,7 @@ h5 + .btn-download {
       }
     }
     table {
-      th {
+      thead th {
         cursor: pointer;
 
         span.sort {
@@ -1109,6 +1109,9 @@ h5 + .btn-download {
         &.sorting_desc {
           span.sort { background-image: url(../img/sort_desc.png); }
         }
+      }
+      tbody th {
+        font-weight: normal;
       }
     }
 


### PR DESCRIPTION
Fixes #106 

One note though: I feel like we should be using the jquery.dataTables library to generate table markup, instead of looping through the data to generate it with custom code. My first thought in implementing this was to use the jquery.dataTables options "columnDefs", "cellType", and "createdCell". This should have worked, but we're generating our table markup outside of jquery.dataTables. Not a pressing issue, but in the future it might be nice if we could trim our custom code and leverage jquery.dataTables more. All that said, there may well be a good reason for the way it is now, that I don't know about.