### PR TITLE
Multilingual news/posts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test.prep:
 	# Copy any custom pages into the starter.
 	mkdir starter/_goals
 	cp -r tests/goals/* starter/_goals/
+	cp -r tests/posts/* starter/_posts/
 	# Add extra languages.
 	cd starter && python scripts/batch/add_language.py es
 	cd starter && python scripts/batch/add_language.py fr fr-CA

--- a/_includes/components/post-categories.html
+++ b/_includes/components/post-categories.html
@@ -4,7 +4,7 @@
     {% for category in site.categories %}
       {% capture category_name %}{{ category | first }}{% endcapture %}
       <li>
-        <a href="{{site.baseurl}}/categories/#{{category_name|slugize}}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_name }}">{{category_name}}</a>
+        <a href="{{ page.baseurl }}categories/#{{ category_name | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_name }}">{{ category_name | t }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -6,14 +6,16 @@ layout: default
     <div class="col-xs-12">
       {{content}}
       {% for category in site.categories %}
+        {% capture category_name %}{{ category | first }}{% endcapture %}
         <div class="archive-group">
           {% capture category_name %}{{ category | first }}{% endcapture %}
           <div id="#{{ category_name | slugize }}">
-            <h4 class="category-head">{{ category_name }}</h4>
+            <h4 class="category-head">{{ category_name | t }}</h4>
             <a name="{{ category_name | slugize }}"></a>
-            {% for post in site.categories[category_name] %}
+            {% assign posts = site.categories[category_name] | where: 'language', page.language %}
+            {% for post in posts %}
             <article class="archive-item">
-              <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %-d, %Y" }}</time> - <a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a>
+              <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | t_date: "standard" }}</time> - <a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a>
             </article>
             {% endfor %}
           </div>

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -6,7 +6,6 @@ layout: default
     <div class="col-xs-12">
       {{content}}
       {% for category in site.categories %}
-        {% capture category_name %}{{ category | first }}{% endcapture %}
         <div class="archive-group">
           {% capture category_name %}{{ category | first }}{% endcapture %}
           <div id="#{{ category_name | slugize }}">
@@ -15,7 +14,7 @@ layout: default
             {% assign posts = site.categories[category_name] | where: 'language', page.language %}
             {% for post in posts %}
             <article class="archive-item">
-              <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | t_date: "standard" }}</time> - <a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a>
+              <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | t_date: "standard" }}</time> - <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
             </article>
             {% endfor %}
           </div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -5,14 +5,23 @@ layout: default
   <div class="row">
     <div class="col-md-9 push-md-3">
       {{content}}
-      {% for post in site.posts %}
+      {% assign posts = site.posts | where: 'language', page.language %}
+      {% for post in posts %}
       <article>
-        <h5><a href="{{site.baseurl}}{{ post.url }}">{{ post.title }}</a></h5>
-        <p><time datetime="{{post.date|date:"%F"}}">{{post.date|date:"%b %d, %Y"}}</time></p>
+        <h5><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h5>
+        <p><time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | t_date: 'standard' }}</time></p>
         <div class="post-excerpt">
           {{ post.excerpt | markdownify }}
         </div>
-        <p>{{post.categories | category_links}}</p>
+        {% if post.categories %}
+        <ul class="post-categories">
+          {% for category in post.categories %}
+          <li class="warning">
+            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category }}">{{ category | t }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </article>
       {% endfor %}
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,19 +6,21 @@ layout: default
     <div class="col-md-9 push-md-3">
       <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
         <h2 class="post-title" itemprop="name headline">{{ page.title }}</h2>
-        <p><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
-        
-        <div class="post-categories">
-          {% assign categories = page.categories %}
-          {% for category in categories %}
-            <a href="{{site.baseurl}}/categories/#{{category|slugize}}" title="View all posts in the {{category}} category">{{category}}</a>
-          {% unless forloop.last %}&nbsp;{% endunless %}
-          {% endfor %}
-        </div>
+        <p><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | t_date: "standard" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
 
         <div class="post-content" itemprop="articleBody">
           {{ content }}
         </div>
+
+        {% if page.categories %}
+        <ul class="post-categories">
+          {% for category in page.categories %}
+          <li class="warning">
+            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="View all posts in the {{category | t}} category">{{ category | t }}</a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </article>
     </div>
     <div class="col-md-3 pull-md-9">

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -6,6 +6,18 @@
   -o-user-select: none;
 }
 
+@mixin tags {
+  padding: 0;
+  margin: 6px 10px 0 0;
+  list-style-type: none;
+  li {
+    margin-right: 6px;
+    padding: 4px 6px;
+    display: inline;
+    border-radius: 10px;
+  }
+}
+
 @mixin indicatorcards {
   .indicator-cards {
     a {
@@ -44,15 +56,7 @@
     }
 
     .tags {
-      padding: 0;
-      margin: 6px 10px 0 0;
-      list-style-type: none;
-      li {
-        margin-right: 6px;
-        padding: 4px 6px;
-        display: inline;
-        border-radius: 10px;
-      }
+      @include tags;
     }
 
     .match {

--- a/_sass/layouts/_news.scss
+++ b/_sass/layouts/_news.scss
@@ -1,5 +1,10 @@
 .post-categories {
-  margin: 3px 0;
+  @include tags;
+  li {
+    a {
+      color: black;
+    }
+  }
 }
 
 .post-title {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,19 @@ custom_js:
   - /assets/js/custom.js
 ```
 
+### date_formats
+
+This optional setting can be used to control date formats for use in the site, such as in the news/category/post layouts. Any number date formats can be entered, using an arbitrary key, such as "standard". Each date format should have a variant for each of your languages. For example, here is how you might configure a "standard" date format:
+
+```nohighlight
+date_formats:
+  standard:
+    en: "%b %d, %Y"
+    es: "%d de %b de %Y"
+```
+
+The `%` variables in the formats correspond to the variables listed [here](https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/DateTime.html#method-i-strftime).
+
 ### frontpage_heading
 
 This optional setting can control the heading that appears on the front page.

--- a/docs/open-sdg-features.md
+++ b/docs/open-sdg-features.md
@@ -79,5 +79,5 @@ Open SDG includes the ability to post news and updates to your site. In all resp
 
 The [site starter](https://github.com/open-sdg/open-sdg-site-starter) includes 2 pages to support this functionality:
 
-* a [News page](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/news.md) which lists your posts
-* a [Categories page](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/categories.md) which lists the "categories" used in your posts
+* a News page, which lists your posts (see an [example](https://open-sdg.github.io/open-sdg-site-starter/news/) and the [code](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/news.md))
+* a Categories page which lists the "categories" used in your posts (see an [example](https://open-sdg.github.io/open-sdg-site-starter/categories/) and the [code](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/categories.md))

--- a/docs/open-sdg-features.md
+++ b/docs/open-sdg-features.md
@@ -73,3 +73,11 @@ Open SDG platforms allow data to be displayed in a way in which it can be filter
 An example of providing disaggregation filtering is [indicator 5.2.2 on the UK site](https://sustainabledevelopment-uk.github.io/5-2-2/).
 
 This feature is configured with the data files. For guidance on how to provide disaggregation filtering, see the [Data format page](https://open-sdg.readthedocs.io/en/latest/data-format/).
+
+## News, posts, and categories
+Open SDG includes the ability to post news and updates to your site. In all respects, this functionality matches what is described in [this Jekyll documentation](https://jekyllrb.com/docs/posts/).
+
+The [site starter](https://github.com/open-sdg/open-sdg-site-starter) includes 2 pages to support this functionality:
+
+* a [News page](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/news.md) which lists your posts
+* a [Categories page](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_pages/categories.md) which lists the "categories" used in your posts

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -137,3 +137,10 @@ hide_empty_metadata: true
 # Search.feature
 search_index_extra_fields:
   - un_custodian_agency
+
+# News.feature
+date_formats:
+  standard:
+    en: '%B %d, %Y'
+    es: '%d de %B de %Y'
+    fr: '%d %B %Y'

--- a/tests/data/translations/en/custom.yml
+++ b/tests/data/translations/en/custom.yml
@@ -1,2 +1,3 @@
 frontpage_heading: My custom frontpage heading
 frontpage_instructions: My custom frontpage instructions
+category: My English custom category

--- a/tests/data/translations/es/custom.yml
+++ b/tests/data/translations/es/custom.yml
@@ -1,2 +1,3 @@
 frontpage_heading: My Spanish frontpage heading
 frontpage_instructions: My Spanish frontpage instructions
+category: My Spanish custom category

--- a/tests/data/translations/fr/custom.yml
+++ b/tests/data/translations/fr/custom.yml
@@ -1,2 +1,3 @@
 frontpage_heading: My French Canadian frontpage heading
 frontpage_instructions: My French Canadian frontpage instructions
+category: My French Canadian custom category

--- a/tests/features/News.feature
+++ b/tests/features/News.feature
@@ -1,0 +1,44 @@
+Feature: News
+
+  As site visitor
+  I need to see the latest news updates
+  So that I can stay up-to-date on any developments
+
+  Scenario: There is a News page with titles, dates, excerpts, and categories.
+    Given I am on "/news"
+    Then I should see "English Test Post 1"
+    And I should see "January 10, 2020"
+    And I should see "English Test Excerpt 1"
+    And I should see "My English custom category"
+    And I should not see "Spanish Test Post 1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "Spanish Test Post 1"
+    And I should see "10 de enero de 2020"
+    And I should see "Spanish Test Excerpt 1"
+    And I should see "My Spanish custom category"
+    And I should not see "English Test Post 1"
+
+  Scenario: There is a Categories page with titles and dates, grouped by category.
+    Given I am on "/categories"
+    Then I should see "My English custom category"
+    And I should see "January 10, 2020"
+    And I should see "English Test Post 1"
+    And I should not see "My Spanish custom category"
+    And I should not see "Spanish Test Post 1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "Spanish Test Post 1"
+    And I should see "My Spanish custom category"
+    And I should see "10 de enero de 2020"
+    And I should not see "English Test Post 1"
+    And I should not see "My English custom category"
+
+  Scenario: Post pages display titles, dates, authors, body, and categories.
+    Given I am on "/news"
+    And I follow "English Test Post 1"
+    Then I should see "English Test Post 1"
+    And I should see "January 10, 2020"
+    And I should see "English Test Author 1"
+    And I should see "English body for test post 1."
+    And I should see "My English custom category"

--- a/tests/posts/2020-01-10-test-post1-en.md
+++ b/tests/posts/2020-01-10-test-post1-en.md
@@ -4,7 +4,7 @@ title: English Test Post 1
 author: English Test Author 1
 excerpt: English Test Excerpt 1
 language: en
-permalink: /test-post-1
+permalink: /test-post-1/
 categories:
   - custom.category
 ---

--- a/tests/posts/2020-01-10-test-post1-en.md
+++ b/tests/posts/2020-01-10-test-post1-en.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: English Test Post 1
+author: English Test Author 1
+excerpt: English Test Excerpt 1
+language: en
+permalink: /test-post-1
+categories:
+  - custom.category
+---
+English body for test post 1.

--- a/tests/posts/2020-01-10-test-post1-es.md
+++ b/tests/posts/2020-01-10-test-post1-es.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Spanish Test Post 1
+author: Spanish Test Author 1
+excerpt: Spanish Test Excerpt 1
+language: es
+permalink: /es/test-post-1
+categories:
+  - custom.category
+---
+Spanish body for test post 1.

--- a/tests/posts/2020-01-10-test-post1-es.md
+++ b/tests/posts/2020-01-10-test-post1-es.md
@@ -4,7 +4,7 @@ title: Spanish Test Post 1
 author: Spanish Test Author 1
 excerpt: Spanish Test Excerpt 1
 language: es
-permalink: /es/test-post-1
+permalink: /es/test-post-1/
 categories:
   - custom.category
 ---

--- a/tests/posts/2020-01-10-test-post1-fr.md
+++ b/tests/posts/2020-01-10-test-post1-fr.md
@@ -4,7 +4,7 @@ title: French Test Post 1
 author: French Test Author 1
 excerpt: French Test Excerpt 1
 language: fr
-permalink: /fr-CA/test-post-1
+permalink: /fr-CA/test-post-1/
 categories:
   - custom.category
 ---

--- a/tests/posts/2020-01-10-test-post1-fr.md
+++ b/tests/posts/2020-01-10-test-post1-fr.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: French Test Post 1
+author: French Test Author 1
+excerpt: French Test Excerpt 1
+language: fr
+permalink: /fr-CA/test-post-1
+categories:
+  - custom.category
+---
+French body for test post 1.


### PR DESCRIPTION
Fixes #433 

This updates the news-related layouts to work with multilingual sites, including translated dates. It adds automated tests for news functionality and documentation about the feature.

Visually one change included is that the post categories are styled like indicator tags. Also, the post categories have been moved to the bottom of the post (beneath the content) instead of the top (above the content).