### PR TITLE
Translate the var_hint_replacement variable

### DIFF
--- a/_includes/components/fields-template.html
+++ b/_includes/components/fields-template.html
@@ -18,7 +18,7 @@
       <% if(allowedFields.indexOf(seriesItem.field) == -1) { %>
         <div class="variable-hint">
           {%- capture var_hint_replacement -%}
-            {% raw %}<%= _.findWhere(edges, { To: seriesItem.field }).From %>{% endraw %}
+            {% raw %}<%= translations.t(_.findWhere(edges, { To: seriesItem.field }).From) %>{% endraw %}
           {%- endcapture -%}
           {{ t.indicator.variable_hint | replace_first: '%field', var_hint_replacement }}
         </div>


### PR DESCRIPTION
Fixes #245 

This problem can be observed [here](https://armstat.github.io/sdg-site-armenia/am/1-2-1/). See how the English "Sex" appears in the midst of the disaggregation widget's help text. This PR should fix it so that word is translated as well.