### PR TITLE
Better selection of fields when there is no headline

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -573,6 +573,7 @@ var indicatorModel = function (options) {
     if((options.initial || options.unitsChangeSeries) && !this.hasHeadline) {
       // if there is no initial data, select some:
 
+      // @TODO: Can the following be customisable per indicator, via metadata?
       // We have to decide what filters will be selected, and in some cases it
       // may need to be multiple filters. So we find the smallest row (meaning,
       // the row with the least number of disaggregations) and then sort it by

--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -37,7 +37,6 @@ var indicatorModel = function (options) {
   this.data = convertJsonFormat(options.data);
   this.edgesData = convertJsonFormat(options.edgesData);
   this.hasHeadline = true;
-  this.minimumFieldSelections = {};
   this.country = options.country;
   this.indicatorId = options.indicatorId;
   this.shortIndicatorId = options.shortIndicatorId;
@@ -592,11 +591,9 @@ var indicatorModel = function (options) {
       // rows. In other words, the number of fields each has. We want the
       // smallest one.
       fieldData = _.sortBy(fieldData, function(item) { return _.size(item); });
-      // Now that we are all sorted, we get the first row and set it as the
-      // "minimumFieldSelections".
-      this.minimumFieldSelections = fieldData[0];
-      // Notify the view that there is no headline.
-      this.onNoHeadlineData.notify();
+      // Now that we are all sorted, we notify the view that there is no headline,
+      // and pass along the first row as the minimum field selections.
+      this.onNoHeadlineData.notify({ minimumFieldSelections: fieldData[0] });
     }
   };
 };

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -54,7 +54,24 @@ var indicatorView = function (model, options) {
   });
 
   this._model.onNoHeadlineData.attach(function() {
-    $('#fields .variable-options :checkbox:eq(0)').trigger('click');
+    var minimumFieldSelections = view_obj._model.minimumFieldSelections;
+    // If the model specifies the minimum field selections, impersonate a user
+    // and "click" on each of them.
+    // @TODO: Can this be customisable per indicator?
+    if (minimumFieldSelections) {
+      for (var fieldToSelect in minimumFieldSelections) {
+        var fieldValue = minimumFieldSelections[fieldToSelect];
+        $('#fields .variable-options input[type="checkbox"]')
+          .filter('[data-field="' + fieldToSelect + '"]')
+          .filter('[value="' + fieldValue + '"]')
+          .first()
+          .click();
+      }
+    }
+    else {
+      // Backwards compatibility - just click on the first one, whatever it is.
+      $('#fields .variable-options :checkbox:eq(0)').trigger('click');
+    }
   });
 
   this._model.onSeriesComplete.attach(function(sender, args) {

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -53,14 +53,12 @@ var indicatorView = function (model, options) {
     view_obj.createSelectionsTable(args);
   });
 
-  this._model.onNoHeadlineData.attach(function() {
-    var minimumFieldSelections = view_obj._model.minimumFieldSelections;
-    // If the model specifies the minimum field selections, impersonate a user
-    // and "click" on each of them.
-    // @TODO: Can this be customisable per indicator?
-    if (minimumFieldSelections) {
-      for (var fieldToSelect in minimumFieldSelections) {
-        var fieldValue = minimumFieldSelections[fieldToSelect];
+  this._model.onNoHeadlineData.attach(function(sender, args) {
+    if (args && args.minimumFieldSelections) {
+      // If we have minimum field selections, impersonate a user and "click" on
+      // each item.
+      for (var fieldToSelect in args.minimumFieldSelections) {
+        var fieldValue = args.minimumFieldSelections[fieldToSelect];
         $('#fields .variable-options input[type="checkbox"]')
           .filter('[data-field="' + fieldToSelect + '"]')
           .filter('[value="' + fieldValue + '"]')

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -54,7 +54,7 @@ var indicatorView = function (model, options) {
   });
 
   this._model.onNoHeadlineData.attach(function(sender, args) {
-    if (args && args.minimumFieldSelections) {
+    if (args && args.minimumFieldSelections && _.size(args.minimumFieldSelections)) {
       // If we have minimum field selections, impersonate a user and "click" on
       // each item.
       for (var fieldToSelect in args.minimumFieldSelections) {
@@ -67,7 +67,7 @@ var indicatorView = function (model, options) {
       }
     }
     else {
-      // Backwards compatibility - just click on the first one, whatever it is.
+      // Fallback behavior - just click on the first one, whatever it is.
       $('#fields .variable-options :checkbox:eq(0)').trigger('click');
     }
   });

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -46,7 +46,8 @@ $(function() {
             geographicalArea: domData.geographicalarea,
             showData: domData.showdata,
             footnote: domData.footnote,
-            graphType: domData.graphtype
+            graphType: domData.graphtype,
+            startValues: domData.startvalues
           }),
           view  = new indicatorView(model, {
             rootElement: '#indicatorData',

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -43,7 +43,9 @@
   </div>
 
   <div class="row" id="indicatorData" data-indicatorid='{{dataset_name}}' data-id="{{meta.indicator | slugify }}" data-country="{{ meta.national_geographical_coverage | t }}"
-  data-charttitle="{{ meta.graph_title | t }}" data-measurementunit="{{ meta.computation_units | t }}" data-datasource="{{ meta.source_organisation_1 | t }}" data-geographicalarea="{{ meta.national_geographical_coverage | t }}" data-footnote="{{ meta.data_footnote | t }}" data-showdata="{{ show_data }}" data-graphtype="{{ meta.graph_type }}" data-geocoderegex="{{ meta.data_geocode_regex }}" data-showmap="{{ meta.data_show_map }}">
+  data-charttitle="{{ meta.graph_title | t }}" data-measurementunit="{{ meta.computation_units | t }}" data-datasource="{{ meta.source_organisation_1 | t }}"
+  data-geographicalarea="{{ meta.national_geographical_coverage | t }}" data-footnote="{{ meta.data_footnote | t }}" data-showdata="{{ show_data }}" data-graphtype="{{ meta.graph_type }}"
+  data-geocoderegex="{{ meta.data_geocode_regex }}" data-showmap="{{ meta.data_show_map }}" data-startvalues="{{ meta.data_start_values | join: '|' }}">
     {% if show_data %}
     <div class="col-md-3">
       <div id="toolbar">

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -61,6 +61,31 @@ A full size demo data set can be [downloaded here](https://raw.githubusercontent
 
 Some indicators are reported using different units of measure. A special column name, `Units` is used to capture this (see the UK's [9-2-1](https://github.com/ONSdigital/sdg-data/blob/develop/data/indicator_9-2-1.csv) as an example). The `Units` column is interpreted as a special top-level disaggregation. You may only choose one at a time and it affects the chart axis labels. A Units column is not required if an indicator only includes one unit.
 
+## Indicators without headlines
+
+A "headline" is a term for the all-blank row mentioned above, which contains no disaggregations. By default, this "headline" is what will display as soon as an indicator page loads.
+
+However, Open SDG can also handle indicator data without a headline. This might happen, for example, if you have statistics for "Apples" and "Oranges", but no aggregated total for all fruits:
+
+|Year|Grade|Fruit   | Value|
+|:---|:----|:-------|:-----|
+|2015|A    |Apples  |1.2   |
+|2016|A    |Apples  |1.5   |
+|2015|     |Oranges |1.3   |
+|2016|     |Oranges |1.4   |
+
+Open SDG will choose the smallest set of disaggregations to start with. So in the example above, Open SDG will start with "Oranges" selected.
+
+In addition, by setting a special metadata field called `data_start_values`, you can also control exactly what disaggregations are selected. For example by setting this in the metadata for an indicator...
+
+```
+data_start_values:
+  - Apples
+  - A
+```
+
+...Open SDG will start with both "Apples" and "A" selected, instead of "Oranges".
+
 ## White space
 
 You can double check for white space within an Excel file using a COUNTIF formula or by running a macro. We will add more information on this soon.

--- a/tests/features/Headline.feature
+++ b/tests/features/Headline.feature
@@ -1,0 +1,17 @@
+Feature: Headlines
+
+  As a site visitor browsing indicator pages with data
+  I need to see a series visualised without requiring any interaction
+  So that I easily and quickly see statistical trends
+
+  Scenario: Indicators with headlines (series without disaggregation) show visualisation
+    Given I am on "/1-2-1"
+    Then I should see 1 "chart legend item" element
+
+  Scenario: Indicators without headlines, but single-disaggregation rows, show visualisation
+    Given I am on "/1-3-1"
+    Then I should see 1 "chart legend item" element
+
+  Scenario: Indicators without headlines, but double-disaggregation rows, show visualisation
+    Given I am on "/1-4-1"
+    Then I should see 1 "chart legend item" element


### PR DESCRIPTION
Fixes #174 

## Breaking changes

None.

## Description

Right now, when there is no headline, the first field is automatically selected. For many cases this is fine, but it doesn't work in cases where more than 1 field is needed to display data.

An example of such as place is: https://onsdigital.github.io/sdg-indicators/10-6-1/

## Files affected

* _includes/assets/js/indicatorModel.js
* _includes/assets/js/indicatorView.js
* _includes/scripts.html
* _layouts/indicator.html

## Documentation added

Yes.

## Tests added

Yes.