### PR TITLE
Accessibility: Enable support for buttons on mobile top level menu

### DIFF
--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -19,7 +19,7 @@ $(function() {
 
     // hide everything:
     $('.menu-target').hide();
-    $('.menu-target').attr("aria-expanded", "false");
+    $(".top-level li button[data-target='" + target + "']").attr("aria-expanded", "false");
 
     if(target === 'search') {
       $(this).toggleClass('open');

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -19,6 +19,7 @@ $(function() {
 
     // hide everything:
     $('.menu-target').hide();
+    $('.menu-target').attr("aria-expanded", "false");
 
     if(target === 'search') {
       $(this).toggleClass('open');
@@ -36,6 +37,7 @@ $(function() {
 
     if(!wasVisible) {
       targetEl.show();
+      targetEl.attr("aria-expanded", "false");
       $(this).parent().addClass('active');
     }
   });

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -8,7 +8,7 @@ $(function() {
     $('.top-level span').removeClass('open');
   };  
 
-  $('.top-level span').click(function() {
+  $('.top-level span, .top-level button').click(function() {
     var target = $(this).data('target');
 
     $('.top-level li').removeClass('active');

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -37,7 +37,7 @@ $(function() {
 
     if(!wasVisible) {
       targetEl.show();
-      targetEl.attr("aria-expanded", "false");
+      targetEl.attr("aria-expanded", "true");
       $(this).parent().addClass('active');
     }
   });

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -1,6 +1,6 @@
 $(function() {
 
-  var topLevelSearchLink = $('.top-level span:eq(1)');
+  var topLevelSearchLink = $('.top-level span:eq(1), .top-level button:eq(1)');
 
   var resetForSmallerViewport = function() {
     topLevelSearchLink.text('Search');

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -37,7 +37,7 @@ $(function() {
 
     if(!wasVisible) {
       targetEl.show();
-      targetEl.attr("aria-expanded", "true");
+      $(".top-level li button[data-target='" + target + "']").attr("aria-expanded", "true");
       $(this).parent().addClass('active');
     }
   });

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -392,6 +392,7 @@ header {
 		padding: 15px;
 		border: 0;
 		text-transform: uppercase;
+		background-color: inherit;
 	}
       }
     }

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -385,6 +385,14 @@ header {
           display: block;
           padding: 15px;
         }
+	      
+      	button{
+		color: #E5E6E7;
+		display: block;
+		padding: 15px;
+		border: 0;
+		text-transform: uppercase;
+	}
       }
     }
 

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -393,6 +393,8 @@ header {
 		border: 0;
 		text-transform: uppercase;
 		background-color: inherit;
+		text-align: left;
+	    	width: 100%;
 	}
       }
     }


### PR DESCRIPTION
The current default interface on the mobile top level menu (Menu, Search) is a series of `<span>` elements. To improve accessibility for screen readers, the `menu.js` script, which deals with expanding and collapsing the menu and search bar on mobile, needs to support replacing `<span>` elements to `<button>`s. 

This pull request is done in conjunction with a request on SDG UK's `sdg-indicators` where the `span`s are replaced with `button`s to improve accessibility. [Test branch here](https://sdg.mango-solutions.com/a11y-mobile-menu-to-button/).