### PR TITLE
Make sure the target name is also white in high-contrast

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1802,7 +1802,7 @@ body.contrast-high {
       }
     }
     .indicator-cards {
-      a {
+      a, &.target {
         color: white !important;
       }
       span.status, .tags li{


### PR DESCRIPTION
Fixes #240 