### PR TITLE
Stop text from rendering outside of metadata table

### DIFF
--- a/_includes/components/metadata.html
+++ b/_includes/components/metadata.html
@@ -1,4 +1,4 @@
-<table class="table table-hover">
+<table class="table table-hover" id="metadata-table">
   {% for indicator_metadata in site.data.schema %}
     {%- if page.t.metadata_fields[indicator_metadata.name] -%}
       {%- assign metadata_label = page.t.metadata_fields[indicator_metadata.name] -%}

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -341,6 +341,10 @@ header {
   }
 }
 
+#metadata-table {
+  table-layout: fixed;
+}
+
 @media only screen and (max-width: 768px) {
 
   header .container {


### PR DESCRIPTION
Fix for #278 

See metadata table [here](https://sustainabledevelopment-uk.github.io/16-1-1/) (broken) compared with [here](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/metadata-table/16-1-1/)