### PR TITLE
Correct the initially-selected unit when headline doesn't use first unit

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -444,6 +444,14 @@ var indicatorModel = function (options) {
     // get the headline data:
     var headline = this.getHeadline();
 
+    // Catch the case where this is the initial display, there is a default
+    // selected unit (the first one), there is a headline, and this headline
+    // uses another unit.
+    if (options.initial && headline.length && this.selectedUnit && this.selectedUnit != headline[0]['Units']) {
+      // In this scenario we need to correct the selected unit here.
+      this.selectedUnit = headline[0]['Units'];
+    }
+
     // all units for headline data:
     if(headline.length) {
       headlineTable = {
@@ -546,7 +554,8 @@ var indicatorModel = function (options) {
         }
 
         this.onUnitsComplete.notify({
-          units: this.units
+          units: this.units,
+          selectedUnit: this.selectedUnit
         });
       }
 

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -259,10 +259,12 @@ var indicatorView = function (model, options) {
 
   this.initialiseUnits = function(args) {
     var template = _.template($('#units_template').html()),
-        units = args.units || [];
+        units = args.units || [],
+        selectedUnit = args.selectedUnit || null;
 
     $('#units').html(template({
-      units: units
+      units: units,
+      selectedUnit: selectedUnit
     }));
 
     if(!units.length) {

--- a/_includes/components/units-template.html
+++ b/_includes/components/units-template.html
@@ -2,7 +2,8 @@
   <% if(units.length) { %>
     <h5>{{ t.indicator.units_type }}</h5>
     <% _.each(units, function(unitsItem, index) { %>
-      <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <% if(!index) { %>checked="checked"<% } %> /> <%=translations.t(unitsItem)%></label>
+      <% var checked = (selectedUnit) ? (selectedUnit==unitsItem) : (index==0); %>
+      <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <%=checked ? 'checked' : ''%> /> <%=translations.t(unitsItem)%></label>
     <% }); %>
   <% } %>
 </script>


### PR DESCRIPTION
Fixes #213 