### PR TITLE
Checkbox focus fix

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -682,6 +682,6 @@ var indicatorView = function (model, options) {
     };
     fieldGroupElement.find('label')
     .sort(sortLabels)
-    .appendTo(fieldGroupElement.find('.variable-options'));
+    .appendTo(fieldGroupElement.find('#indicatorData .variable-options'));
   }
 };


### PR DESCRIPTION
Screen reader users would expect check boxes to announce ‘Checkbox checked’ and ‘Checkbox not checked’ respectively.