### PR TITLE
Support flattened global translations

### DIFF
--- a/_includes/components/breadcrumb.html
+++ b/_includes/components/breadcrumb.html
@@ -1,7 +1,7 @@
 <ol class="breadcrumb">
   <li><a href="{{ site.baseurl }}{{ baseurl_folder }}/">{{ t.general.home }}</a></li>
-  {% if goal_href %}
-      <li><a href="{{ goal_href }}" title="{{ goal_title }}">{{ t.general.goal }} {{ goal_number }}</a></li>
+  {% if goal_uri %}
+      <li><a href="{{ goal_uri }}" title="{{ goal_title }}">{{ t.general.goal }} {{ goal_number }}</a></li>
       <li class="active">{{ t.general.indicator }} {{ page.indicator }}</li>
   {% else %}
       <li class="active">{{ t.general.goal }} {{ goal_number }}</li>

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -12,10 +12,11 @@
 {% assign headline = site.data.headline[indicator_id] %}
 
 {%- assign goal_number = meta.sdg_goal | downcase -%}
-{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
-{%- assign translated_goal = t.global_goals[goal_number] -%}
 {% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}{% endcapture %}
-{% capture goal_title %}{{ goal.title }}{% endcapture %}
+{% assign goal_title_key = goal_number | append: '-title' %}
+{% assign goal_short_key = goal_number | append: '-short' %}
+{% assign goal_title = t.global_goals[goal_title_key] %}
+{% assign goal_short = t.global_goals[goal_short_key] %}
 
 {% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
   {% assign show_data = false %}
@@ -31,3 +32,5 @@
 {% assign indicator_id_dashes = meta.indicator | replace: ".", "-" %}
 {% assign translated_indicator = t.global_indicators[indicator_id_dashes] | default: t.global_indicators[indicator_id] %}
 {% assign goal_href = goal_uri %}
+{%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
+{%- assign translated_goal = t.global_goals[goal_number] -%}

--- a/_includes/indicator-variables.html
+++ b/_includes/indicator-variables.html
@@ -15,7 +15,6 @@
 {%- assign goal = site.data.translations[default_language].global_goals[goal_number] -%}
 {%- assign translated_goal = t.global_goals[goal_number] -%}
 {% capture goal_uri %}{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}{% endcapture %}
-{% capture goal_href %}{{ goal_uri }}{% endcapture %}
 {% capture goal_title %}{{ goal.title }}{% endcapture %}
 
 {% if meta.reporting_status != "complete" or meta.data_non_statistical == true %}
@@ -27,7 +26,8 @@
 {% capture dataset_name %}indicator_{{meta.indicator | slugify }}{% endcapture %}
 
 {% comment %}
-@deprecated: The following variable will be removed for 1.0.0.
+@deprecated: The following variables will be removed for 1.0.0.
 {% endcomment %}
 {% assign indicator_id_dashes = meta.indicator | replace: ".", "-" %}
 {% assign translated_indicator = t.global_indicators[indicator_id_dashes] | default: t.global_indicators[indicator_id] %}
+{% assign goal_href = goal_uri %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -12,13 +12,13 @@
     {%- assign goals = site.goals | where: 'language', current_language -%}
     {% for goal in goals %}
         {%- assign goal_number = goal.sdg_goal -%}
-        {%- assign default_goal = site.data.translations[default_language].global_goals[goal_number] -%}
-        {%- assign translated_goal = t.global_goals[goal_number] -%}
+        {%- assign goal_short_key = goal_number | append: '-short' -%}
+        {%- assign goal_short = t.global_goals[goal_short_key] -%}
 
         {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
             <div class="col-xs-4 col-md-2">
                 <a href="./{{ goal_number }}/">
-                  <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" id="goal-{{ goal_number }}" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
+                  <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" id="goal-{{ goal_number }}" alt="{{ goal_short }} - {{ t.general.goal }} {{ goal_number }}" />
               </a>
             </div>
         {% cycle 'end row' : '', '', '', '', '', '</div>' %}

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -2,17 +2,20 @@
 {% include head.html %}
 {% include header.html %}
 {% assign goal_number = page.sdg_goal %}
-{% assign translated_goal = t.global_goals[goal_number] %}
+{% assign goal_title_key = goal_number | append: '-title' %}
+{% assign goal_short_key = goal_number | append: '-short' %}
+{% assign goal_title = t.global_goals[goal_title_key] %}
+{% assign goal_short = t.global_goals[goal_short_key] %}
 
 <div class="heading goal-{{page.sdg_goal}}">
   <div class="container">
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2">
-        <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
+        <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ goal_short }} - {{ t.general.goal }} {{ goal_number }}" />
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>
-          <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
+          <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ goal_title }}
         </h1>
       </div>
     </div>
@@ -37,13 +40,15 @@
   {% for group in goal_indicators %}
     {% assign target_id = group.name %}
     {% assign target_id_dashes = target_id | replace: ".", "-" %}
-    {% assign translated_target = t.global_targets[target_id_dashes] | default: t.global_targets[target_id] %}
+    {% target_title_key = target_id | append: '-title' %}
+    {% target_title_key_dashes = target_id_dashes | append: '-title' %}
+    {% assign target_title = t.global_targets[target_title_key_dashes] | default: t.global_targets[target_title_key] %}
     <div class="indicator-cards target col-md-6">
       <span>
         <label class="hidden-md hidden-lg">{{ t.general.target }}</label>
         {{ target_id }}
       </span>
-      {{ translated_target.title }}
+      {{ target_title }}
     </div>
     <div class="indicator-cards col-md-6 row no-gutters">
     {% for indicator in group.items %}

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -2,17 +2,20 @@
 {% include head.html %}
 {% include header.html %}
 {% assign goal_number = page.sdg_goal %}
-{% assign translated_goal = t.global_goals[goal_number] %}
+{% assign goal_title_key = goal_number | append: '-title' %}
+{% assign goal_short_key = goal_number | append: '-short' %}
+{% assign goal_title = t.global_goals[goal_title_key] %}
+{% assign goal_short = t.global_goals[goal_short_key] %}
 
 <div class="heading goal-{{page.sdg_goal}}">
   <div class="container">
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2">
-        <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
+        <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ goal_short }} - {{ t.general.goal }} {{ goal_number }}" />
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>
-          <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
+          <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ goal_title }}
         </h1>
       </div>
     </div>

--- a/_layouts/indicator-json.html
+++ b/_layouts/indicator-json.html
@@ -3,11 +3,12 @@
   {%- assign goals = site.goals | where: 'language', current_language -%}
   {%- for goal in goals -%}
   {%- assign goal_number = goal.sdg_goal | downcase -%}
-  {%- assign translated_goal = t.global_goals[goal_number] -%}
+  {%- assign goal_title_key = goal_number | append: '-title' -%}
+  {%- assign goal_title = t.global_goals[goal_title_key] -%}
   {
     "goal": {
       "id": "{{goal_number}}",
-      "title": "{{translated_goal.title | strip_newlines | strip | replace: '"', "'"}}",
+      "title": "{{goal_title | strip_newlines | strip | replace: '"', "'"}}",
       "indicators": [
         {%- assign all_meta = site.data.meta -%}
         {%- if all_meta[current_language] -%}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -12,13 +12,13 @@
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2">
         <a href="{{ goal_uri }}" title="{{ t.indicator.view_indicator_list }}">
-          <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" />
+          <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ goal_short }} - {{ t.general.goal }} {{ goal_number }}" />
         </a>
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>
           <a href="{{ goal_uri }}">
-            <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ translated_goal.title }}
+            <span class="hidden-sm hidden-md hidden-lg">{{ t.general.goal }} {{ goal_number }}: </span>{{ goal_title }}
           </a>
         </h1>
         <h2>{{ t.general.indicator }} {{ meta.indicator }}: {{ meta.indicator | get_indicator_name }}</h2>
@@ -42,12 +42,12 @@
       <h2>{{ meta.graph_title | t }}</h2>
     </div>
   </div>
-  
+
   {% assign sources_list = '' | split: ',' %}
   {% for i in (1..12) %}
     {% assign src_active = "source_active_" | append: i %}
     {% if meta[src_active] == true %}
-      {% assign src_org = "source_organisation_" | append: i %} 
+      {% assign src_org = "source_organisation_" | append: i %}
       {% assign src_org_translated = meta[src_org] | t %}
       {% assign sources_list = sources_list | push: src_org_translated  %}
     {% endif %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -38,17 +38,17 @@
 
   {%- for goalreport in site.data.reporting.goals -%}
     {%- assign goal_number = goalreport.goal  | downcase -%}
-    {%- assign default_goal = site.data.translations[default_language].global_goals[goal_number] -%}
-    {%- assign translated_goal = t.global_goals[goal_number] -%}
+    {%- assign goal_short_key = goal_number | append: '-short' -%}
+    {%- assign goal_short = t.global_goals[goal_short_key] -%}
     <div class="goal">
         <div class="frame">
           <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}/">
-            <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ translated_goal.short }} - {{ t.general.goal }} {{ goal_number }}" width="100" height="100" />
+            <img src="{{ site.goal_image_base }}/{{ current_language }}/{{ goal_number }}.png" alt="{{ goal_short }} - {{ t.general.goal }} {{ goal_number }}" width="100" height="100" />
           </a>
         </div>
         <div class="details">
           <h3 class="status-goal">
-            <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}/">{{ translated_goal.short }}</a>
+            <a href="{{ site.baseurl }}{{ baseurl_folder }}/{{ goal_number }}/">{{ goal_short }}</a>
             <span class="total">{{ goalreport.totals.total }}<span></span> {{ t.general.indicators | downcase }}</span>
           </h3>
           <div class="summary">

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -13,6 +13,14 @@ remote_data_prefix: "https://open-sdg.github.io/open-sdg-data-testing/staging"
 remote_translations:
   - https://open-sdg.github.io/sdg-translations/translations.json
 
+# Automatically create indicator pages, goal pages,
+# and some other required pages.
+create_indicators:
+  layout: indicator
+create_goals:
+  layout: goal
+create_pages: true
+
 analytics:
   ga_prod: ''
 


### PR DESCRIPTION
The sdg-translations project now has "flattened" global translation keys. For example, instead of this:
```
1:
    title: Foo
2:
    title: Bar
```
...now has this:
```
1-title: Foo
2-title: Bar
```

As a consequence several parts of the templates in Open SDG need to be adjusted. This is an attempt at that, as well as a general cleanup/deprecation of some indicator variables.