### PR TITLE
Move aria-expanded to button

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -249,11 +249,11 @@ var indicatorView = function (model, options) {
 
   $(this._rootElement).on('click', '.variable-selector', function(e) {
     var currentSelector = e.target;
-
+    var accessButton = currentSelector.querySelector("button.accessBtn");
     var options = $(this).find('.variable-options');
     var optionsAreVisible = options.is(':visible');
     $(options)[optionsAreVisible ? 'hide' : 'show']();
-    currentSelector.setAttribute("aria-expanded", optionsAreVisible ? "true" : "false");
+    accessButton.setAttribute("aria-expanded", optionsAreVisible ? "true" : "false");
 
     e.stopPropagation();
   });


### PR DESCRIPTION
Ensure that the state of the expandable and collapsible content is identified. For example, the elements should be read as expandable or collapsible. Provide ariaexpanded="false" and change the value of the aria-expanded attribute as per the action.