### PR TITLE
Ensure binary graphs always stretch from Yes (1) to No (-1)

### DIFF
--- a/_includes/components/charts/binary.html
+++ b/_includes/components/charts/binary.html
@@ -24,9 +24,10 @@
       scales: {
         yAxes: [{
           ticks: {
-            // Set the minimum to -1 so that the bars will start from the
+            // Set the min/max to -1/1 so that the bars will start from the
             // middle and either go up (for 1) or down (for -1).
             min: -1,
+            max: 1,
             callback: function(value, index, values) {
                 if (value == 1) {
                   return 'Yes';


### PR DESCRIPTION
Fixes #176 

## Breaking changes

None

## Description

See #176 for a description of the problem.

## Files affected

* _includes/components/charts/binary.html

## Documentation added

No, this is a bug fix.

## Tests added

No because it would be too difficult, as far as I know, to test the output of canvas elements.