### PR TITLE
Remove `inprogress` reporting status

### DIFF
--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -35,9 +35,6 @@
       {% if indicator.reporting_status == 'notstarted' %}
         {% assign status_desc = t.status.exploring_data_sources %}
       {% endif %}
-      {% if indicator.reporting_status == 'inprogress' %}
-        {% assign status_desc = t.status.statistics_in_progress %}
-      {% endif %}
       {% if indicator.reporting_status == 'complete' %}
         {% assign status_desc = t.status.reported_online %}
       {% endif %}


### PR DESCRIPTION
Can the `inprogress` option be removed so that the default is `complete` / `notstarted` / `notapplicable`?