### PR TITLE
Add link to zip file on homepage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -18,12 +18,15 @@
         {% cycle 'end row' : '', '', '', '', '', '</div>' %}
     {% endfor %}
     {% comment %}
-        If there were exactly 17 goals, "pad" it with 1 more, to make it come
-        out more symmetrically.
+        If there were exactly 17 goals, "pad" it with the download link.
     {% endcomment %}
     {% if page.goals.size == 17 %}
-        <div class="col-xs-4 col-md-2">
-            <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+        <div class="col-xs-4 col-md-2 download-all-indicators">
+            <a aria-label="{{ page.t.frontpage.download_all | escape }}"
+               title="{{ page.t.frontpage.download_all | escape }}"
+               href="{{ page.remote_data_prefix | append: '/zip/all_indicators.zip' }}">
+              <i class="fa fa-download"></i>
+            </a>
         </div>
     {% endif %}
     </div>

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -30,6 +30,19 @@ h5 + .btn-download {
   }
 }
 
+.download-all-indicators {
+  a {
+    display: block;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+    .fa-download {
+      font-size: 9em;
+      padding-top: 15%;
+    }
+  }
+}
+
 body.contrast-high {
   .btn { background: white !important; color: black !important;
     &:hover {

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -12,3 +12,6 @@ Feature: Homepage
 
   Scenario: All 17 goal icons are visible
     Then I should see 17 "goal icon" elements
+
+  Scenario: All indicator data can be downloaded as a zip file
+    Then I should see "Download all data as a zip file"


### PR DESCRIPTION
Fixes #380 

This requires the latest version of jekyll-open-sdg-plugins (1.0.0.rc19) and translations-open-sdg (1.0.0-rc5).

Here's a screenshot:

![download-all-open-sdg](https://user-images.githubusercontent.com/1319083/73580924-712e7380-4455-11ea-8523-7453021ffd0a.png)

It's using the Font Awesome [download icon](https://fontawesome.com/v4.7.0/icon/download).