### PR TITLE
Remove the default language snippet, since it is no longer needed

### DIFF
--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -89,14 +89,6 @@ goal_image_base: https://open-sdg.github.io/sdg-translations/assets/img/goals
 plugins:
   - jekyll-open-sdg-plugins
 
-# This makes sure that all pages have a language.
-defaults:
-  -
-    scope:
-      path: ""
-    values:
-      language: "en"
-
 # Apply any custom CSS.
 custom_css:
   - /assets/css/custom.css


### PR DESCRIPTION
Because jekyll-open-sdg-plugins should now be setting the default language on all goals, indicators, and pages, this confusing snippet can be removed from the _config.yml files. Let's confirm by removing it in the test suite.