### PR TITLE
Move search box above the top navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,6 +33,8 @@
         <li><span data-target="search">{{ page.t.search.search }}</span></li>
       </ul>
 
+      {% include search.html %}
+      
       <ul class="nav navbar-nav menu-target contrast-switcher" id="menu">
         {%- if site.menu -%}
           {%- assign current_path_no_slash = page.url | remove: '/' -%}
@@ -55,7 +57,7 @@
         {%- endif -%}
       </ul>
 
-      {% include search.html %}
+      
 
     </nav>
   </div>

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -44,6 +44,7 @@ header {
   ul.navbar-nav {
     float: right;
     margin-top: 12px;
+    clear: both;
 
     li {
       a {


### PR DESCRIPTION
This change moves the search box above the top menu navigation in the header

UK feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/opensdg_move_search/