### PR TITLE
Remove all "canvas" text and replace with HTML

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -43,9 +43,6 @@ var indicatorModel = function (options) {
   this.chartTitle = options.chartTitle;
   this.graphType = options.graphType;
   this.measurementUnit = options.measurementUnit;
-  this.dataSource = options.dataSource;
-  this.geographicalArea = options.geographicalArea;
-  this.footnote = options.footnote;
   this.showData = options.showData;
   this.selectedFields = [];
   this.allowedFields = [];
@@ -178,12 +175,6 @@ var indicatorModel = function (options) {
       spanGaps: false
     };
 
-    that.footerFields = {
-      'Source': that.dataSource,
-      'Geographical Area': that.geographicalArea,
-      'Unit of Measurement': that.measurementUnit,
-      'Footnote': that.footnote,
-    };
   }());
 
   var headlineColor = '777777';
@@ -281,12 +272,12 @@ var indicatorModel = function (options) {
 
   this.updateSelectedUnit = function(selectedUnit) {
     this.selectedUnit = selectedUnit;
-    
+
     // if fields are dependent on the unit, reset:
     this.getData({
       unitsChangeSeries: this.dataHasUnitSpecificFields
     });
-    
+
     this.onUnitsSelectedChanged.notify(selectedUnit);
   };
 
@@ -512,7 +503,7 @@ var indicatorModel = function (options) {
         return ds.data[yearIndex]
       })));
     });
-      
+
     this.onDataComplete.notify({
       datasetCountExceedsMax: datasetCountExceedsMax,
       datasets: datasetCountExceedsMax ? datasets.slice(0, maxDatasetCount) : datasets,
@@ -522,7 +513,6 @@ var indicatorModel = function (options) {
       indicatorId: this.indicatorId,
       shortIndicatorId: this.shortIndicatorId,
       selectedUnit: this.selectedUnit,
-      footerFields: this.footerFields
     });
 
     if(options.initial || options.unitsChangeSeries) {
@@ -579,7 +569,7 @@ var indicatorModel = function (options) {
 
 indicatorModel.prototype = {
   initialise: function () {
-    this.getData({ 
+    this.getData({
       initial: true
     });
   },

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -1,4 +1,5 @@
 {% if include.graph_type %}
+    {% include components/data-header.html meta=include.meta %}
 
     <div id="dataset-size-warning" style="display:none">
       <i class="fa fa-bolt"></i> {{ t.indicator.dataset_size_warning }}
@@ -9,6 +10,9 @@
         {% include {{graph_template}} %}
     </div>
     <div id="plotLegend"></div>
+    <div id="chart-footer">
+        {% include components/data-footer.html meta=include.meta %}
+    </div>
 
     <div id="chartSelectionDownload"></div>
 

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -9,10 +9,10 @@
     <div class="plot-container">
         {% include {{graph_template}} %}
     </div>
-    <div id="plotLegend"></div>
     <div id="chart-footer">
         {% include components/data-footer.html meta=include.meta %}
     </div>
+    <div id="plotLegend"></div>
 
     <div id="chartSelectionDownload"></div>
 

--- a/_includes/components/data-footer.html
+++ b/_includes/components/data-footer.html
@@ -1,0 +1,18 @@
+<dl class="data-footer dl-horizontal">
+  {% if include.meta['source_organisation_1'] %}
+    <dt>{{ t.indicator.source }}</dt>
+    <dd>{{ include.meta['source_organisation_1'] | t }}</dd>
+  {% endif %}
+  {% if include.meta['national_geographical_coverage'] %}
+    <dt>{{ t.indicator.geographical_area }}</dt>
+    <dd>{{ include.meta['national_geographical_coverage'] | t }}</dd>
+  {% endif %}
+  {% if include.meta['computation_units'] %}
+    <dt>{{ t.indicator.unit_of_measurement }}</dt>
+    <dd>{{ include.meta['computation_units'] | t }}</dd>
+  {% endif %}
+  {% if include.meta['data_footnote'] %}
+    <dt>{{ t.indicator.footnote }}</dt>
+    <dd>{{ include.meta['data_footnote'] | t }}</dd>
+  {% endif %}
+</dl>

--- a/_includes/components/data-header.html
+++ b/_includes/components/data-header.html
@@ -1,0 +1,3 @@
+{% if include.meta.graph_title %}
+  <h5>{{ include.meta.graph_title }}</h5>
+{% endif %}

--- a/_includes/components/data-table.html
+++ b/_includes/components/data-table.html
@@ -1,0 +1,5 @@
+<div id="selectionsTable"></div>
+<div id="selectionTableFooter" class="table-footer-text">
+  {% include components/data-footer.html meta=include.meta %}
+</div>
+<div id="tableSelectionDownload"></div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -42,16 +42,13 @@ $(function() {
             shortIndicatorId: domData.id,
             chartTitle: domData.charttitle,
             measurementUnit: domData.measurementunit,
-            dataSource: domData.datasource,
-            geographicalArea: domData.geographicalarea,
             showData: domData.showdata,
-            footnote: domData.footnote,
             graphType: domData.graphtype
           }),
           view  = new indicatorView(model, {
             rootElement: '#indicatorData',
             legendElement: '#plotLegend',
-            maxChartHeight: 600,
+            maxChartHeight: 500,
             tableColumnDefs: [
               { maxCharCount: 25 }, // nowrap
               { maxCharCount: 35, width: 200 },

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -42,8 +42,17 @@
     </div>
   </div>
 
-  <div class="row" id="indicatorData" data-indicatorid='{{dataset_name}}' data-id="{{meta.indicator | slugify }}" data-country="{{ meta.national_geographical_coverage | t }}"
-  data-charttitle="{{ meta.graph_title | t }}" data-measurementunit="{{ meta.computation_units | t }}" data-datasource="{{ meta.source_organisation_1 | t }}" data-geographicalarea="{{ meta.national_geographical_coverage | t }}" data-footnote="{{ meta.data_footnote | t }}" data-showdata="{{ show_data }}" data-graphtype="{{ meta.graph_type }}" data-geocoderegex="{{ meta.data_geocode_regex }}" data-showmap="{{ meta.data_show_map }}">
+  <div class="row"
+       id="indicatorData"
+       data-indicatorid='{{dataset_name}}'
+       data-id="{{meta.indicator | slugify }}"
+       data-country="{{ meta.national_geographical_coverage | t }}"
+       data-charttitle="{{ meta.graph_title | t }}"
+       data-measurementunit="{{ meta.computation_units | t }}"
+       data-showdata="{{ show_data }}"
+       data-graphtype="{{ meta.graph_type }}"
+       data-geocoderegex="{{ meta.data_geocode_regex }}"
+       data-showmap="{{ meta.data_show_map }}">
     {% if show_data %}
     <div class="col-md-3">
       <div id="toolbar">
@@ -92,10 +101,10 @@
           <!-- Tab panes -->
           <div class="tab-content data-view">
             <div role="tabpanel" class="tab-pane active" id="chartview">
-              {% include components/charts/chart.html graph_type=meta.graph_type %}
+              {% include components/charts/chart.html graph_type=meta.graph_type meta=meta %}
             </div>
             <div role="tabpanel" class="tab-pane" id="tableview">
-              <div id="selectionsTable"></div>
+              {% include components/data-table.html meta=meta %}
             </div>
             <div role="tabpanel" class="tab-pane" id="mapview" class="map">
               <div id="map">

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -974,8 +974,11 @@ h5 + .btn-download {
   }
 
   .plot-container {
-    margin-bottom: 4.5rem;
     padding: 10px;
+  }
+
+  #chart-footer {
+    margin-bottom: 4.5rem;
   }
 
   #chartSelectionDownload {


### PR DESCRIPTION
Fixes #142 

This changes the graph title and footer so that they are normal HTML instead of "canvas" text. This allows it to be drag-selected, wrap normally, and be styled more easily. For consistency, the table footer is also changed to match. A general cleanup of indicatorView.js is also included (removing empty functions and unused variables).

Backwards-compatibility note: This changes a lot of files, but doesn't break much if files are overridden. From my testing, the worst that can happen is that, if a country is overriding both the indicator.html layout and the default.scss file, the chart legend will bump up against the chart footer.

Below is are screenshots of the new charts/tables. The footer table is not using any new CSS -- instead it's using the out-of-the-box Bootstrap treatment of "description lists" provided by the "dl-horizontal" class.

![remove-canvas-text--chart](https://user-images.githubusercontent.com/1319083/58174394-dcd80400-7c6b-11e9-89ff-577cfac76741.png)

![remove-canvas-text--table](https://user-images.githubusercontent.com/1319083/58174404-e19cb800-7c6b-11e9-8269-580fe8a715c5.png)
