### PR TITLE
Use page.url instead of page.permalink to determine active menu item

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,7 +29,7 @@
       <ul class="nav navbar-nav menu-target contrast-switcher" id="menu">
         {%- if site.menu -%}
           {%- for item in site.menu -%}
-          <li class="nav-link {% if page.permalink == item.path %}active{% endif %}">
+          <li class="nav-link {% if page.url == item.path %}active{% endif %}">
             <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ item.translation_key | t }}</a>
           </li>
           {%- endfor -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,8 +28,10 @@
 
       <ul class="nav navbar-nav menu-target contrast-switcher" id="menu">
         {%- if site.menu -%}
+          {%- assign current_path_no_slash = page.url | remove: '/' -%}
           {%- for item in site.menu -%}
-          <li class="nav-link {% if page.url == item.path %}active{% endif %}">
+          {%- assign item_path_no_slash = item.path | remove: '/' -%}
+          <li class="nav-link {% if current_path_no_slash == item_path_no_slash %}active{% endif %}">
             <a href="{{ site.baseurl }}{{ baseurl_folder }}{{ item.path }}">{{ item.translation_key | t }}</a>
           </li>
           {%- endfor -%}


### PR DESCRIPTION
Page.url is more reliable, since it is a Jekyll-generated variable that doesn't depend on user configuration.
This also increases consistency in the logic by removing slashes before comparing the current path to the menu item path. This avoid confusing "misses" when a trailing slash is used or not used in the menu config.