### PR TITLE
Take user straight to indicator page if search by indicator ID

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -22,7 +22,7 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
     if(e.keyCode === 13 && searchValue.length) {
       if(searchQueryMatchesIndicatorPattern){
-        window.location.replace("/" + searchValue);
+        window.location.replace("/" + searchValue.split(".").join("-"));
       }
       else{
         window.location.replace(that.inputElement.data('pageurl') + searchValue);

--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -18,8 +18,15 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
   this.inputElement.keyup(function(e) {
     var searchValue = that.inputElement.val();
+    var searchQueryMatchesIndicatorPattern = searchValue.match(/^[0-9]+\.[0-9a-z]+\.[0-9]+$/g) !== null
+
     if(e.keyCode === 13 && searchValue.length) {
-      window.location.replace(that.inputElement.data('pageurl') + searchValue);
+      if(searchQueryMatchesIndicatorPattern){
+        window.location.replace("/" + searchValue);
+      }
+      else{
+        window.location.replace(that.inputElement.data('pageurl') + searchValue);
+      }
     }
   });
   

--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -22,7 +22,7 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
     if(e.keyCode === 13 && searchValue.length) {
       if(searchQueryMatchesIndicatorPattern){
-        window.location.replace("/{{ site.baseurl }}/" + searchValue.split(".").join("-"));
+        window.location.replace("{{ site.baseurl }}/" + searchValue.split(".").join("-"));
       }
       else{
         window.location.replace(that.inputElement.data('pageurl') + searchValue);

--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -22,7 +22,7 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
     if(e.keyCode === 13 && searchValue.length) {
       if(searchQueryMatchesIndicatorPattern){
-        window.location.replace("/" + searchValue.split(".").join("-"));
+        window.location.replace("/{{ site.branch }}/" + searchValue.split(".").join("-"));
       }
       else{
         window.location.replace(that.inputElement.data('pageurl') + searchValue);

--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -22,7 +22,7 @@ var indicatorSearch = function(inputElement, indicatorDataStore) {
 
     if(e.keyCode === 13 && searchValue.length) {
       if(searchQueryMatchesIndicatorPattern){
-        window.location.replace("/{{ site.branch }}/" + searchValue.split(".").join("-"));
+        window.location.replace("/{{ site.baseurl }}/" + searchValue.split(".").join("-"));
       }
       else{
         window.location.replace(that.inputElement.data('pageurl') + searchValue);


### PR DESCRIPTION
If a user searches for an indicator by ID (eg. `1.1.1`), the site will take the user straight to the indicator page.

UK feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/search_by_indicator/