### PR TITLE
Add footer to embed tab

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -130,9 +130,9 @@
                 <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
                 <script>document.querySelector("li.nav-item.embedded-map").addEventListener("click",function(){ var pymParent = new pym.Parent('embeddedmapframe', '{{ meta.embedded_feature_url }}', {});})</script>
               </div>
-              {% if meta.embed_footer %}
+              {% if meta.embedded_feature_footer %}
                 <div id="embedfooter" class="table-footer-text">
-                  <p>{{ meta.embed_footer | t | markdownify}}</p>
+                  <p>{{ meta.embedded_feature_footer | t | markdownify}}</p>
                 </div>
               {% endif %}
             </div>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -130,11 +130,11 @@
                 <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
                 <script>document.querySelector("li.nav-item.embedded-map").addEventListener("click",function(){ var pymParent = new pym.Parent('embeddedmapframe', '{{ meta.embedded_feature_url }}', {});})</script>
               </div>
-              <div id="embedfooter" class="table-footer-text">
-                {% if meta.embed_footer %}
-                <p>{{ meta.embed_footer | t | markdownify}}</p>
-                {% endif %}
-              </div>
+              {% if meta.embed_footer %}
+                <div id="embedfooter" class="table-footer-text">
+                  <p>{{ meta.embed_footer | t | markdownify}}</p>
+                </div>
+              {% endif %}
             </div>
             {% endif %}
           </div>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -129,7 +129,11 @@
               <div class="embedded-map" id="embeddedmapframe">
                 <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
                 <script>document.querySelector("li.nav-item.embedded-map").addEventListener("click",function(){ var pymParent = new pym.Parent('embeddedmapframe', '{{ meta.embedded_feature_url }}', {});})</script>
-
+              </div>
+              <div id="embedfooter" class="table-footer-text">
+                {% if meta.embed_footer %}
+                <p>{{ meta.embed_footer | t | markdownify}}</p>
+                {% endif %}
               </div>
             </div>
             {% endif %}
@@ -227,4 +231,3 @@
 </div>
 
 {% include footer.html %}
-

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -143,7 +143,7 @@ You may want to add an additional feature which isn't created from data, such as
 | embedded_feature_tab_title          | Tab title e.g. Embedded Chart                    |
 | embedded_feature_title              | The title to be shown above the embedded feature |
 | embedded_feature_url                | URL of feature that you want to embed            |
-| embed_footer                        | Information about the embedded feature which displays below embed |
+| embedded_feature_footer             | Information about the embedded feature which displays below embed |
 
 # Non-Standard Information
 

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -143,6 +143,7 @@ You may want to add an additional feature which isn't created from data, such as
 | embedded_feature_tab_title          | Tab title e.g. Embedded Chart                    |
 | embedded_feature_title              | The title to be shown above the embedded feature |
 | embedded_feature_url                | URL of feature that you want to embed            |
+| embed_footer                        | Information about the embedded feature which displays below embed |
 
 # Non-Standard Information
 


### PR DESCRIPTION
Added a section below the embed within the embed tab where info about the embedded feature can go e.g. source, footnote.

[Here](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/5-4-1-embed-deploy/5-4-1/)'s an example of how it would look.

Also I realise to be in line with #394 `meta` should be `page.indicator` but wasn't sure which PR that should be part of?