### PR TITLE
A more precise check for data (disaggregation) translations.

### DIFF
--- a/_includes/multilingual-js-base.html
+++ b/_includes/multilingual-js-base.html
@@ -10,12 +10,12 @@ var translations = {
 
     // The majority of uses of this function are to translate disaggregation
     // data. To spare data providers of needing to enter "data." in front of
-    // their disaggregation data, we do it for them here.
-    var originalKey = key;
-    if (!key.includes('.') && this.data) {
-      key = 'data.' + key.toLowerCase();
+    // their disaggregation data, we specifically look for that here.
+    if (typeof this.data === 'object' && this.data[key]) {
+      return this.data[key];
     }
 
+    var originalKey = key;
     var drilled = this;
     var levelsDrilled = 0;
     var levels = key.split('.');

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -111,10 +111,7 @@ Similarly, instead of a values like `Female`, you could use `data.female` to cor
 
 > NOTE: There is a shortcut available here. Because data disaggregations/columns
 > will almost always refer to the `data` group, you can actually leave the `data.`
-> off. Additionally, the capitalization does not matter. So for example, the
-> columns/values `Sex` and `Female` would work fine, assuming that `data.sex`
-> and `data.female` were valid translation keys. Behind the scenes, `Sex` gets
-> converted to `data.sex` and `Female` gets converted to `data.female`, etc.
+> off.
 
 ## Available translation-related variables
 

--- a/tests/data/translations/en/data.yml
+++ b/tests/data/translations/en/data.yml
@@ -1,2 +1,2 @@
-a: A
-group: Group
+A: A
+Group: Group

--- a/tests/data/translations/es/data.yml
+++ b/tests/data/translations/es/data.yml
@@ -1,2 +1,2 @@
-a: A-translated
-group: Group-translated
+A: A-translated
+Group: Group-translated


### PR DESCRIPTION
## Breaking changes

If any countries were relying on a behind-the-scenes lower-case conversion of disaggregations before being translated, those disaggregations would no longer get translated. No countries are actually doing this, and it fails gracefully and obviously, so I would not call this a "breaking change".

## Description

Right now there is a convenience check, when displaying disaggregation labels, which looks in a translation group called "data" for a lower-case version of the whatever the label is. Documentation exists [here](https://open-sdg.readthedocs.io/en/latest/translation/#translating-data-disaggregations-and-columns).

The problem is the lower-case part. A common use-case is for a country to copy/paste _exactly_ what is in their data (CSV files) into the data.yml as the translation keys. But the lower-case conversion prevents this from working, unless the values in the CSV files happen to be lower-case already.

Let's remove the lower-case aspect of this. This "feature" is not being used by any countries, and turns out to be contrary to the way countries actually want to use this platform.

## Tests added

There are existing tests that will confirm this still works.

## Documentation added

The part of the documentation mentioning the lower-case part is being removed as part of this PR.