### PR TITLE
Accessibility: Set Goal page title

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,11 +17,11 @@
         ================================================== -->
 
         {% capture indicator_page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ site.sdg_goal }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ page.sdg_goal }}
         {% endcapture %}
 
         {% capture goal_page_title %}
-        {{ t.general.goal }} {{ site.sdg_goal }} - {{ site.short }}
+        {{ t.general.goal }} {{ page.sdg_goal }} - {{ page.short }}
         {% endcapture %}
 
         <title>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,11 +17,11 @@
         ================================================== -->
 
         {% capture indicator_page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ site.sdg_goal }} - {{ site.short }}
         {% endcapture %}
 
         {% capture goal_page_title %}
-        {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
+        {{ t.general.goal }} {{ site.sdg_goal }} - {{ site.short }}
         {% endcapture %}
 
         <title>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,10 +15,25 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Title and meta description
         ================================================== -->
-        {% capture page_title %}
+
+        {% capture indicator_page_title %}
         {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
         {% endcapture %}
-        <title>{% if page.indicator %}{{ page_title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+
+        {% capture goal_page_title %}
+        {{ t.general.goal }} {{ goal_number }} - {{ goal.short }}
+        {% endcapture %}
+
+        <title>
+          {% if page.indicator %}
+            {{ indicator_page_title | escape }}
+          {% elsif page.sdg_goal %}
+            {{ goal_page_title | escape }}
+          {% else %}
+            {{ site.title | escape }}
+          {% endif %}
+        </title>
+        
         <meta name="description" content="">
         <meta property="og:description" content="">
         {% if site.environment == 'staging' %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
         ================================================== -->
 
         {% capture indicator_page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ page.sdg_goal }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} 
         {% endcapture %}
 
         {% capture goal_page_title %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
         ================================================== -->
 
         {% capture indicator_page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ site.sdg_goal }} - {{ site.short }}
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ site.sdg_goal }}
         {% endcapture %}
 
         {% capture goal_page_title %}


### PR DESCRIPTION
This change sets the title of the Goal page to `Goal <goal number> - <goal description>`.

Test here: https://sdg.mango-solutions.com/test-goal-tab