### PR TITLE
More robust way to display indicator names

### DIFF
--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -25,3 +25,8 @@
 {% endif %}
 
 {% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
+
+{% comment %}
+@deprecated: The following variable will be removed for 1.0.0.
+{% endcomment %}
+{%- assign translated_indicator = t.global_indicators[meta.indicator] -%}

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -25,5 +25,3 @@
 {% endif %}
 
 {% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
-
-{%- assign translated_indicator = t.global_indicators[meta.indicator] -%}

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -46,8 +46,7 @@
     </div>
     <div class="indicator-cards col-md-6 row no-gutters">
     {% for indicator in group.items %}
-      {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
-      
+
       {% assign status_css = indicator.reporting_status | slugify %}
       {% if indicator.reporting_status == 'notapplicable' %}
         {% assign status_desc = t.status.not_applicable %}
@@ -78,7 +77,7 @@
               {{ status_desc }}
             </span>
           </span>
-          {{ translated_indicator.title }}
+          {{ indicator.indicator | get_indicator_name }}
           {% if indicator.tags %}
             <ul class="tags">
             {% for tag in indicator.tags %}

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -26,7 +26,6 @@
 
   {% assign goal_indicators = site.data.meta | where: 'sdg_goal', page.sdg_goal | sort: 'indicator_sort_order' %}
   {% for indicator in goal_indicators %}
-    {%- assign translated_indicator = t.global_indicators[indicator.indicator] -%}
 
     {% assign status_css = indicator.reporting_status | slugify %}
       {% if indicator.reporting_status == 'notapplicable' %}
@@ -59,7 +58,7 @@
                 {{ status_desc }}
               </span>
             </span>
-            {{ translated_indicator.title }}
+            {{ indicator.indicator | get_indicator_name }}
             {% if indicator.tags %}
               <ul class="tags">
               {% for tag in indicator.tags %}

--- a/_layouts/indicator-json.html
+++ b/_layouts/indicator-json.html
@@ -17,10 +17,9 @@
         {%- for indicator in indicators -%}
         {%- capture indicator_id -%}{{indicator.indicator | slugify}}{%- endcapture -%}
         {%- assign meta = all_meta[indicator_id] -%}
-        {%- assign translated_meta = t.global_indicators[indicator.indicator] -%}
         {
           "id": "{{indicator_id}}",
-          "title": "{{translated_meta.title | strip_newlines | strip | replace: '"', "'"}}",
+          "title": "{{indicator_id | get_indicator_name | strip_newlines | strip | replace: '"', "'"}}",
           "description": "{{meta.national_indicator_description | strip_newlines | strip | replace: '"', "'" }}",
           "keywords": "{{meta.data_keywords}}",
           "href": "{{ site.baseurl }}{{ baseurl_folder }}/{{ indicator_id }}",

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -21,7 +21,7 @@
             <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
           </a>
         </h1>
-        <h2>{{ t.general.indicator }} {{ meta.indicator }}: {{ translated_indicator.title }}</h2>
+        <h2>{{ t.general.indicator }} {{ meta.indicator }}: {{ meta.indicator | get_indicator_name }}</h2>
       </div>
     </div>
   </div>

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -87,8 +87,8 @@ languages:
 goal_image_base: https://open-sdg.github.io/sdg-translations/assets/img/goals
 
 plugins:
-  - jekyll-open-sdg-plugins
   - jekyll-get-json
+  - jekyll-open-sdg-plugins
 
 # This makes sure that all pages have a language.
 defaults:

--- a/tests/data/translations/en/metadata.yml
+++ b/tests/data/translations/en/metadata.yml
@@ -1,0 +1,2 @@
+indicator-name-key: This is a non-translated indicator name
+computation-units-key: This is a non-translated unit of measurement

--- a/tests/data/translations/es/metadata.yml
+++ b/tests/data/translations/es/metadata.yml
@@ -1,0 +1,2 @@
+indicator-name-key: This is a translated indicator name via translation key
+computation-units-key: This is a translated unit of measurement via translation key

--- a/tests/features/LanguageSwitcher.feature
+++ b/tests/features/LanguageSwitcher.feature
@@ -1,4 +1,4 @@
-Feature: Multilingual
+Feature: Language switcher
 
   As a site visitor
   I need to be able to switch to my native language

--- a/tests/features/MultilingualMetadata.feature
+++ b/tests/features/MultilingualMetadata.feature
@@ -1,0 +1,36 @@
+Feature: Multilingual Metadata
+
+  As a site visitor
+  I need to be able to read metadata in my own language
+  So that I can learn about the data I am looking at
+
+  Scenario: Indicator names can be translated using a "subfolder" approach
+    Given I am on "/2-1-1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "This is a translated indicator name in a subfolder"
+
+  Scenario: Indicator names can be translated using a "translation key" approach
+    Given I am on "/2-2-2"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "This is a translated indicator name via translation key"
+
+  Scenario: National metadata can be translated using a "subfolder" approach
+    Given I am on "/2-4-1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "This is a translated unit of measurement in a subfolder"
+
+  Scenario: National metadata can be translated using a "translation key" approach
+    Given I am on "/2-3-2"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "This is a translated unit of measurement via translation key"
+
+  Scenario: Global indicators will fall back to the United Nations translation
+    Given I am on "/6-3-1"
+    Then I should see "Proportion of wastewater safely treated"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "Proporción de aguas residuales tratadas de manera adecuada"


### PR DESCRIPTION
This refactors a few places where indicator names are needed. Mostly it changes the code from relying on global indicator names, to using a new filter in jekyll-open-sdg-plugins that figures out the indicator name in a more forgiving way.

The upside of this change is that if countries are using national/proxy/etc indicators, the custom indicator name will appear instead of the current behavior, which is that the name is either global or missing altogether.

## Breaking change

This requires that the Gemfile for a site be updated to pull in at least version 0.0.10 of the jekyll-open-sdg-plugins Gem, like [this](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/Gemfile#L8).

Otherwise there are a lot of changed files, but it won't break anything if they are overridden. One unnecessary variable has been marked as "deprecated" but left in for backwards compatibility.

## Tech notes

* The mechanism here is a Liquid filter called "get_indicator_name"
* This filter has a particular series of places that it looks for indicator names. The idea is that it finds the intended translation, but always falls back to something. Here is the order of places it looks for translations:
    1. A translation of the "indicator_name" metadata field
    2. If this is the default language, the un-translated "indicator_name" metadata field
    3. If this indicator is global, the translated global indicator name
    4. Fall back to the untranslated "indicator_name" metadata field
    5. Fall back to the indicator ID