### PR TITLE
Expert review: Underline menu items on hover

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -251,7 +251,6 @@ header {
 
         &:hover {
           background: transparent;
-          border-bottom: 2px solid #aaaaaa;
         }
       }
 
@@ -287,6 +286,11 @@ header {
         background: black;
         a {
           color: yellow;
+        }
+      }
+      &:not(.active){
+        a:hover{
+          border-bottom: 2px solid #aaaaaa;
         }
       }
     }

--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -251,6 +251,7 @@ header {
 
         &:hover {
           background: transparent;
+          border-bottom: 2px solid #aaaaaa;
         }
       }
 


### PR DESCRIPTION
An update to the `scss` file to underline inactive menu items on hover.

Since Brock is currently refactoring the style sheets, we'll deal with them when the merge conflicts arise.

Test: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/opensdg_menu_underline/