### PR TITLE
Sort the years array in maps, to fix first/last year functionality

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -78,7 +78,7 @@
       .domain(this.valueRange)
       .classes(this.options.colorRange.length);
 
-    this.years = _.uniq(_.pluck(this.geoData, 'Year'));
+    this.years = _.uniq(_.pluck(this.geoData, 'Year')).sort();
     this.currentYear = this.years[0];
 
     this.init();


### PR DESCRIPTION
There is functionality, particularly in the year slider, that assumes the years array is sorted from first to last. But in practice it isn't necessarily sorted that way, so let's ensure that.