### PR TITLE
Refactor Google Analytics code

### DIFF
--- a/_includes/assets/js/googleAnalytics.js
+++ b/_includes/assets/js/googleAnalytics.js
@@ -2,7 +2,9 @@ function initialiseGoogleAnalytics(){
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');       
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        
+    sendPageviewToGoogleAnalytics();
 }
 
 function sendPageviewToGoogleAnalytics(){

--- a/_includes/assets/js/googleAnalytics.js
+++ b/_includes/assets/js/googleAnalytics.js
@@ -1,0 +1,17 @@
+function initialiseGoogleAnalytics(){
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');       
+}
+
+function sendPageviewToGoogleAnalytics(){
+    ga('create', '{{ site.analytics['ga_prod'] }}', 'auto');
+    // anonymize user IPs (chops off the last IP triplet)
+    ga('set', 'anonymizeIp', true);
+    // forces SSL even if the page were somehow loaded over http://
+    ga('set', 'forceSSL', true);
+    ga('send', 'pageview');
+}
+
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,10 +23,11 @@
 <!-- /.container </div> -->
 {% include scripts.html %}
 
+{% if site.analytics.ga_prod and site.analytics.ga_prod != '' %}
 <script>
-  {% if site.analytics.ga_prod and site.analytics.ga_prod != '' %}
   initialiseGoogleAnalytics();
-  {% endif %}
 </script>
+{% endif %}
+
 </body>
 </html>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
 {% include scripts.html %}
 
 <script>
-  {% if site.analytics.ga_prod and site.analytics.ga_prod != blank %}
+  {% if site.analytics.ga_prod and site.analytics.ga_prod != '' %}
   initialiseGoogleAnalytics();
   {% endif %}
 </script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,12 +24,10 @@
 {% include scripts.html %}
 
 <script>
-  initialiseGoogleAnalytics();
-  {% if site.environment == 'staging' %}
   
-  {% else %}
+  initialiseGoogleAnalytics();
   sendPageviewToGoogleAnalytics();
-  {% endif %}
+
 </script>
 </body>
 </html>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
 {% include scripts.html %}
 
 <script>
-  {% if site.analytics.ga_prod %}
+  {% if site.analytics.ga_prod and site.analytics.ga_prod != blank %}
   initialiseGoogleAnalytics();
   {% endif %}
 </script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,24 +20,16 @@
 <!-- <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script> -->
 <!-- Google Analytics -->
 
-<script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-{% if site.environment == 'staging' %}
-
-{% else %}
-ga('create', '{{ site.analytics['ga_prod'] }}', 'auto');
-// anonymize user IPs (chops off the last IP triplet)
-ga('set', 'anonymizeIp', true);
-// forces SSL even if the page were somehow loaded over http://
-ga('set', 'forceSSL', true);
-ga('send', 'pageview');
-{% endif %}
-</script>
-
 <!-- /.container </div> -->
 {% include scripts.html %}
+
+<script>
+  initialiseGoogleAnalytics();
+  {% if site.environment == 'staging' %}
+  
+  {% else %}
+  sendPageviewToGoogleAnalytics();
+  {% endif %}
+</script>
 </body>
 </html>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,10 +24,9 @@
 {% include scripts.html %}
 
 <script>
-  
+  {% if site.analytics.ga_prod %}
   initialiseGoogleAnalytics();
-  sendPageviewToGoogleAnalytics();
-
+  {% endif %}
 </script>
 </body>
 </html>

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -19,3 +19,4 @@
 {%- include assets/js/plugins/leaflet.downloadGeoJson.js -%}
 {%- include assets/js/plugins/leaflet.selectionLegend.js -%}
 {%- include assets/js/plugins/leaflet.yearSlider.js -%}
+{%- include assets/js/googleAnalytics.js -%}


### PR DESCRIPTION
This PR moves the google analytics code into a separate file `googleAnalytics.js` which can then be overridden without having to override the whole page footer.

I did sneak in another change, which I want to check with you @brockfanning. Rather than disabling `ga` for staging I've put it so that it checks for a `ga_prod` string in the config. If it has one, it'll use `ga`, if not, it won't. This is set from the line:

```
{% if site.analytics.ga_prod %}
initialiseGoogleAnalytics();
{% endif %}
```

This makes no changes for the UK. How about the US and other countries?

See #125 