### PR TITLE
Fix mobile menu

### DIFF
--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -10,7 +10,7 @@ $(function() {
   
   this.topLevelMenuToggle = document.querySelector("#menuToggle");
   
-  topLevelMenuToggle.addEventListener("click", function(){
+  this.topLevelMenuToggle.addEventListener("click", function(){
     setTopLevelMenuAccessibilityActions();
   });
   function setTopLevelMenuAccessibilityActions(){

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -7,6 +7,34 @@ $(function() {
     $('.top-level li').removeClass('active');
     $('.top-level span').removeClass('open');
   };  
+  
+  this.topLevelMenuToggle = document.querySelector("#menuToggle");
+  
+  topLevelMenuToggle.addEventListener("click", function(){
+    setTopLevelMenuAccessibilityActions();
+  });
+  function setTopLevelMenuAccessibilityActions(){
+    if(topLevelMenuIsOpen()){
+      setAriaExpandedStatus(true);
+      focusOnFirstMenuElement();
+    }
+    else{
+      setAriaExpandedStatus(false);
+    }
+    function topLevelMenuIsOpen(){
+      return topLevelMenuToggle.classList.contains("active");
+    }
+    function setAriaExpandedStatus(expandedStatus){
+      topLevelMenuToggle.setAttribute("aria-expanded", expandedStatus.toString());
+    }
+    function focusOnFirstMenuElement(){
+      var firstMenuElement = getFirstMenuElement();
+      firstMenuElement.focus();
+    }
+    function getFirstMenuElement(){
+      return document.querySelector("#menu .nav-link:first-child a");
+    }
+  }
 
   $('.top-level span, .top-level button').click(function() {
     var target = $(this).data('target');

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -8,9 +8,9 @@ $(function() {
     $('.top-level span').removeClass('open');
   };  
   
-  this.topLevelMenuToggle = document.querySelector("#menuToggle");
+  var topLevelMenuToggle = document.querySelector("#menuToggle");
   
-  this.topLevelMenuToggle.addEventListener("click", function(){
+  topLevelMenuToggle.addEventListener("click", function(){
     setTopLevelMenuAccessibilityActions();
   });
   function setTopLevelMenuAccessibilityActions(){

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,33 +55,3 @@
   </div>
 
 </header>
-
-<script>
-  this.topLevelMenuToggle = document.querySelector("#menuToggle");
-  
-  topLevelMenuToggle.addEventListener("click", function(){
-    setTopLevelMenuAccessibilityActions();
-  });
-  function setTopLevelMenuAccessibilityActions(){
-    if(topLevelMenuIsOpen()){
-      setAriaExpandedStatus(true);
-      focusOnFirstMenuElement();
-    }
-    else{
-      setAriaExpandedStatus(false);
-    }
-    function topLevelMenuIsOpen(){
-      return topLevelMenuToggle.classList.contains("active");
-    }
-    function setAriaExpandedStatus(expandedStatus){
-      topLevelMenuToggle.setAttribute("aria-expanded", expandedStatus.toString());
-    }
-    function focusOnFirstMenuElement(){
-      var firstMenuElement = getFirstMenuElement();
-      firstMenuElement.focus();
-    }
-    function getFirstMenuElement(){
-      return document.querySelector("#menu .nav-link:first-child a");
-    }
-  }
-</script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,13 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li><span data-target="menu">{{ t.menu.menu }}</span></li>
+        <li id="menuToggle"
+            aria-label="Menu toggle. Click to expand or collapse the menu."
+            aria-haspopup="true"
+            aria-expanded="false">
+          <span data-target="menu" tabindex="0"
+          role="navigation">{{ t.menu.menu }}</span>
+        </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>
       </ul>
 
@@ -49,3 +55,33 @@
   </div>
 
 </header>
+
+<script>
+  this.topLevelMenuToggle = document.querySelector("#menuToggle");
+  
+  topLevelMenuToggle.addEventListener("click", function(){
+    setTopLevelMenuAccessibilityActions();
+  });
+  function setTopLevelMenuAccessibilityActions(){
+    if(topLevelMenuIsOpen()){
+      setAriaExpandedStatus(true);
+      focusOnFirstMenuElement();
+    }
+    else{
+      setAriaExpandedStatus(false);
+    }
+    function topLevelMenuIsOpen(){
+      return topLevelMenuToggle.classList.contains("active");
+    }
+    function setAriaExpandedStatus(expandedStatus){
+      topLevelMenuToggle.setAttribute("aria-expanded", expandedStatus.toString());
+    }
+    function focusOnFirstMenuElement(){
+      var firstMenuElement = getFirstMenuElement();
+      firstMenuElement.focus();
+    }
+    function getFirstMenuElement(){
+      return document.querySelector("#menu .nav-link:first-child a");
+    }
+  }
+</script>


### PR DESCRIPTION
When the screen readers is focused on the Menu link on mobile, the reader reads it as "Menu toggle. Click to expand or collapse the menu".

The link now has aria-expanded and aria-haspopup attributes that help the reader know this is an expandable menu

When the user clicks on the Menu, the focus switches automatically to the first element in the menu ("Goals"). This will make it easier to navigate the menu from a screen reader.