### PR TITLE
Require jekyll-open-sdg-plugins 0.0.13, and not jekyll-get-json

### DIFF
--- a/open-sdg.gemspec
+++ b/open-sdg.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |spec|
   spec.name          = "open-sdg"
   spec.summary       = "A platform for collecting and disseminating data for the Sustainable Development Goal global indicators"
   spec.description   = "A platform for collecting and disseminating data for the Sustainable Development Goal global indicators"
-  spec.version       = "0.5.2"
+  spec.version       = "0.8.0"
   spec.authors       = ["Open SDG team"]
   spec.email         = ["brockfanning@gmail.com"]
   spec.homepage      = "https://github.com/open-sdg/open-sdg"
@@ -11,6 +11,5 @@ Gem::Specification.new do |spec|
     f.match(%r!^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))!i)
   end
   spec.add_dependency "jekyll", "~> 3.0"
-  spec.add_dependency "jekyll-open-sdg-plugins", "~> 0.0.6"
-  spec.add_dependency "jekyll-get-json", "~> 0.0.1"
+  spec.add_dependency "jekyll-open-sdg-plugins", "~> 0.0.13"
 end


### PR DESCRIPTION
This is a preemptive PR for the next minor release, 0.8.0. With jekyll-open-sdg-plugins version 0.0.13, the jekyll-get-json plugin is no longer required. So this updates the gemspec file accordingly.

Breaking change: After this change, all sites will need to have jekyll-open-sdg-plugins 0.0.13 or later. So this should also be accompanied by a corresponding change in open-sdg-site-starter.