### PR TITLE
Move charset up to beginning of head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
     <head>
+        <meta charset="utf-8">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
         {% include polyfills.html %}
         {% include javascript-variables.html %}
         {% include multilingual-js-base.html %}
         <!-- Basic Page Needs
         ================================================== -->
-        <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge"><!-- Mobile Specific Metas
         ================================================== -->
         <meta name="HandheldFriendly" content="True">
@@ -16,13 +16,13 @@
         <!-- Title and meta description
         ================================================== -->
         {% capture indicator_page_title %}
-        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }} 
+        {{ t.general.indicator }} {{ page.indicator }} - {{ t.general.goal }} {{ goal_number }}
         {% endcapture %}
 
         {% capture goal_page_title %}
         {{ t.general.goal }} {{ page.sdg_goal }} - {{ page.short }}
         {% endcapture %}
-        
+
         <title>
           {% if page.indicator %}
             {{ indicator_page_title | escape }}
@@ -32,7 +32,7 @@
             {{ site.title | escape }}
           {% endif %}
         </title>
-        
+
         <meta name="description" content="">
         <meta property="og:description" content="">
         {% if site.environment == 'staging' %}


### PR DESCRIPTION
This avoids a console message in Firefox: "The page was reloaded, because the character encoding declaration of the HTML document was not found when prescanning the first 1024 bytes of the file. The encoding declaration needs to be moved to be within the first 1024 bytes of the file." Probably not a big deal, but an easy fix.