### PR TITLE
Configurable footer menu links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,12 @@
                 {% if item.path contains ":" %}
                   <a href="{{ item.path }}" target="_blank">{{ item.translation_key | t }}</a>
                 {% else %}
-                  <a href="{{ page.baseurl }}{{ item.path }}">{{ item.translation_key | t }}</a>
+                  {%- assign item_path = item.path -%}
+                  {%- assign item_path_first = item_path | slice: 0 %}
+                  {%- if item_path_first == '/' -%}
+                    {%- assign item_path = item_path | slice: 1, item_path.size -%}
+                  {%- endif -%}
+                  <a href="{{ page.baseurl }}{{ item_path }}">{{ item.translation_key | t }}</a>
                 {% endif %}
                 </li>
               {% endfor %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,15 +4,17 @@
       <div class="col-xs-12">
         <div id="footerLinks">
           <ul>
-            <li><a href="mailto:{{site.email_contacts.suggestions}}">{{ page.t.menu.contact_us }}</a></li>
-            {% if site.twitter %}
-            <li><a class="twitter-follow-button" href="https://twitter.com/{{ site.twitter }}" data-show-count="false">{{ page.t.general.twitter }}: @{{ site.twitter }}</a></li>
+            {% if site.footer_menu %}
+              {% for item in site.footer_menu %}
+                <li>
+                {% if item.path contains ":" %}
+                  <a href="{{ item.path }}" target="_blank">{{ item.translation_key | t }}</a>
+                {% else %}
+                  <a href="{{ page.baseurl }}{{ item.path }}">{{ item.translation_key | t }}</a>
+                {% endif %}
+                </li>
+              {% endfor %}
             {% endif %}
-            {% if site.facebook %}
-            <li><a href="https://facebook.com/{{ site.facebook }}" target="_blank">{{ page.t.general.facebook }}: @{{ site.facebook }}</a></li>
-            {% endif %}
-            <li><a href="{{ site.baseurl }}{% link _pages/faq.md %}">{{ page.t.menu.faq }}</a></li>
-            <li><a href="{{ site.baseurl }}{% link _pages/cookies.md %}">{{ page.t.menu.cookies }}</a></li>
           </ul>
         </div>
       </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,8 +38,13 @@
           {%- assign current_path_no_slash = page.url | remove: '/' -%}
           {%- for item in site.menu -%}
           {%- assign item_path_no_slash = item.path | remove: '/' -%}
+          {%- assign item_path = item.path -%}
+          {%- assign item_path_first = item_path | slice: 0 %}
+          {%- if item_path_first == '/' -%}
+            {%- assign item_path = item_path | slice: 1, item_path.size -%}
+          {%- endif -%}
           <li class="nav-link {% if current_path_no_slash == item_path_no_slash %}active{% endif %}">
-            <a href="{{ page.baseurl }}{{ item.path }}">{{ item.translation_key | t }}</a>
+            <a href="{{ page.baseurl }}{{ item_path }}">{{ item.translation_key | t }}</a>
           </li>
           {%- endfor -%}
         {%- endif -%}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,26 @@ This **required** setting should be either `staging` or `production`. Certain fe
 environment: staging
 ```
 
+### footer_menu
+
+This **required** setting controls the footer menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](https://open-sdg.readthedocs.io/en/latest/translation/).
+
+The following example provides a footer menu matching older versions of Open SDG, which included options for social media and email contacts.
+
+```nohighlight
+footer_menu:
+  - path: mailto:my-email-address@example.com
+    translation_key: menu.contact-us
+  - path: https://twitter.com/MyTwitterAccount
+    translation_key: general.twitter
+  - path: https://facebook.com/MyFacebookAccount
+    translation_key: general.facebook
+  - path: /faq
+    translation_key: menu.faq
+  - path: /cookies
+    translation_key: menu.cookies
+```
+
 ### goal_image_base
 
 This **required** setting controls the base URL for downloading the imagery for the goals (PNG files). The platform will use this as a base, and complete the URLs (behind the scenes) by adding a language and number. For example, if you set this to `https://example.com`, then the platform will try to download the Spanish image for Goal 4 at: `https://example.com/en/4.png`.
@@ -192,22 +212,6 @@ This optional setting can be used to load additional JavaScript files on each pa
 ```
 custom_js:
   - /assets/js/custom.js
-```
-
-### twitter
-
-This optional setting creates a [Twitter](https://twitter.com) link in the platform's footer. It should be a Twitter account name.
-
-```nohighlight
-twitter: MyTwitterAccount
-```
-
-### facebook
-
-This optional setting creates a [Facebook](https://facebook.com) link in the platform's footer. It should be a Facebook account name.
-
-```nohighlight
-facebook: MyFacebookAccount
 ```
 
 ### frontpage_heading

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ The following example provides a footer menu matching older versions of Open SDG
 ```nohighlight
 footer_menu:
   - path: mailto:my-email-address@example.com
-    translation_key: menu.contact-us
+    translation_key: menu.contact_us
   - path: https://twitter.com/MyTwitterAccount
     translation_key: general.twitter
   - path: https://facebook.com/MyFacebookAccount

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -71,7 +71,9 @@ menu:
     translation_key: menu.about
   - path: guidance
     translation_key: menu.guidance
-  - path: faq
+    # Internal paths do not need a preceding slash,
+    # but it is fine to have one.
+  - path: /faq
     translation_key: menu.faq
 
 footer_menu:
@@ -83,7 +85,9 @@ footer_menu:
     translation_key: general.facebook
   - path: faq
     translation_key: menu.faq
-  - path: about/cookies-and-privacy
+  # Internal paths do not need a preceding slash,
+  # but it is fine to have one.
+  - path: /about/cookies-and-privacy
     translation_key: menu.cookies
 
 # The list of languages that are translated. The first one is the default.

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -65,25 +65,25 @@ collections:
 # Menu
 menu:
   # Use these to customise the main navigation.
-  - path: /reporting-status
+  - path: reporting-status
     translation_key: menu.reporting_status
-  - path: /about
+  - path: about
     translation_key: menu.about
-  - path: /guidance
+  - path: guidance
     translation_key: menu.guidance
-  - path: /faq
+  - path: faq
     translation_key: menu.faq
 
 footer_menu:
   - path: mailto:test@example.com
-    translation_key: menu.contact-us
+    translation_key: menu.contact_us
   - path: https://twitter.com/MyTwitterAccount
     translation_key: general.twitter
   - path: https://facebook.com/MyFacebookAccount
     translation_key: general.facebook
-  - path: /faq
+  - path: faq
     translation_key: menu.faq
-  - path: /cookies
+  - path: about/cookies-and-privacy
     translation_key: menu.cookies
 
 # The list of languages that are translated. The first one is the default.

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -74,6 +74,18 @@ menu:
   - path: /faq
     translation_key: menu.faq
 
+footer_menu:
+  - path: mailto:test@example.com
+    translation_key: menu.contact-us
+  - path: https://twitter.com/MyTwitterAccount
+    translation_key: general.twitter
+  - path: https://facebook.com/MyFacebookAccount
+    translation_key: general.facebook
+  - path: /faq
+    translation_key: menu.faq
+  - path: /cookies
+    translation_key: menu.cookies
+
 # The list of languages that are translated. The first one is the default.
 languages:
   - en

--- a/tests/features/Footer.feature
+++ b/tests/features/Footer.feature
@@ -6,8 +6,8 @@ Feature: Footer
 
   Scenario: A link to a Twitter account is in the footer
     Given I am on the homepage
-    Then I should see "MyTwitterAccount"
+    Then I should see "Twitter"
 
   Scenario: A link to a Facebook account is in the footer
     Given I am on the homepage
-    Then I should see "MyFacebookAccount"
+    Then I should see "Facebook"


### PR DESCRIPTION
This is an attempt at #412.

The upside of this approach is that we don't need specific configuration settings for Twitter and Facebook. So along those lines, those configuration items are removed from the documentation. This also makes it easier to add additional footer menu items.

There is a downside - or at least a change of behavior: The Twitter and Facebook links can't include the account names. For example, instead of "Twitter: @MyTwitterAccout" it has to be just "Twitter". This is because the labels of the menu items have to be controlled by a single "translation key".

Finally this also includes a fix for the main menu as well. Apparently there is a problem with the main menu when the site does not have a "baseurl" - this would only have been visible on a production site, so maybe that is why nobody has mentioned it yet. The problem is that if the "path" of the menu item includes a preceding slash, the href of the menu item ends up with 2 slashes, which can break the link completely. So the fix included here is to remove any preceding slashes.

If we decide not to use this PR, we should still implement the fix mentioned above (in a separate PR).