### PR TITLE
Refactor/cleanup of footerFields for charts/tables

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -177,12 +177,13 @@ var indicatorModel = function (options) {
       spanGaps: false
     };
 
-    that.footerFields = {
-      'Source': that.dataSource,
-      'Geographical Area': that.geographicalArea,
-      'Unit of Measurement': that.measurementUnit,
-      'Footnote': that.footnote,
-    };
+    that.footerFields = {};
+    that.footerFields[translations.indicator.source] = that.dataSource;
+    that.footerFields[translations.indicator.geographical_area] = that.geographicalArea;
+    that.footerFields[translations.indicator.unit_of_measurement] = that.measurementUnit;
+    that.footerFields[translations.indicator.footnote] = that.footnote;
+    // Filter out the empty values.
+    that.footerFields = _.pick(that.footerFields, _.identity);
   }());
 
   var headlineColor = '777777';

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -440,35 +440,17 @@ var indicatorView = function (model, options) {
           });
         }
 
-        // TODO Merge this with the that.footerFields object used by table
         var graphFooterItems = [];
-        if (that._model.dataSource) {
-          var sourceRows = getLinesFromText(translations.indicator.source + ': ' + that._model.dataSource);
-          graphFooterItems = graphFooterItems.concat(sourceRows);
-
-          if(sourceRows.length > 1) {
-            that._chartInstance.resize(parseInt($canvas.css('width')), parseInt($canvas.css('height')) + textRowHeight * sourceRows.length);
+        _.each(that._model.footerFields, function(value, key) {
+          // For each footer item, we have to manually do any line
+          // wrapping, because this is canvas, not HTML.
+          var rows = getLinesFromText(key + ': ' + value);
+          graphFooterItems = graphFooterItems.concat(rows);
+          if (rows.length > 1) {
+            that._chartInstance.resize(parseInt($canvas.css('width')), parseInt($canvas.css('height')) + textRowHeight * rows.length);
             that._chartInstance.resize();
           }
-        }
-        if (that._model.geographicalArea) {
-          graphFooterItems.push(translations.indicator.geographical_area + ': ' + that._model.geographicalArea);
-        }
-        if (that._model.measurementUnit) {
-          graphFooterItems.push(translations.indicator.unit_of_measurement + ': ' + that._model.measurementUnit);
-        }
-
-        if(that._model.footnote) {
-          var footnoteRows = getLinesFromText('Footnote: ' + that._model.footnote);
-          graphFooterItems = graphFooterItems.concat(footnoteRows);
-
-          if(footnoteRows.length > 1) {
-            //that._chartInstance.options.layout.padding.bottom += textRowHeight * footnoteRows.length;
-            that._chartInstance.resize(parseInt($canvas.css('width')), parseInt($canvas.css('height')) + textRowHeight * footnoteRows.length);
-            that._chartInstance.resize();
-          }
-        }
-
+        });
         putTextOutputs(graphFooterItems, 0);
       }
     });
@@ -683,7 +665,7 @@ var indicatorView = function (model, options) {
     });
 
     _.each(footerFields, function(val, key) {
-      if(val) footdiv.append($('<p />').text(key + ': ' + val));
+      footdiv.append($('<p />').text(key + ': ' + val));
     });
 
     $(el).append(footdiv);


### PR DESCRIPTION
This makes the treatment of the footer fields more consistent between the table and chart, by having both use the same object. It also takes care of a TODO.

Fixes #238 