### PR TITLE
Use indicator_available instead of graph_title for the indicator page H2

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -39,11 +39,13 @@
     </div>
   </div>
 
-  <div class="row">
+  {% if page.indicator.indicator_available %}
+  <div class="row metadata-available-indicator">
     <div class="col-xs-12">
-      <h2>{{ page.indicator.graph_title }}</h2>
+      <h2>{{ page.indicator.indicator_available }}</h2>
     </div>
   </div>
+  {% endif %}
 
   {% assign sources_list = '' | split: ',' %}
   {% for i in (1..12) %}

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -41,6 +41,7 @@ If the indicator is going to display a graph, the following fields are required:
 
 The following fields are not strictly required, but are recommended because they serve special purposes:
 
+* `indicator_available` - an alternate name for the indicator, intended for when the global indicator name might not accurately describe the available national/regional statistics
 * `computation_units` - the unit used in the headline series for this indicator. Examples:
     * Metric tons * my_translations.metric_tons
 * `source_active_1` - whether source #1 should be displayed. Examples:

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -41,3 +41,10 @@ Feature: Indicator
   Scenario: Missing metdata can be hidden
     And I click on "the Global metadata tab"
     Then I should not see "Global indicator description"
+
+  Scenario: The 'indicator_available' metadata appears as a sub-heading
+    Then I should see an "available indicator" element
+    And I should see "Name of available indicator"
+    And I am on "/1-2-1"
+    Then I should not see an "available indicator" element
+    And I should not see "Name of available indicator"

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -38,7 +38,8 @@ const driver = new mink.Mink({
     "the 'Clear all' button": "button[data-type='clear']",
     "the 'Clear selections' button": "button#clear",
     "success data notice": "div.alert.success",
-    "disaggregation sidebar": "#indicator-sidebar:not(.indicator-sidebar-hidden)"
+    "disaggregation sidebar": "#indicator-sidebar:not(.indicator-sidebar-hidden)",
+    "available indicator": '.metadata-available-indicator'
   }
 });
 


### PR DESCRIPTION
Fixes #337 

This changes the H2 on the indicator pages to `indicator_available` instead of `graph_title`.

This could be considered a breaking change. The most probable result for most implementations will be that the H2 will disappear, since there is nothing in the `indicator_available` field. On the bright side, this isn't so bad, because that H2 was just duplicating the graph title anyway.