### PR TITLE
Catch another spot where zeroes are getting clobbered: the headline

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -210,7 +210,7 @@ var indicatorModel = function (options) {
         return that.selectedUnit ? i.Units : i.Year;
       })
       .map(function (d) {
-        return _.pick(d, _.identity);
+        return _.pick(d, function(val) { return val !== null });
       })
       .value();
   };

--- a/_includes/multilingual-js-base.html
+++ b/_includes/multilingual-js-base.html
@@ -11,7 +11,7 @@ var translations = {
     // The majority of uses of this function are to translate disaggregation
     // data. To spare data providers of needing to enter "data." in front of
     // their disaggregation data, we specifically look for that here.
-    if (typeof this.data === 'object' && this.data[key]) {
+    if (typeof this.data === 'object' && this.data !== null && this.data[key]) {
       return this.data[key];
     }
 


### PR DESCRIPTION
We recently added code to allow zeroes in data to survive into the charts/tables, but we forgot this one spot: the headline data.