### PR TITLE
Auto fit search bar around text

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -320,7 +320,7 @@ header {
     input {
       padding: 5px;
       padding-left: 5px;
-      width: 150px;
+      width: auto;
       height: 34px;
       transition: width 0.4s;
       margin-top: 5px;


### PR DESCRIPTION
Currently some placeholder text is cut off if language is anything but English - change to using `width: auto` so no text is cut off in any language