### PR TITLE
Clean up embed + allow for configurable title

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -86,7 +86,7 @@
             </li>
             {%- if meta.embedded_feature_url -%}
             <li role="presentation" class="nav-item embedded-map">
-              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ meta.embedded_feature_tab_title }}</a>
+              <a data-no-disagg="true" class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ meta.embedded_feature_tab_title }}</a>
             </li>
           </li>
             {%- endif -%}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -84,9 +84,10 @@
             <li role="presentation" class="nav-item map" style="display:none">
               <a data-no-disagg="true" class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab" {% include autotrack.html preset="tab_data_map" category="Tab change" action="Change data view" label="Change to Map tab" %}>{{ t.indicator.map }}</a>
             </li>
-            {%- if meta.embedded_map_html -%}
+            {%- if meta.embedded_feature_url -%}
             <li role="presentation" class="nav-item embedded-map">
-              <a data-no-disagg="true" class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ t.indicator.map }}</a>
+              <a class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ meta.embedded_feature_tab_title }}</a>
+            </li>
           </li>
             {%- endif -%}
           </ul>
@@ -104,9 +105,19 @@
                 <img src="{{ site.baseurl }}/assets/img/loading.gif" alt="{{ t.indicator.loading_map }}" />
               </div>
             </div>
-            {% if meta.embedded_map_html %}
+            {% if meta.embedded_feature_url %}
             <div role="tabpanel" class="tab-pane" id="embeddedmapview" class="embedded-map">
-              {{ meta.embedded_map_html }}
+              <div role="tabpanel" class="tab-pane" id="embeddedmapview" >
+              <div class="row">
+              <div class="col-xs-12">
+                <h3 tabindex="0">{{ meta.embedded_feature_title }}</h3>
+              </div>
+            </div>
+              <div class="embedded-map" id="embeddedmapframe">
+                <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
+                <script>document.querySelector("li.nav-item.embedded-map").addEventListener("click",function(){ var pymParent = new pym.Parent('embeddedmapframe', '{{ meta.embedded_feature_url }}', {});})</script>
+
+              </div>
             </div>
             {% endif %}
           </div>

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -123,8 +123,19 @@ Some additional tags are available for the graphs, including the graph type and 
 | graph_type                          | One of `line` or `bar`     |
 | graph_title                         | The title to be shown on the graph |
 
+## Embedded Feature Metadata
+
+You may want to add an additional feature which isn't created from data, such as an iframe. You can create an extra tab to display this feature by adding the following tags to the metadata file.
+
+| Tag                                 | Description                                       
+|-------------------------------------|--------------------------------------------------|
+| embedded_feature_tab_title          | Tab title e.g. Embedded Chart                    |
+| embedded_feature_title              | The title to be shown above the embedded feature |
+| embedded_feature_url                | URL of feature that you want to embed            |
+
 # Non-Standard Information
 
 In the Prose editor, you can add free Markdown text in the same file as the metadata. This is the `edit` section in prose and is part of the metadata. In the raw .md file this is the content underneath the yaml header. You can add any content you like in this section and the content will be converted to html and placed above the graph near the top of the screen.
 
 A guide to writing [Markdown is here](https://guides.github.com/features/mastering-markdown/) and you can write your own tables, lists, links, headings, and so on. This is a useful place to add information about an indicator that doesn't fit in with the rest of the metadata.
+


### PR DESCRIPTION
Saves having to add JS to metadata files. Can be used like this:
`embedded_content_url: https://www.ons.gov.uk/visualisations/dvc529/multiline/index.html`
`embedded_content_title: A nice title`
`embedded_feature_tab_title: Tab title`