### PR TITLE
Change chart attributes to HTML

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -317,6 +317,8 @@ var indicatorView = function (model, options) {
 
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
+  
+  
 
   this.createPlot = function (chartInfo) {
 
@@ -375,11 +377,7 @@ var indicatorView = function (model, options) {
           display: false
         },
         title: {
-          fontSize: 18,
-          fontStyle: 'normal',
-          display: this._model.chartTitle,
-          text: this._model.chartTitle,
-          padding: 20
+          display: false
         },
         plugins: {
           scaler: {}
@@ -402,77 +400,14 @@ var indicatorView = function (model, options) {
         ctx.textAlign = 'left';
         ctx.textBaseline = 'middle';
         ctx.fillStyle = '#6e6e6e';
-
-        var getLinesFromText = function(text) {
-          var width = parseInt($canvas.css('width')), //width(),
-          lines = [],
-          line = '',
-          lineTest = '',
-          words = text.split(' ');
-
-          for (var i = 0, len = words.length; i < len; i++) {
-            lineTest = line + words[i] + ' ';
-
-            // Check total width of line or last word
-            if (ctx.measureText(lineTest).width > width) {
-              // Record and reset the current line
-              lines.push(line);
-              line = words[i] + ' ';
-            } else {
-              line = lineTest;
-            }
-          }
-
-          // catch left overs:
-          if (line.length > 0) {
-            lines.push(line.trim());
-          }
-
-          return lines;
-        };
-
-        function putTextOutputs(textOutputs, x) {
-          var y = $canvas.height() - 10 - ((textOutputs.length - 1) * textRowHeight);
-
-          _.each(textOutputs, function(textOutput) {
-            ctx.fillText(textOutput, x, y);
-            y += textRowHeight;
-          });
-        }
-
-        // TODO Merge this with the that.footerFields object used by table
-        var graphFooterItems = [];
-        if (that._model.dataSource) {
-          var sourceRows = getLinesFromText(translations.indicator.source + ': ' + that._model.dataSource);
-          graphFooterItems = graphFooterItems.concat(sourceRows);
-
-          if(sourceRows.length > 1) {
-            that._chartInstance.resize(parseInt($canvas.css('width')), parseInt($canvas.css('height')) + textRowHeight * sourceRows.length);
-            that._chartInstance.resize();
-          }
-        }
-        if (that._model.geographicalArea) {
-          graphFooterItems.push(translations.indicator.geographical_area + ': ' + that._model.geographicalArea);
-        }
-        if (that._model.measurementUnit) {
-          graphFooterItems.push(translations.indicator.unit_of_measurement + ': ' + that._model.measurementUnit);
-        }
-
-        if(that._model.footnote) {
-          var footnoteRows = getLinesFromText('Footnote: ' + that._model.footnote);
-          graphFooterItems = graphFooterItems.concat(footnoteRows);
-
-          if(footnoteRows.length > 1) {
-            //that._chartInstance.options.layout.padding.bottom += textRowHeight * footnoteRows.length;
-            that._chartInstance.resize(parseInt($canvas.css('width')), parseInt($canvas.css('height')) + textRowHeight * footnoteRows.length);
-            that._chartInstance.resize();
-          }
-        }
-
-        putTextOutputs(graphFooterItems, 0);
       }
     });
 
+    this.createTableFooter('selectionChartFooter', chartInfo.footerFields, '#chart-canvas');
+    this.createDownloadImageButton(chartInfo.indicatorId, '#selectionsChart', '#chart-canvas');
+    this.createDownloadButton(chartInfo.selectionsTable, 'Chart', chartInfo.indicatorId, '#selectionsChart');
+    this.createSourceButton(chartInfo.shortIndicatorId, '#selectionsChart');
+    
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
 
@@ -552,15 +487,29 @@ var indicatorView = function (model, options) {
 
   this.createSelectionsTable = function(chartInfo) {
     this.createTable(chartInfo.selectionsTable, chartInfo.indicatorId, '#selectionsTable', true);
-    this.createTableFooter(chartInfo.footerFields, '#selectionsTable');
+    this.createTableFooter('selectionTableFooter', chartInfo.footerFields, '#selectionsTable');
     this.createDownloadButton(chartInfo.selectionsTable, 'Table', chartInfo.indicatorId, '#selectionsTable');
     this.createSourceButton(chartInfo.shortIndicatorId, '#selectionsTable');
-    // Chart buttons
-    $('#chartSelectionDownload').empty();
-    this.createDownloadButton(chartInfo.selectionsTable, 'Chart', chartInfo.indicatorId, '#chartSelectionDownload');
-    this.createSourceButton(chartInfo.shortIndicatorId, '#chartSelectionDownload');
   };
-
+  
+  this.createDownloadImageButton = function(indicatorId, el, eltoImage) {
+    $(el).append($('<a />').text('Download chart as image')
+    .attr({
+      'href': URL.createObjectURL(new Blob([this.toImage(eltoImage)], {
+          type: 'image/png'
+        })),
+      'download': indicatorId + '.png',
+      'title': 'Download chart as image',
+      'class': 'btn btn-primary btn-download',
+      'tabindex': 0
+    }));
+  }
+  
+  this.toImage = function(divID) {
+    //NEED TO CREATE WORKING FUNCTION
+   }
+  
+                 
   this.createDownloadButton = function(table, name, indicatorId, el) {
     if(window.Modernizr.blobconstructor) {
       var downloadKey = 'download_csv';
@@ -676,9 +625,9 @@ var indicatorView = function (model, options) {
     }
   };
 
-  this.createTableFooter = function(footerFields, el) {
+  this.createTableFooter = function(divid, footerFields, el) {
     var footdiv = $('<div />').attr({
-      'id': 'selectionTableFooter',
+      'id': divid,
       'class': 'table-footer-text'
     });
 
@@ -688,6 +637,7 @@ var indicatorView = function (model, options) {
 
     $(el).append(footdiv);
   };
+  
 
   this.sortFieldGroup = function(fieldGroupElement) {
     var sortLabels = function(a, b) {

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -317,8 +317,8 @@ var indicatorView = function (model, options) {
 
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
-  
-  
+
+
 
   this.createPlot = function (chartInfo) {
 
@@ -350,14 +350,6 @@ var indicatorView = function (model, options) {
               labelString: this._model.selectedUnit ? translations.t(this._model.selectedUnit) : this._model.measurementUnit
             }
           }]
-        },
-        layout: {
-          padding: {
-            top: 20,
-            // default of 85, but do a rough line count based on 150
-            // characters per line * 20 pixels per row
-            bottom: that._model.footnote ? (20 * (that._model.footnote.length / 150)) + 85 : 85
-          }
         },
         legendCallback: function(chart) {
             var text = ['<ul id="legend">'];
@@ -404,10 +396,36 @@ var indicatorView = function (model, options) {
     });
 
     this.createTableFooter('selectionChartFooter', chartInfo.footerFields, '#chart-canvas');
-    this.createDownloadImageButton(chartInfo.indicatorId, '#selectionsChart', '#chart-canvas');
     this.createDownloadButton(chartInfo.selectionsTable, 'Chart', chartInfo.indicatorId, '#selectionsChart');
     this.createSourceButton(chartInfo.shortIndicatorId, '#selectionsChart');
-    
+
+    $("#btnSave").click(function() {
+        html2canvas($("#chart-canvas"), {
+          onrendered: function(canvas) {
+            saveAs(canvas.toDataURL(), chartInfo.indicatorId+'.png');
+          }
+        });
+      });
+
+    function saveAs(uri, filename) {
+      var link = document.createElement('a');
+      if (typeof link.download === 'string') {
+        link.href = uri;
+        link.download = filename;
+
+        //Firefox requires the link to be in the body
+        document.body.appendChild(link);
+
+        //simulate click
+        link.click();
+
+        //remove the link when done
+        document.body.removeChild(link);
+        } else {
+        window.open(uri);
+        }
+        }
+
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
   };
 
@@ -491,25 +509,8 @@ var indicatorView = function (model, options) {
     this.createDownloadButton(chartInfo.selectionsTable, 'Table', chartInfo.indicatorId, '#selectionsTable');
     this.createSourceButton(chartInfo.shortIndicatorId, '#selectionsTable');
   };
-  
-  this.createDownloadImageButton = function(indicatorId, el, eltoImage) {
-    $(el).append($('<a />').text('Download chart as image')
-    .attr({
-      'href': URL.createObjectURL(new Blob([this.toImage(eltoImage)], {
-          type: 'image/png'
-        })),
-      'download': indicatorId + '.png',
-      'title': 'Download chart as image',
-      'class': 'btn btn-primary btn-download',
-      'tabindex': 0
-    }));
-  }
-  
-  this.toImage = function(divID) {
-    //NEED TO CREATE WORKING FUNCTION
-   }
-  
-                 
+
+
   this.createDownloadButton = function(table, name, indicatorId, el) {
     if(window.Modernizr.blobconstructor) {
       var downloadKey = 'download_csv';
@@ -637,7 +638,7 @@ var indicatorView = function (model, options) {
 
     $(el).append(footdiv);
   };
-  
+
 
   this.sortFieldGroup = function(fieldGroupElement) {
     var sortLabels = function(a, b) {

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -6,7 +6,7 @@
 
     {% assign graph_template = 'components/charts/' | append: include.graph_type | append: '.html' %}
 
-    <div id="selectionsChart" style="font-size: 12px; line-height: 10px">
+    <div id="selectionsChart" style="font-size: 12px; line-height: 1.5em">
       <div id="chart-canvas">
         <h3 class="chart-title">{{ meta.graph_title | t }}</h3>
         <div id="chart" class="plot-container">

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -6,14 +6,15 @@
 
     {% assign graph_template = 'components/charts/' | append: include.graph_type | append: '.html' %}
 
-    <div id="selectionsChart">
+    <div id="selectionsChart" style="font-size: 12px; line-height: 10px">
       <div id="chart-canvas">
         <h3 class="chart-title">{{ meta.graph_title | t }}</h3>
         <div id="chart" class="plot-container">
           {% include {{graph_template}} %}
-        </div> 
+        </div>
         <div id="plotLegend"></div>
       </div>
+      <button id="btnSave" title='Download chart as image' class='btn btn-primary btn-download'>Download chart as image</button>
     </div>
 
 {% endif %}

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -5,11 +5,15 @@
     </div>
 
     {% assign graph_template = 'components/charts/' | append: include.graph_type | append: '.html' %}
-    <div class="plot-container">
-        {% include {{graph_template}} %}
-    </div>
-    <div id="plotLegend"></div>
 
-    <div id="chartSelectionDownload"></div>
+    <div id="selectionsChart">
+      <div id="chart-canvas">
+        <h3 class="chart-title">{{ meta.graph_title | t }}</h3>
+        <div id="chart" class="plot-container">
+          {% include {{graph_template}} %}
+        </div> 
+        <div id="plotLegend"></div>
+      </div>
+    </div>
 
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,6 +16,8 @@
 <script src="https://bowercdn.net/c/leaflet.zoomhome-latest/dist/leaflet.zoomhome.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/autotrack/2.4.1/autotrack.js"></script>
+<script src="https://github.com/niklasvh/html2canvas/releases/download/0.4.1/html2canvas.js"></script>
+<script src="https://hongru.github.io/proj/canvas2image/canvas2image.js"></script>
 <script src='{{ site.baseurl }}/assets/js/sdg.js?v={{ cache_bust }}'></script>
 {%- if site.custom_js -%}
   {%- for custom_js_file in site.custom_js -%}
@@ -26,18 +28,14 @@
 $(function() {
     if($('#indicatorData').length) {
       var domData = $('#indicatorData').data();
-
       $('.async-loading').each(function(i, obj) {
           $(obj).append($('<img />').attr('src', $(obj).data('img')));
       });
-
       $.ajax({
         url: opensdg.remoteDataBaseUrl + '/comb/' + domData.id + '.json',
         success: function(res) {
-
           $('.async-loading').remove();
           $('.async-loaded').show();
-
           var model = new indicatorModel({
             data: res.data,
             edgesData: res.edges,
@@ -58,7 +56,7 @@ $(function() {
           view  = new indicatorView(model, {
             rootElement: '#indicatorData',
             legendElement: '#plotLegend',
-            maxChartHeight: 600,
+            maxChartHeight: 420,
             tableColumnDefs: [
               { maxCharCount: 25 }, // nowrap
               { maxCharCount: 35, width: 200 },
@@ -70,9 +68,6 @@ $(function() {
         }
       });
     }
-
     var switcher = new accessibilitySwitcher();
-
-
 });
 </script>

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1233,7 +1233,6 @@ h5 + .btn-download {
     position: absolute;
     top: 12px;
     right: 12px;
-
     a {
       background-color: white;
       border: none;
@@ -1241,7 +1240,6 @@ h5 + .btn-download {
       float: left;
     }
   }
-
   #zoom-in, #zoom-out {
     background-color: black;
     background-repeat: no-repeat;
@@ -1250,11 +1248,9 @@ h5 + .btn-download {
     width: 18px;
     height: 18px;
   }
-
   #zoom-in {
     background-position: 1px 1px;
   }
-
   #zoom-out {
     background-position: 1px -51px;
   }
@@ -1645,6 +1641,10 @@ footer {
       }
     }
   }
+}
+
+.chart-title {
+  text-align: center;
 }
 
 #accessibility-nav {

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1165,6 +1165,11 @@ h5 + .btn-download {
     }
   }
 
+  .chart-footer {
+    font-size: 12px;
+    line-height: 10px;
+  }
+
   /*
       MAP STUFF
   */


### PR DESCRIPTION
Fixes #73 

Can be see on this [test branch](https://sdg.mango-solutions.com/html-chart-attibutes/)

Not completely done - all chart attributes have been changed into HTML and a button has been created to allow the chart to be downloaded with all of the html attributes.

However still need to get the function for turning the canvas into an image working so that `URL.createObjectURL(new Blob(..))` can be used as the href for the element. 

The way it was being done [here](https://github.com/open-sdg/open-sdg/blob/49a60c233553237ec1c2b5209eaea18499746465/_includes/assets/js/indicatorView.js): 
`$(function() { $("#btn-save").click(function() {html2canvas($("#chart"), {onrendered: function(canvas) {Canvas2Image.saveAsPNG(canvas);}});});});`

uses a click function but was trying to get it so that it's in the same format as this.createDownloadButton and this.createSourceButton, which is proving quite difficult (maybe because I'm not quite sure what I'm doing)

I should also note that html2canvas and Canvas2Image aren't currently in scripts.html as I wasn't sure whether we would use those in this new function. 

Another problem you may notice is that the gap between the chart and the legend is too big - wasn't sure how to change the size of this.