### PR TITLE
Ignore Observation status and Unit multiplier fields

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -108,7 +108,7 @@ var indicatorModel = function (options) {
     }
 
     that.fieldItemStates = _.map(_.filter(Object.keys(that.data[0]), function (key) {
-        return ['Year', 'Value', 'Units', 'GeoCode'].indexOf(key) === -1;
+        return ['Year', 'Value', 'Units', 'GeoCode', 'Observation status', 'Unit multiplier'].indexOf(key) === -1;
       }), function(field) {
       return {
         field: field,

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -14,7 +14,7 @@
 {%- assign goal_number = meta.sdg_goal | downcase -%}
 {%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
 {%- assign translated_goal = t.global_goals[goal_number] -%}
-{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal.short | slugify }}{% endcapture %}
+{% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}{% endcapture %}
 {% capture goal_href %}{{ goal_uri }}{% endcapture %}
 {% capture goal_title %}{{ goal.title }}{% endcapture %}
 

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -15,7 +15,7 @@
 
         {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
             <div class="col-xs-4 col-md-2">
-                <a href="./{{ default_goal.short | slugify }}/">
+                <a href="./{{ goal_number }}/">
                   <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" id="goal-{{ goal_number }}" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
               </a>
             </div>

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -19,7 +19,7 @@
               <span class="status {{ status.status | slugify }}">{{ status.count }}</span><strong>{{ status.translation_key | t }}</strong><span class="value">{{ status.percentage }}%</span>
             </div>
             {%- endfor -%}
-            
+
             <br style="clear:both;">
           </div>
         </div>
@@ -28,7 +28,7 @@
             <span class="{{ status.status | slugify }}" style="width:{{ status.percentage }}%" title="{{ status.translation_key | t }}: {{ status.percentage }}%"></span>
             {%- endfor -%}
         </div>
-        
+
       </div>
     <!--</li>-->
     <br style="clear:both;">
@@ -42,13 +42,13 @@
     {%- assign translated_goal = t.global_goals[goal_number] -%}
     <div class="goal">
         <div class="frame">
-          <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ default_goal.short | slugify }}/">
+          <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}/">
             <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" width="100" height="100" />
           </a>
         </div>
         <div class="details">
           <h3 class="status-goal">
-            <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ default_goal.short | slugify }}/">{{ translated_goal.short }}</a>
+            <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}/">{{ translated_goal.short }}</a>
             <span class="total">{{ goalreport.totals.total }}<span></span> {{ t.general.indicators | downcase }}</span>
           </h3>
           <div class="summary">

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -9,21 +9,21 @@ Feature: Goal page
     Then I should see <TOTAL> "goal indicator" elements
 
     Examples:
-      | PATH                                    | TOTAL |
-      | /no-poverty                             | 14    |
-      | /zero-hunger                            | 13    |
-      | /good-health-and-well-being             | 27    |
-      | /quality-education                      | 11    |
-      | /gender-equality                        | 14    |
-      | /clean-water-and-sanitation             | 11    |
-      | /affordable-and-clean-energy            | 6     |
-      | /decent-jobs-and-economic-growth        | 17    |
-      | /industry-innovation-and-infrastructure | 12    |
-      | /reduced-inequalities                   | 11    |
-      | /sustainable-cities-communities         | 15    |
-      | /responsible-consumption-and-production | 13    |
-      | /climate-action                         | 8     |
-      | /life-below-water                       | 10    |
-      | /life-on-land                           | 14    |
-      | /peace-and-justice-strong-institutions  | 23    |
-      | /partnerships-for-the-goals             | 25    |
+      | PATH | TOTAL |
+      | /1   | 14    |
+      | /2   | 13    |
+      | /3   | 27    |
+      | /4   | 11    |
+      | /5   | 14    |
+      | /6   | 11    |
+      | /7   | 6     |
+      | /8   | 17    |
+      | /9   | 12    |
+      | /10  | 11    |
+      | /11  | 15    |
+      | /12  | 13    |
+      | /13  | 8     |
+      | /14  | 10    |
+      | /15  | 14    |
+      | /16  | 23    |
+      | /17  | 25    |

--- a/tests/features/Multilingual.feature
+++ b/tests/features/Multilingual.feature
@@ -12,7 +12,7 @@ Feature: Multilingual
     Then I should see "Haga clic en cada objetivo"
 
   Scenario: Lanugage switcher works on a goal page
-    Given I am on "/no-poverty"
+    Given I am on "/1"
     Then I should see "End poverty in all its forms everywhere"
     And I click on "the language toggle dropdown"
     And I follow "the first language option"


### PR DESCRIPTION
Update to `indicatorModel.js` to ignore Observation status and Unit multiplier fields when displaying the data in the site.

I haven't been able to test if it actually works because `jekyll serve` is giving me weird errors. Please let me know if you can run it.