### PR TITLE
Add optional contrast button

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -70,7 +70,7 @@ var accessibilitySwitcher = function() {
       'href': 'javascript:void(0)',
       'title': 'Set to ' + contrast + ' contrast',
       'data-contrast': contrast,
-    }).text(getContrastToggleLabel(contrast)).click(function() {
+    }).html(getContrastToggleLabel(contrast).replace(" ", "<br/>")).click(function() {
       setActiveContrast($(this).data('contrast'));
       imageFix(contrast);
     })));

--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -3,7 +3,7 @@ var accessibilitySwitcher = function() {
   var contrastIdentifiers = ['default', 'high'];
 
   function setActiveContrast(contrast) {
-    var contrastType = "{{ site.contrast_type }}
+    var contrastType = "{{ site.contrast_type }}"
     _.each(contrastIdentifiers, function(id) {
       $('body').removeClass('contrast-' + id);
     });

--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -3,9 +3,13 @@ var accessibilitySwitcher = function() {
   var contrastIdentifiers = ['default', 'high'];
 
   function setActiveContrast(contrast) {
+    var contrastType = "{{ site.contrast_type }}
     _.each(contrastIdentifiers, function(id) {
       $('body').removeClass('contrast-' + id);
     });
+    if(contrastType === "long"){
+	    $("body").addClass("long");
+    }
     $('body').addClass('contrast-' + contrast);
 
     createCookie("contrast", contrast, 365);
@@ -66,11 +70,35 @@ var accessibilitySwitcher = function() {
       'href': 'javascript:void(0)',
       'title': 'Set to ' + contrast + ' contrast',
       'data-contrast': contrast,
-    }).text('A').click(function() {
+    }).text(getContrastToggleLabel(contrast)).click(function() {
       setActiveContrast($(this).data('contrast'));
       imageFix(contrast);
     })));
   });
+  
+function getContrastToggleLabel(identifier){
+  var contrastType = "{{ site.contrast_type }}"
+  if(contrastType === "long") {
+    if(identifier === "default"){	
+      return translations.header.default_contrast; 	
+    }	
+    else if(identifier === "high"){	
+      return translations.header.high_contrast;	
+    }
+  }
+  else {
+    return 'A'
+  }
+}
+
+function getContrastToggleTitle(identifier){	
+  if(identifier === "default"){	
+    return translations.header.disable_high_contrast; 	
+  }	
+  else if(identifier === "high"){	
+    return translations.header.enable_high_contrast;	
+  }	
+}
   
   
 function imageFix(contrast) {

--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -68,7 +68,7 @@ var accessibilitySwitcher = function() {
       'class': 'nav-link contrast contrast-' + contrast
     }).html($('<a />').attr(gaAttributes).attr({
       'href': 'javascript:void(0)',
-      'title': 'Set to ' + contrast + ' contrast',
+      'title': getContrastToggleTitle(contrast),
       'data-contrast': contrast,
     }).html(getContrastToggleLabel(contrast).replace(" ", "<br/>")).click(function() {
       setActiveContrast($(this).data('contrast'));

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,4 @@
+{% include multilingual-js.html key="header" %}
 <a class="sr-only sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">{{ t.header.skip_link }}</a>
 <div id="disclaimer">
   {% include components/dev-disclaimer.html %}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -2040,3 +2040,75 @@ body.contrast-high {
     cursor: pointer;
   }
 }
+
+body.long.contrast-default{
+  li.contrast-default{
+    display: none;
+  }
+  li.contrast-high{
+    display: block;
+    @media only screen and (max-width: 767px) {
+      width: 60px;
+    }
+  }
+}
+
+body.long.contrast-high{
+  li.contrast-default{
+    display: block;
+    @media only screen and (max-width: 767px) {
+      width: 60px;
+    }
+  }
+  li.contrast-high{
+    display: none;
+  }
+}
+
+body.long {
+  .navbar ul.navbar-nav li.contrast {
+    @media only screen and (max-width: 768px) {
+      display: none
+    }
+    font-size: 0.75em;
+    font-weight: bold;
+    border-radius: 5px;
+    width: fit-content;
+    max-width: 150px;
+    height: fit-content;
+    max-height: 50px;
+    text-align: center;
+    margin-left: 1em;
+    a {
+      margin: auto;
+      text-decoration: none;
+    }
+  }
+  
+  #accessibility-nav li.contrast {
+    @media screen and (max-width: 500px) {
+      font-size: 3vw;
+    }
+    @media screen and (min-width: 501px) {
+      font-size: 1em;
+    }
+    border-radius: 5px;
+    height: fit-content;
+    width: fit-content;
+    text-align: center;
+    margin: 0.25em;
+    margin-top: 0.1em;
+    position: relative;
+    top: -2px;
+    max-height: 60px;
+    max-width: 110px;
+    a {
+      margin: auto;
+      text-decoration: none;
+      padding: 1px;
+      display: table-caption;  
+    }
+  }
+
+}
+

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -2079,9 +2079,9 @@ body.long {
     font-size: 0.75em;
     font-weight: bold;
     border-radius: 5px;
-    width: fit-content;
+    width: auto;
     max-width: 150px;
-    height: fit-content;
+    height: auto;
     max-height: 50px;
     text-align: center;
     margin-left: 1em;
@@ -2099,8 +2099,8 @@ body.long {
       font-size: 1em;
     }
     border-radius: 5px;
-    height: fit-content;
-    width: fit-content;
+    height: auto;
+    width: auto;
     text-align: center;
     margin: 0.25em;
     margin-top: 0.1em;
@@ -2112,7 +2112,6 @@ body.long {
       margin: auto;
       text-decoration: none;
       padding: 1px;
-      display: table-caption;  
     }
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,14 @@ analytics:
   ga_prod: 'paste ID here'
 ```
 
+### contrast_type
+
+This optional setting allows you to change the type of contrast button your site uses. By default there are two buttons containing 'A'. If you use this option one single button will be displayed with the text 'High contrast' / 'Default contrast', depending on which mode of contrast is active.
+
+```nohighlight
+contrast_type: long
+```
+
 ### create_goals
 
 This optional setting can be used to automatically create the goal pages. Without this setting, you will need a file for each goal (per language), in a `_goals` folder. This setting should include another (indented) setting indicating the Jekyll layout to use for the goals.
@@ -245,11 +253,7 @@ non_global_metadata: indicator.national_metadata
 
 ### sharethis_property
 
-This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](https://open-sdg.readthedocs.io/en/latest/social-media-sharing/) page.
-
-### contrast_type: long
-
-This optional setting allows you to change the type of contrast button your site uses. By default there are two buttons containing 'A'. If you use this option one single button will be displayed with the text 'High contrast' / 'Default contrast', depending on which mode of contrast is active. 
+This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](https://open-sdg.readthedocs.io/en/latest/social-media-sharing/) page. 
 
 ## Examples
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,10 @@ non_global_metadata: indicator.national_metadata
 
 This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](https://open-sdg.readthedocs.io/en/latest/social-media-sharing/) page.
 
+### contrast_type: long
+
+This optional setting allows you to change the type of contrast button your site uses. By default there are two buttons containing 'A'. If you use this option one single button will be displayed with the text 'High contrast' / 'Default contrast', depending on which mode of contrast is active. 
+
 ## Examples
 
 To see many of these options in action, the [site starter repository](https://github.com/open-sdg/open-sdg-site-starter) contains an [example config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml).


### PR DESCRIPTION
Using the line `contrast_type: long` in their config file, countries can choose whether to use the small 'A' contrast buttons or the longer 'Default contrast'/'High contrast' button

Here's a feature branch where `contrast _type: long`:
https://sdg.mango-solutions.com/optional-contrast/