### PR TITLE
Expect dash-delimited translation keys for indicators/targets

### DIFF
--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -30,4 +30,4 @@
 @deprecated: The following variable will be removed for 1.0.0.
 {% endcomment %}
 {% assign indicator_id_dashes = meta.indicator | replace: ".", "-" %}
-{% assign translated_indicator = t.global_indicators[indicator_id_dashes] %}
+{% assign translated_indicator = t.global_indicators[indicator_id_dashes] | default: t.global_indicators[indicator_id] %}

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -29,4 +29,5 @@
 {% comment %}
 @deprecated: The following variable will be removed for 1.0.0.
 {% endcomment %}
-{%- assign translated_indicator = t.global_indicators[meta.indicator] -%}
+{% assign indicator_id_dashes = meta.indicator | replace: ".", "-" %}
+{% assign translated_indicator = t.global_indicators[indicator_id_dashes] %}

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -36,7 +36,8 @@
   {% assign goal_indicators = site.data.meta | where: 'sdg_goal', goal_number | sort: 'indicator_sort_order' | group_by: 'target_id' %}
   {% for group in goal_indicators %}
     {% assign target_id = group.name %}
-    {% assign translated_target = t.global_targets[target_id] %}
+    {% assign target_id_dashes = target_id | replace: ".", "-" %}
+    {% assign translated_target = t.global_targets[target_id_dashes] %}
     <div class="indicator-cards target col-md-6">
       <span>
         <label class="hidden-md hidden-lg">{{ t.general.target }}</label>

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -37,7 +37,7 @@
   {% for group in goal_indicators %}
     {% assign target_id = group.name %}
     {% assign target_id_dashes = target_id | replace: ".", "-" %}
-    {% assign translated_target = t.global_targets[target_id_dashes] %}
+    {% assign translated_target = t.global_targets[target_id_dashes] | default: t.global_targets[target_id] %}
     <div class="indicator-cards target col-md-6">
       <span>
         <label class="hidden-md hidden-lg">{{ t.general.target }}</label>


### PR DESCRIPTION
## Breaking changes

None (backwards-compatibility is included)

However note that after adopting the translation updates in [this PR](https://github.com/open-sdg/sdg-translations/pull/93) a country would need to update their version of jekyll-open-sdg-plugins to 0.0.12, [like so](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/Gemfile#L8).

## Description

This is to support a potential change in SDG Translations, from dot-delimited translation keys to dash-delimited translation keys. See [here](https://github.com/open-sdg/sdg-translations/issues/92) for details.

The main use-case for this change is to allow countries to add translation keys for global indicators in their metadata. For example, they can put the following in an indicator's metadata file:

```
graph_title: global_indicators.1-1-1.title
```

Currently, with the dot-delimited keys, the above is impossible, because it would have to be:

```
graph_title: global_indicators.1.1.1.title
```

All of the dots break the parsing of the translation key.

## Tests added

I believe no new tests are needed.

## Documentation added

This is more of a bugfix, so existing documentation is fine.