### PR TITLE
Allow min and max value be set on y axis

### DIFF
--- a/_includes/components/charts/bar.html
+++ b/_includes/components/charts/bar.html
@@ -4,3 +4,24 @@ apart from providing the canvas tag. For details on the Chart.js configuration
 being used, see `createPlot()` in `indicatorView.js`.
 {% endcomment %}
 <canvas></canvas>
+{% if meta.graph_min_value and meta.graph_max_value %}
+  <script>
+    opensdg.chartConfigAlter = function(config) {
+      var overrides = {
+        options: {
+          scales: {
+            yAxes: [{
+              ticks: {
+                min: {{ meta.graph_min_value }},
+                max: {{ meta.graph_max_value }}
+                }
+              }]
+            }
+          }
+        }
+    // Add these overrides onto the normal config, and return it.
+    $.extend(true, config, overrides);
+    return config;
+    }
+  </script>
+{% endif %}

--- a/_includes/components/charts/line.html
+++ b/_includes/components/charts/line.html
@@ -4,3 +4,24 @@ apart from providing the canvas tag. For details on the Chart.js configuration
 being used, see `createPlot()` in `indicatorView.js`.
 {% endcomment %}
 <canvas></canvas>
+{% if meta.graph_min_value and meta.graph_max_value %}
+  <script>
+    opensdg.chartConfigAlter = function(config) {
+      var overrides = {
+        options: {
+          scales: {
+            yAxes: [{
+              ticks: {
+                min: {{ meta.graph_min_value }},
+                max: {{ meta.graph_max_value }}
+                }
+              }]
+            }
+          }
+        }
+    // Add these overrides onto the normal config, and return it.
+    $.extend(true, config, overrides);
+    return config;
+    }
+  </script>
+{% endif %}

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -122,6 +122,8 @@ Some additional tags are available for the graphs, including the graph type and 
 |-------------------------------------|------------------------------------|
 | graph_type                          | One of `line` or `bar`     |
 | graph_title                         | The title to be shown on the graph |
+| graph_min_value                     | The lowest value to be shown on the y-axis |
+| graph_max_value                     | The highest value to be shown on the y-axis |
 
 ## Embedded Feature Metadata
 

--- a/tests/features/SetMinMaxValues.feature
+++ b/tests/features/SetMinMaxValues.feature
@@ -1,0 +1,10 @@
+Feature: Set min/max values
+
+  As a site visitor
+  I need to be able to see data on the correct scale
+  So that I am not misled
+  
+  Scenario: Indicators have a "Chart" tab which displays data in a chart
+  Given I am on "/1-5-1"
+  And I wait 3 seconds
+  Then I should see a "visual chart" element


### PR DESCRIPTION
For #348 

This PR will allow data providers/editors to set a min and max value on the y-axis using new metadata fields `graph_min_value` and `graph_max_value`

Test branch:
https://sdg.mango-solutions.com/set-axis-test
Bar chart test:
https://sdg.mango-solutions.com/set-axis-test/5-5-1/
Line graph test:
https://sdg.mango-solutions.com/set-axis-test/16-6-2