### PR TITLE
Support zero values

### DIFF
--- a/_includes/assets/js/chartjs/rescaler.js
+++ b/_includes/assets/js/chartjs/rescaler.js
@@ -25,8 +25,8 @@ Chart.plugins.register({
 
     var ranges = _.chain(datasets).pluck('allData').map(function (data) {
       return {
-        min: _.findIndex(data, _.identity),
-        max: _.findLastIndex(data, _.identity)
+        min: _.findIndex(data, function(val) { return val !== null }),
+        max: _.findLastIndex(data, function(val) { return val !== null })
       };
     }).value();
 

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -636,7 +636,7 @@ var indicatorView = function (model, options) {
           var isUnits = (heading.toLowerCase() == 'units');
           var cell_prefix = (isYear) ? '<th scope="row"' : '<td';
           var cell_suffix = (isYear) ? '</th>' : '</td>';
-          row_html += cell_prefix + (isYear || isUnits ? '' : ' class="table-value"') + '>' + (data[index] ? data[index] : '-') + cell_suffix;
+          row_html += cell_prefix + (isYear || isUnits ? '' : ' class="table-value"') + '>' + (data[index] !== null ? data[index] : '-') + cell_suffix;
         });
         row_html += '</tr>';
         currentTable.find('tbody').append(row_html);

--- a/tests/features/Analytics.feature
+++ b/tests/features/Analytics.feature
@@ -16,6 +16,7 @@ Feature: Analytics
 
   Scenario: Google Analytics data can be customised by preset
     Given I am on "/1-1-1"
+    And I wait 1 second
     Then I should see "My custom category"
     And I should see "My custom action"
     And I should see "My custom label"

--- a/tests/features/Headline.feature
+++ b/tests/features/Headline.feature
@@ -6,12 +6,15 @@ Feature: Headlines
 
   Scenario: Indicators with headlines (series without disaggregation) show visualisation
     Given I am on "/1-2-1"
+    And I wait 1 second
     Then I should see 1 "chart legend item" element
 
   Scenario: Indicators without headlines, but single-disaggregation rows, show visualisation
     Given I am on "/1-3-1"
+    And I wait 1 second
     Then I should see 1 "chart legend item" element
 
   Scenario: Indicators without headlines, but double-disaggregation rows, show visualisation
     Given I am on "/1-4-1"
+    And I wait 1 second
     Then I should see 1 "chart legend item" element


### PR DESCRIPTION
Fixes #175 

This allows "0" to appear in both charts and tables. Previously there were some "truthy" checks that were unintentionally filtering out zeroes. This change looks specifically for "null" instead, which lets the zeroes get through.

Minor enough bug fix, no docs or tests needed.