### PR TITLE
Force a specific unit if needed when there is no headline

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -77,6 +77,13 @@ var indicatorView = function (model, options) {
 
   this._model.onNoHeadlineData.attach(function(sender, args) {
     if (args && args.minimumFieldSelections && _.size(args.minimumFieldSelections)) {
+      // Force a unit if necessary.
+      if (args.forceUnit) {
+        $('#units input[type="radio"]')
+          .filter('[value="' + args.forceUnit + '"]')
+          .first()
+          .click();
+      }
       // If we have minimum field selections, impersonate a user and "click" on
       // each item.
       for (var fieldToSelect in args.minimumFieldSelections) {
@@ -84,13 +91,6 @@ var indicatorView = function (model, options) {
         $('#fields .variable-options input[type="checkbox"]')
           .filter('[data-field="' + fieldToSelect + '"]')
           .filter('[value="' + fieldValue + '"]')
-          .first()
-          .click();
-      }
-      // Force a unit if necessary.
-      if (args.forceUnit) {
-        $('#units input[type="radio"]')
-          .filter('[value="' + args.forceUnit + '"]')
           .first()
           .click();
       }

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -87,6 +87,13 @@ var indicatorView = function (model, options) {
           .first()
           .click();
       }
+      // Force a unit if necessary.
+      if (args.forceUnit) {
+        $('#units input[type="radio"]')
+          .filter('[value="' + args.forceUnit + '"]')
+          .first()
+          .click();
+      }
     }
     else {
       // Fallback behavior - just click on the first one, whatever it is.


### PR DESCRIPTION
This should fix #262 

This updates the automatic "minimum field" selection logic, for when an indicator has no headline. It should also look for a unit, and "force" this unit if necessary.