### PR TITLE
Autotrack for Google Analytics

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -59,21 +59,17 @@ var accessibilitySwitcher = function() {
   ////////////////////////////////////////////////////////////////////////////////////
 
   _.each(contrastIdentifiers, function(contrast) {
-    $('.contrast-switcher')
-      .append($('<li />').attr({
-        'class': 'nav-link contrast contrast-' + contrast
-      })
-      .html($('<a />').attr({
-        'href': 'javascript:void(0)',
-        'title': 'Set to ' + contrast + ' contrast',
-        'data-contrast': contrast,
-      })
-      .attr(opensdg.autotrack('switch_contrast', 'Accessibility', 'Change contrast setting', contrast))
-      .text('A')
-      .click(function() {
-        setActiveContrast($(this).data('contrast'));
-        imageFix(contrast);
-      })));
+    var gaAttributes = opensdg.autotrack('switch_contrast', 'Accessibility', 'Change contrast setting', contrast);
+    $('.contrast-switcher').append($('<li />').attr({
+      'class': 'nav-link contrast contrast-' + contrast
+    }).html($('<a />').attr(gaAttributes).attr({
+      'href': 'javascript:void(0)',
+      'title': 'Set to ' + contrast + ' contrast',
+      'data-contrast': contrast,
+    }).text('A').click(function() {
+      setActiveContrast($(this).data('contrast'));
+      imageFix(contrast);
+    })));
   });
 
 function imageFix(contrast) {

--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -59,16 +59,21 @@ var accessibilitySwitcher = function() {
   ////////////////////////////////////////////////////////////////////////////////////
 
   _.each(contrastIdentifiers, function(contrast) {
-    $('.contrast-switcher').append($('<li />').attr({
-      'class': 'nav-link contrast contrast-' + contrast
-    }).html($('<a />').attr({
-      'href': 'javascript:void(0)',
-      'title': 'Set to ' + contrast + ' contrast',
-      'data-contrast': contrast,
-    }).text('A').click(function() {
-      setActiveContrast($(this).data('contrast'));
-      imageFix(contrast);
-    })));
+    $('.contrast-switcher')
+      .append($('<li />').attr({
+        'class': 'nav-link contrast contrast-' + contrast
+      })
+      .html($('<a />').attr({
+        'href': 'javascript:void(0)',
+        'title': 'Set to ' + contrast + ' contrast',
+        'data-contrast': contrast,
+      })
+      .attr(opensdg.autotrack('switch_contrast', 'Accessibility', 'Change contrast setting', contrast))
+      .text('A')
+      .click(function() {
+        setActiveContrast($(this).data('contrast'));
+        imageFix(contrast);
+      })));
   });
 
 function imageFix(contrast) {

--- a/_includes/assets/js/autotrack-element.js
+++ b/_includes/assets/js/autotrack-element.js
@@ -1,0 +1,38 @@
+---
+# Don't delete this line.
+---
+/**
+ * This function returns a javascript object containing autotrack.js properties.
+ *
+ * These properties can be added to an element with jQuery: $(element).attr(props)
+ *
+ * See _includes/autotrack.html for parameter descriptions.
+ */
+opensdg.autotrack = function(preset, category, action, label) {
+  var presets = {};
+  {%- if site.data.autotrack -%}
+    presets = {%- site.data.autotrack | jsonify -%};
+  {%- endif -%}
+  var params = {
+    category: category,
+    action: action,
+    label: label
+  };
+  if (presets[preset]) {
+    params = presets[preset];
+  }
+  var obj = {
+    'data-on': 'click'
+  };
+  if (params.category) {
+    obj['data-event-category'] = params.category;
+  }
+  if (params.action) {
+    obj['data-event-action'] = params.action;
+  }
+  if (params.label) {
+    obj['data-event-label'] = params.label;
+  }
+
+  return obj;
+};

--- a/_includes/assets/js/autotrack-element.js
+++ b/_includes/assets/js/autotrack-element.js
@@ -1,6 +1,3 @@
----
-# Don't delete this line.
----
 /**
  * This function returns a javascript object containing autotrack.js properties.
  *

--- a/_includes/assets/js/autotrack-element.js
+++ b/_includes/assets/js/autotrack-element.js
@@ -11,7 +11,7 @@
 opensdg.autotrack = function(preset, category, action, label) {
   var presets = {};
   {%- if site.data.autotrack -%}
-    presets = {%- site.data.autotrack | jsonify -%};
+    presets = {{ site.data.autotrack | jsonify }};
   {%- endif -%}
   var params = {
     category: category,

--- a/_includes/assets/js/googleAnalytics.js
+++ b/_includes/assets/js/googleAnalytics.js
@@ -3,12 +3,15 @@ function initialiseGoogleAnalytics(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        
+
     sendPageviewToGoogleAnalytics();
 }
 
 function sendPageviewToGoogleAnalytics(){
     ga('create', '{{ site.analytics['ga_prod'] }}', 'auto');
+    ga('require', 'eventTracker', {
+        attributePrefix: 'data-'
+    });
     // anonymize user IPs (chops off the last IP triplet)
     ga('set', 'anonymizeIp', true);
     // forces SSL even if the page were somehow loaded over http://

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -531,7 +531,9 @@ var indicatorView = function (model, options) {
       if (name == 'Table') {
         downloadKey = 'download_table';
       }
+      var gaLabel = 'Download ' + name + ' CSV: ' + indicatorId.replace('indicator_', '');
       $(el).append($('<a />').text(translations.indicator[downloadKey])
+      .attr(opensdg.autotrack('download_data_current', 'Downloads', 'Download CSV', gaLabel))
       .attr({
         'href': URL.createObjectURL(new Blob([this.toCsv(table)], {
           type: 'text/csv'
@@ -544,8 +546,10 @@ var indicatorView = function (model, options) {
       .data('csvdata', this.toCsv(table)));
     } else {
       var headlineId = indicatorId.replace('indicator', 'headline');
-      var id = indicatorId.replace('indicator', '');
+      var id = indicatorId.replace('indicator_', '');
+      var gaLabel = 'Download Headline CSV: ' + id;
       $(el).append($('<a />').text(translations.indicator.download_headline)
+      .attr(opensdg.autotrack('download_data_headline', 'Downloads', 'Download CSV', gaLabel))
       .attr({
         'href': opensdg.remoteDataBaseUrl + '/headline/' + id + '.csv',
         'download': headlineId + '.csv',
@@ -557,7 +561,9 @@ var indicatorView = function (model, options) {
   }
 
   this.createSourceButton = function(indicatorId, el) {
+    var gaLabel = 'Download Source CSV: ' + indicatorId;
     $(el).append($('<a />').text(translations.indicator.download_source)
+    .attr(opensdg.autotrack('download_data_source', 'Downloads', 'Download CSV', gaLabel))
     .attr({
       'href': opensdg.remoteDataBaseUrl + '/data/' + indicatorId + '.csv',
       'download': indicatorId + '.csv',

--- a/_includes/autotrack.html
+++ b/_includes/autotrack.html
@@ -1,0 +1,27 @@
+{%- comment -%}
+Renders HTML properties that autotrack.js can use to track a click event.
+Parameters
+----------
+preset
+  The name of a "preset" combination of properties, which is expected to exist
+  in site.data.autotrack. For example, if the preset is "foo", then this looks
+  for an object at site.data.autotrack.foo. If found, that object should contain
+  all the other parameters of this include. If not found, the other parameters
+  of this include will be used instead.
+  This preset logic allows sites to override the other parameters by creating an
+  autotrack data file (such as data/autotrack.yml).
+category
+  The Google Analytics "category" for this event, if any
+action
+  The Google Analytics "action" for this event, if any
+label
+  The Google Analytics "label" for this event, if any
+{%- endcomment -%}
+{%- assign params = include -%}
+{%- if include.preset and site.data.autotrack and site.data.autotrack[include.preset] -%}
+  {%- assign params = site.data.autotrack[include.preset] -%}
+{%- endif -%}
+data-on="click"
+{% if params.category %}data-event-category="{{ params.category }}"{% endif %}
+{% if params.action %}data-event-action="{{ params.action }}"{% endif %}
+{% if params.label %}data-event-label="{{ params.label }}"{% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -15,6 +15,7 @@
 <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js'></script>
 <script src="https://bowercdn.net/c/leaflet.zoomhome-latest/dist/leaflet.zoomhome.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/autotrack/2.4.1/autotrack.js"></script>
 <script src='{{ site.baseurl }}/assets/js/sdg.js?v={{ cache_bust }}'></script>
 <script>
 $(function() {

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -74,17 +74,17 @@
         <div class="async-loaded" style="display:none">
           <ul class="nav nav-tabs data-view" role="tablist">
             <li role="presentation" class="nav-item active">
-              <a class="nav-link" data-toggle="tab" href="#chartview" aria-controls="chartview" role="tab">{{ t.indicator.chart }}</a>
+              <a class="nav-link" data-toggle="tab" href="#chartview" aria-controls="chartview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Chart tab" %}>{{ t.indicator.chart }}</a>
             </li>
             <li role="presentation" class="nav-item">
-              <a class="nav-link" data-toggle="tab" href="#tableview" aria-controls="tableview" role="tab">{{ t.indicator.table }}</a>
+              <a class="nav-link" data-toggle="tab" href="#tableview" aria-controls="tableview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Table tab" %}>{{ t.indicator.table }}</a>
             </li>
             <li role="presentation" class="nav-item map" style="display:none">
-              <a class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab">{{ t.indicator.map }}</a>
+              <a class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Map tab" %}>{{ t.indicator.map }}</a>
             </li>
             {%- if meta.embedded_map_html -%}
             <li role="presentation" class="nav-item embedded-map">
-              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab">{{ t.indicator.map }}</a>
+              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ t.indicator.map }}</a>
             </li>
             {%- endif -%}
           </ul>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -74,17 +74,17 @@
         <div class="async-loaded" style="display:none">
           <ul class="nav nav-tabs data-view" role="tablist">
             <li role="presentation" class="nav-item active">
-              <a class="nav-link" data-toggle="tab" href="#chartview" aria-controls="chartview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Chart tab" %}>{{ t.indicator.chart }}</a>
+              <a class="nav-link" data-toggle="tab" href="#chartview" aria-controls="chartview" role="tab" {% include autotrack.html preset="tab_data_chart" category="Tab change" action="Change data view" label="Change to Chart tab" %}>{{ t.indicator.chart }}</a>
             </li>
             <li role="presentation" class="nav-item">
-              <a class="nav-link" data-toggle="tab" href="#tableview" aria-controls="tableview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Table tab" %}>{{ t.indicator.table }}</a>
+              <a class="nav-link" data-toggle="tab" href="#tableview" aria-controls="tableview" role="tab" {% include autotrack.html preset="tab_data_table" category="Tab change" action="Change data view" label="Change to Table tab" %}>{{ t.indicator.table }}</a>
             </li>
             <li role="presentation" class="nav-item map" style="display:none">
-              <a class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to Map tab" %}>{{ t.indicator.map }}</a>
+              <a class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab" {% include autotrack.html preset="tab_data_map" category="Tab change" action="Change data view" label="Change to Map tab" %}>{{ t.indicator.map }}</a>
             </li>
             {%- if meta.embedded_map_html -%}
             <li role="presentation" class="nav-item embedded-map">
-              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_chart" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ t.indicator.map }}</a>
+              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ t.indicator.map }}</a>
             </li>
             {%- endif -%}
           </ul>
@@ -114,13 +114,13 @@
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
           <li role="presentation" class="nav-item active">
-            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab">{{ site.non_global_metadata | default: 'indicator.national_metadata' | t }}</a>
+            <a class="nav-link" data-toggle="tab" href="#metadata" aria-controls="metadata" role="tab" {% include autotrack.html preset="tab_meta_national" category="Tab change" action="Change metadata view" label="Change to National Metadata tab" %}>{{ site.non_global_metadata | default: 'indicator.national_metadata' | t }}</a>
           </li>
           <li role="presentation" class="nav-item">
-            <a class="nav-link" data-toggle="tab" href="#globalmetadata" aria-controls="globalmetadata" role="tab">{{ t.indicator.global_metadata }}</a>
+            <a class="nav-link" data-toggle="tab" href="#globalmetadata" aria-controls="globalmetadata" role="tab" {% include autotrack.html preset="tab_meta_global" category="Tab change" action="Change metadata view" label="Change to Global Metadata tab" %}>{{ t.indicator.global_metadata }}</a>
           </li>
           <li role="presentation" class="nav-item">
-            <a class="nav-link" data-toggle="tab" href="#sources" aria-controls="sources" role="tab">{{ t.indicator.sources }}</a>
+            <a class="nav-link" data-toggle="tab" href="#sources" aria-controls="sources" role="tab" {% include autotrack.html preset="tab_meta_sources" category="Tab change" action="Change metadata view" label="Change to Sources tab" %}>{{ t.indicator.sources }}</a>
           </li>
           {% if site.environment == 'staging' %}
           <li role="presentation" class="nav-item">

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -1,6 +1,7 @@
 ---
 # Don't delete this line.
 ---
+{%- include assets/js/autotrack-element.js -%}
 {%- include assets/js/lib/d3-simple-slider.min.js -%}
 {%- include assets/js/plugins/jquery.sdgMap.js -%}
 {%- include assets/js/chartjs/rescaler.js -%}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,21 @@
+<h1>Analytics</h1>
+
+Out of the box, Open SDG sends information to Google Analytics for certain events:
+
+* User changes data tabs (Table, Chart, etc.)
+* User changes metadata tabs (National, Global, etc.)
+* User changes the contrast setting
+* User downloads a CSV file
+
+## Customising the Google Analytics parameters
+
+If you would like to change the Google Analytics parameters (category/action/label) that Open SDG sends, you can create a data file at this path in your site repository: `data/autotrack.yml`
+
+The contents of this YAML file can override any tracked event, according to their "preset" value. For example:
+
+```
+preset_name:
+  category: My category name
+  action: My action name
+  label: My label name
+```

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -2,10 +2,22 @@
 
 Out of the box, Open SDG sends information to Google Analytics for certain events:
 
+* All page loads
 * User changes data tabs (Table, Chart, etc.)
 * User changes metadata tabs (National, Global, etc.)
 * User changes the contrast setting
 * User downloads a CSV file
+
+## Google Analytics ID
+
+In order to turn on the analytics functionality, you must set the [Google Analytics ID](https://support.google.com/analytics/answer/1008080?hl=en) in the site repository's `_config_prod.yml` like so:
+
+```
+analytics:
+  ga_prod: 'paste ID here'
+```
+
+It is recommend to only put this in `_config_prod.yml`, and not in `_config.yml`, because you would not want to confuse your metrics by mixing staging and production together.
 
 ## Customising the Google Analytics parameters
 
@@ -14,8 +26,38 @@ If you would like to change the Google Analytics parameters (category/action/lab
 The contents of this YAML file can override any tracked event, according to their "preset" value. For example:
 
 ```
-preset_name:
-  category: My category name
-  action: My action name
-  label: My label name
+my_preset:
+  category: My category
+  action: My action
+  label: My label
+```
+
+## Tracking new click events
+
+You can track a new click event using either HTML or Javascript.
+
+### Tracking a click event with HTML
+
+Here is an example of tracking a new click event using HTML, in a Jekyll page or layout:
+
+```
+Below is a call-to-action that we would like to track.
+
+<a href="/my-url" {% include autotrack.html preset="my_preset" category="My category" action="My action" %}>
+  My link
+</a>
+
+```
+
+### Tracking a click event with Javascript
+
+Here is an example of tracking a new click event using Javascript:
+
+```
+<a href="/my-url" id="my-link">My link</a>
+
+<script>
+var attributes = opensdg.autotrack('my_preset', 'My category', 'My action');
+$('#my-link').attr(attributes);
+</script>
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ pages:
         - Customisation: customisation.md
         - Translation: translation.md
         - Maps: maps.md
+        - Analytics: analytics.md
     - Automation:
         - CircleCI: automation/circle-ci.md
         - TravisCI: automation/travis-ci.md

--- a/tests/data/autotrack.yml
+++ b/tests/data/autotrack.yml
@@ -1,0 +1,4 @@
+download_data_current:
+  category: My custom category
+  action: My custom action
+  label: My custom label

--- a/tests/features/Analytics.feature
+++ b/tests/features/Analytics.feature
@@ -1,0 +1,21 @@
+Feature: Analytics
+
+  As a site admin
+  I need anonymous statistics on user activity
+  So that I can improve the site
+
+  Scenario: Google Analytics tags track events on the indicator data tabs
+    Given I am on "/1-1-1"
+    And I should see "Change data view"
+    And I should see "Change to Chart tab"
+
+  Scenario: Google Analytics tags track events on the contrast switcher
+    Given I am on "/"
+    Then I should see "Accessibility"
+    And I should see "Change contrast setting"
+
+  Scenario: Google Analytics data can be customised by preset
+    Given I am on "/1-1-1"
+    Then I should see "My custom category"
+    And I should see "My custom action"
+    And I should see "My custom label"


### PR DESCRIPTION
Fixes #125 

## Breaking changes

* If `assets/js/sdg.js` is being overridden, this update will cause javascript errors. To resolve, either remove the `assets/js/sdg.js` file from your site repository, or incorporate the latest changes to that file.

## Description

This uses Google's autotrack.js library, and some Jekyll includes, to allow for out-of-the-box event tracking, plus optional overriding of the category/action/label of the events. It includes some brief documentation.

This "wires up" the following events:
* User changes data tabs (Table, Chart, etc.)
* User changes metadata tabs (National, Global, etc.)
* User changes the contrast setting
* User downloads a CSV file

This hopefully captures everything decided on in #125 

## Files affected

* _includes/assets/js/accessibility.js
* _includes/assets/js/googleAnalytics.js
* _includes/assets/js/indicatorView.js
* _includes/scripts.html
* _layouts/indicator.html
* assets/js/sdg.js

## Documentation added

Yes.

## Tests added

Yes.