### PR TITLE
Keep searchbox the same size when in focus

### DIFF
--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -138,10 +138,6 @@ header {
       height: 34px;
       transition: width 0.4s;
       margin-top: 5px;
-
-      &:focus {
-        width: 350px;
-      }
     }
   }
 }


### PR DESCRIPTION
This change keeps the searchbox the same size when in focus

UK feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/static_search/