### PR TITLE
Remove data rounding and provide an easier way to add custom rounding

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -15,12 +15,6 @@ var indicatorModel = function (options) {
   this.onSelectionUpdate = new event(this);
   this.onNoHeadlineData = new event(this);
 
-  // data rounding:
-  this.roundingFunc = options.roundingFunc || function(value) {
-    var to = 3, mult = Math.pow(10, to - Math.floor(Math.log(Math.abs(value)) / Math.LN10) - 1);
-    return Math.round(value * mult) / mult;
-  };
-
   // json conversion:
   var convertJsonFormat = function(data) {
     var keys = _.keys(data);
@@ -157,7 +151,11 @@ var indicatorModel = function (options) {
 
       // only apply a rounding function for non-zero values:
       if(item.Value != 0) {
-        item.Value = that.roundingFunc(item.Value);
+        // For rounding, use a function that can be set on the global opensdg
+        // object, for easier control: opensdg.dataRounding()
+        if (typeof opensdg.dataRounding === 'function') {
+          item.Value = opensdg.dataRounding(item.Value);
+        }
       }
 
       // remove any undefined/null values:

--- a/_includes/javascript-variables.html
+++ b/_includes/javascript-variables.html
@@ -12,6 +12,13 @@ var opensdg = {
     // Alterations go here.
     return config;
   },
+
+  // A hook which can be replaced to alter whether/how the values that are
+  // displayed on indicator tables/graphs get rounded.
+  dataRounding: function(value) {
+    // Alterations go here.
+    return value;
+  },
 };
 
 // For backwards compatibility, some of these might need to be global.

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -17,6 +17,11 @@
 <script src="https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/autotrack/2.4.1/autotrack.js"></script>
 <script src='{{ site.baseurl }}/assets/js/sdg.js?v={{ cache_bust }}'></script>
+{%- if site.custom_js -%}
+  {%- for custom_js_file in site.custom_js -%}
+    <script src="{{ site.baseurl }}{{ custom_js_file }}?v={{ cache_bust }}"></script>
+  {%- endfor -%}
+{%- endif -%}
 <script>
 $(function() {
     if($('#indicatorData').length) {


### PR DESCRIPTION
This change removes the data rounding function, which has been causing issues recently. It also adds an easier way for countries to add custom rounding, without needing to override any files. Finally it adds a way to add custom javascript, through the site config, similar to the `custom_css` config option.

Fixes #199 