### PR TITLE
Configurable frontpage headings

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -4,9 +4,11 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     {% assign country_name = site.country.name | t %}
-    <h1>{{ t.frontpage.heading | replace: '%name', country_name }}</h1>
+    {% assign heading_default = t.frontpage.heading | replace: '%name', country_name %}
+    <h1>{{ site.frontpage_heading | default: heading_default }}</h1>
 
-    <p>{{ t.frontpage.instructions | replace_first: '%before_link', '<span style="display:none" id="jump-to-search"><a href="javascript:void(0)">' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name }}</p>
+    {% assign instructions_default = t.frontpage.instructions | replace_first: '%before_link', '<span id="jump-to-search"><a>' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name %}
+    <p>{{ site.frontpage_instructions | default: instructions_default }}</p>
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -5,10 +5,10 @@
 
     {% assign country_name = site.country.name | t %}
     {% assign heading_default = t.frontpage.heading | replace: '%name', country_name %}
-    <h1>{{ site.frontpage_heading | default: heading_default }}</h1>
+    <h1>{{ site.frontpage_heading | default: heading_default | t }}</h1>
 
     {% assign instructions_default = t.frontpage.instructions | replace_first: '%before_link', '<span id="jump-to-search"><a>' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name %}
-    <p>{{ site.frontpage_instructions | default: instructions_default }}</p>
+    <p>{{ site.frontpage_instructions | default: instructions_default | t }}</p>
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1998,3 +1998,9 @@ body.contrast-high {
     }
   }
 }
+
+#jump-to-search {
+  a {
+    cursor: pointer;
+  }
+}

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -2,6 +2,8 @@
 
 # Replace this title as needed.
 title: Indicators For The Sustainable Development Goals
+frontpage_heading: custom.frontpage_heading
+frontpage_instructions: custom.frontpage_instructions
 # Replace the baseurl with the name of this repository.
 baseurl: ""
 url: ""

--- a/tests/data/translations/en/custom.yml
+++ b/tests/data/translations/en/custom.yml
@@ -1,0 +1,2 @@
+frontpage_heading: My custom frontpage heading
+frontpage_instructions: My custom frontpage instructions

--- a/tests/data/translations/es/custom.yml
+++ b/tests/data/translations/es/custom.yml
@@ -1,0 +1,2 @@
+frontpage_heading: My translated frontpage heading
+frontpage_instructions: My translated frontpage instructions

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -7,5 +7,8 @@ Feature: Homepage
   Background:
     Given I am on the homepage
 
+  Scenario: The heading text can be customised
+    Then I should see "My custom frontpage heading"
+
   Scenario: All 17 goal icons are visible
     Then I should see 17 "goal icon" elements

--- a/tests/features/LanguageSwitcher.feature
+++ b/tests/features/LanguageSwitcher.feature
@@ -6,10 +6,10 @@ Feature: Language switcher
 
   Scenario: Language switcher works on the homepage
     Given I am on the homepage
-    Then I should see "Click on each goal"
+    Then I should see "My custom frontpage instructions"
     And I click on "the language toggle dropdown"
     And I follow "the first language option"
-    Then I should see "Haga clic en cada objetivo"
+    Then I should see "My translated frontpage instructions"
 
   Scenario: Lanugage switcher works on a goal page
     Given I am on "/1"


### PR DESCRIPTION
Fixes #146 

## Breaking changes

None.

## Description

See #146 for details of the problem.

## Changes needed in other projects

After merging, the [open-sdg-site-starter config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml) should have this added to it:

```
# To customise the frontpage heading, uncomment and change the following line:
#frontpage_heading: This is my frontpage heading

# To customise the frontpage instructions, uncomment and change the following line:
#frontpage_instructions: These are my frontpage instructions
```

## Files affected

* _layouts/frontpage.html
* assets/css/default.scss

## Other notes
* believe at one point, probably before the open-sdg revamp, the jump-to-search was truly a "progressive enhancement", in that the whole phrase was hidden until javascript revealed it. At the moment it's only part of the phrase that's hidden, and the markup is tied up in sdg-translations, so is difficult to change. So I'm not worrying too much here about progressive enhancement. Long-term I think we should remove this whole phrase from sdg-translations and eventually just rely on _config.yml for this phrase. It can be much more easily tweaked from there.

## Documentation added

No, the additions to the starter repo's _config.yml afterwards will serve as documentation.

## Tests added

Yes.