### PR TITLE
[Accessibility] Disaggregation accordions: Move ARIA expanded status to button

### DIFF
--- a/_includes/components/fields-template.html
+++ b/_includes/components/fields-template.html
@@ -1,7 +1,7 @@
 <script type="text/template" id="item_template">
   <% _.each(series, function(seriesItem) { %>
-    <div class="variable-selector<% if(allowedFields.indexOf(seriesItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=seriesItem.field%>" aria-expanded='false'>
-      <button class='accessBtn' tabindex='0'><h5><%=translations.t(seriesItem.field)%><i class="fa fa-chevron-down"></i></h5></button>
+    <div class="variable-selector<% if(allowedFields.indexOf(seriesItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=seriesItem.field%>">
+      <button class='accessBtn' tabindex='0' aria-expanded='false'><h5><%=translations.t(seriesItem.field)%><i class="fa fa-chevron-down"></i></h5></button>
       <div class="bar">
         <div class="selected"></div>
       </div>


### PR DESCRIPTION
Moved `aria-expanded='false'` label from `<div>` to `<button>` to fix an issue with the screen reader not announcing the expanded/collapsed status