### PR TITLE
add notapplicable as fully supported status #130

### DIFF
--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -47,18 +47,19 @@
     <div class="indicator-cards col-md-6 row no-gutters">
     {% for indicator in group.items %}
       {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
-
+      
+      {% assign status_css = indicator.reporting_status | slugify %}
+      {% if indicator.reporting_status == 'notapplicable' %}
+        {% assign status_desc = t.status.not_applicable %}
+      {% endif %}
       {% if indicator.reporting_status == 'notstarted' %}
         {% assign status_desc = t.status.exploring_data_sources %}
-        {% assign status_css = 'danger' %}
       {% endif %}
       {% if indicator.reporting_status == 'inprogress' %}
         {% assign status_desc = t.status.statistics_in_progress %}
-        {% assign status_css = 'warning' %}
       {% endif %}
       {% if indicator.reporting_status == 'complete' %}
         {% assign status_desc = t.status.reported_online %}
-        {% assign status_css = 'success' %}
       {% endif %}
       {% assign tag_classes = "" | split: "," %}
       {% if indicator.tags %}

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -29,15 +29,18 @@
     {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
 
     {% assign status_css = indicator.reporting_status | slugify %}
-    {% if indicator.reporting_status == 'notstarted' %}
-      {% assign status_desc = t.status.exploring_data_sources %}
-    {% endif %}
-    {% if indicator.reporting_status == 'inprogress' %}
-      {% assign status_desc = t.status.statistics_in_progress %}
-    {% endif %}
-    {% if indicator.reporting_status == 'complete' %}
-      {% assign status_desc = t.status.reported_online %}
-    {% endif %}
+      {% if indicator.reporting_status == 'notapplicable' %}
+        {% assign status_desc = t.status.not_applicable %}
+      {% endif %}
+      {% if indicator.reporting_status == 'notstarted' %}
+        {% assign status_desc = t.status.exploring_data_sources %}
+      {% endif %}
+      {% if indicator.reporting_status == 'inprogress' %}
+        {% assign status_desc = t.status.statistics_in_progress %}
+      {% endif %}
+      {% if indicator.reporting_status == 'complete' %}
+        {% assign status_desc = t.status.reported_online %}
+      {% endif %}
     {% assign tag_classes = "" | split: "," %}
     {% if indicator.tags %}
       {% for tag in indicator.tags %}

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -25,7 +25,7 @@
         </div>
         <div class="col col-xs-9 col-md-10 indicator-cards">
           <% _.each(goal.indicators, function(indicator){ %>
-            <a href="<%=indicator.href%>"><span><%= indicator.id %><span class="status <%= indicator.status %>"><% if(indicator.status == 'notstarted') { %>{{ t.status.exploring_data_sources }}<% } else if(indicator.status == 'inprogress') { %>{{ t.status.statistics_in_progress }}<% } else if(indicator.status == 'complete') { %>{{ t.status.reported_online }}<% } %></span></span> <%=indicator.parsedTitle%><% if(indicator.hasDescription) { %><p class="description"><%=indicator.parsedDescription%></p><%}%><% if(indicator.hasKeywords) { %><p class="keywords">{{ t.search.keywords }}: <%=indicator.parsedKeywords%></p><%}%></a>
+            <a href="<%=indicator.href%>"><span><%= indicator.id %><span class="status <%= indicator.status %>"><% if(indicator.status == 'notstarted') { %>{{ t.status.exploring_data_sources }}<% } else if(indicator.status == 'inprogress') { %>{{ t.status.statistics_in_progress }}<% } else if(indicator.status == 'complete') { %>{{ t.status.reported_online }}<% } else if(indicator.status == 'notapplicable') { %>{{ t.status.not_applicable }}<% } %></span></span> <%=indicator.parsedTitle%><% if(indicator.hasDescription) { %><p class="description"><%=indicator.parsedDescription%></p><%}%><% if(indicator.hasKeywords) { %><p class="keywords">{{ t.search.keywords }}: <%=indicator.parsedKeywords%></p><%}%></a>
           <% }); %>
         </div>
       </div>

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -622,6 +622,9 @@ h5 + .btn-download {
   background-color: #5cb85c;
 }
 
+.notapplicable {
+  background-color: #B7B7B7;
+}
 .notstarted {
   background-color: #E27874;
 }

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -111,7 +111,7 @@ These are not displayed on the website but affect how it is laid out.
 
 | Tag                                 | Description                        |
 |-------------------------------------|------------------------------------|
-| reporting_status                    | One of `notstarted` (red), `inprogress` (amber), or `complete` (green). |
+| reporting_status                    | One of `notstarted` (red), `inprogress` (amber), `complete` (green), or `notapplicable` (gray). |
 | data_non_statistical                | `true` or `false` flag. Non-statistical data does not have csv or graphs. |
 
 ## Graph Metadata


### PR DESCRIPTION
* Everywhere we reference `notstarted` etc I add `notapplicable`
* goal-by-target.html gets an update on the css to use status rather than danger, warning, success.

Fixes #130 