### PR TITLE
Add facebook option to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,9 @@
             {% if site.twitter %}
             <li><a class="twitter-follow-button" href="https://twitter.com/{{ site.twitter }}" data-show-count="false">@{{ site.twitter }}</a></li>
             {% endif %}
+            {% if site.facebook %}
+            <li><a href="https://facebook.com/{{ site.facebook }}" target="_blank">@{{ site.facebook }}</a></li>
+            {% endif %}
             <li><a href="{{ site.baseurl }}{% link _pages/faq.md %}">{{ t.menu.faq }}</a></li>
             <li><a href="{{ site.baseurl }}{% link _pages/cookies.md %}">{{ t.menu.cookies }}</a></li>
           </ul>

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -101,3 +101,7 @@ defaults:
 # Apply any custom CSS.
 custom_css:
   - /assets/css/custom.css
+
+# Social media accounts.
+twitter: 'MyTwitterAccount'
+facebook: 'MyFacebookAccount'

--- a/tests/features/Footer.feature
+++ b/tests/features/Footer.feature
@@ -1,0 +1,13 @@
+Feature: Footer
+
+  As a site viewer
+  I need to see useful information in the footer
+  In case I missed what I was looking for on the rest of the page
+
+  Scenario: A link to a Twitter account is in the footer
+    Given I am on the homepage
+    Then I should see "MyTwitterAccount"
+
+  Scenario: A link to a Facebook account is in the footer
+    Given I am on the homepage
+    Then I should see "MyFacebookAccount"


### PR DESCRIPTION
Fixes #151 

## Breaking changes:

None.

## Changes needed in other projects

After merging, the [open-sdg-site-starter config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml) should have this added to it under the `twitter` line:

```
# To add a Facebook link to the footer, uncomment and change this line:
#facebook: MyFacebookAccount
```

## Files affected:

* _includes/footer.html

## Documentation added:

We don't have documentation of individual _config.yml settings (though we probably should). For now the [open-sdg-site-starter config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml) serves as the documentation for all of these settings.

## Tests added:

Yes.
