### PR TITLE
Some final fixes for set y axis min/max

### DIFF
--- a/_includes/components/charts/bar.html
+++ b/_includes/components/charts/bar.html
@@ -14,14 +14,14 @@ being used, see `createPlot()` in `indicatorView.js`.
               ticks: {
                 min: {{ meta.graph_min_value }},
                 max: {{ meta.graph_max_value }}
-                }
-              }]
-            }
+                    }
+                    }]
           }
         }
-    // Add these overrides onto the normal config, and return it.
-    $.extend(true, config, overrides);
-    return config;
+      }
+      // Add these overrides onto the normal config, and return it.
+      $.extend(true, config, overrides);
+      return config;
     }
   </script>
 {% endif %}

--- a/_includes/components/charts/line.html
+++ b/_includes/components/charts/line.html
@@ -14,14 +14,14 @@ being used, see `createPlot()` in `indicatorView.js`.
               ticks: {
                 min: {{ meta.graph_min_value }},
                 max: {{ meta.graph_max_value }}
-                }
-              }]
-            }
+                    }
+                    }]
           }
         }
-    // Add these overrides onto the normal config, and return it.
-    $.extend(true, config, overrides);
-    return config;
+      }
+      // Add these overrides onto the normal config, and return it.
+      $.extend(true, config, overrides);
+      return config;
     }
   </script>
 {% endif %}

--- a/tests/features/SetMinMaxValues.feature
+++ b/tests/features/SetMinMaxValues.feature
@@ -4,7 +4,7 @@ Feature: Set min/max values
   I need to be able to see data on the correct scale
   So that I am not misled
   
-  Scenario: Indicators have a "Chart" tab which displays data in a chart
-  Given I am on "/1-5-1"
-  And I wait 3 seconds
-  Then I should see a "visual chart" element
+  Scenario: Indicators with a min/max value display data in a chart
+    Given I am on "/1-5-1"
+    And I wait 3 seconds
+    Then I should see a "visual chart" element


### PR DESCRIPTION
Following on from #351 

Brock:
Already been merged, but just a few more nitpicks:

The indentation is still not quite right, starting with the closing brace beneath "max".
It might be better if the name of the test scenario was more descriptive for this particular case, like maybe "Indicators with a min/max value display data in a chart"
The steps beneath a scenario are generally indented 2 spaces
