### PR TITLE
Test only the minimum amount of data/metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build: clean
 	# Clone the starter repositories.
 	git clone https://github.com/open-sdg/open-sdg-site-starter.git site-starter
 	git clone https://github.com/open-sdg/open-sdg-data-starter.git data-starter
+	# To make the tests run faster, remove all the starter data.
+	rm -fr data-starter/data
+	rm -fr data-starter/meta
 	# Copy all the theme files into the site starter (using symbolic links).
 	rm -fr site-starter/_includes
 	rm -fr site-starter/_layouts

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -11,7 +11,7 @@ Feature: Goal page
     Examples:
       | PATH | TOTAL |
       | /1   | 9     |
-      | /2   | 2     |
+      | /2   | 4     |
       | /3   | 1     |
 
   Scenario: The goal-by-target layout displays correctly

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -10,26 +10,12 @@ Feature: Goal page
 
     Examples:
       | PATH | TOTAL |
-      | /1   | 14    |
-      | /2   | 13    |
-      | /3   | 27    |
-      | /4   | 11    |
-      | /5   | 14    |
-      | /6   | 11    |
-      | /7   | 6     |
-      | /8   | 17    |
-      | /9   | 12    |
-      | /10  | 11    |
-      | /11  | 15    |
-      | /12  | 13    |
-      | /13  | 8     |
-      | /14  | 10    |
-      | /15  | 14    |
-      | /16  | 23    |
-      | /17  | 25    |
+      | /1   | 9     |
+      | /2   | 2     |
+      | /3   | 1     |
 
   Scenario: The goal-by-target layout displays correctly
     Given I am on "/testing-goal-by-target"
     Then I should see "Targets"
-    And I should see 7 "goal target" elements
-    And I should see 14 "goal indicator" elements
+    And I should see 5 "goal target" elements
+    And I should see 9 "goal indicator" elements

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -10,7 +10,7 @@ Feature: Goal page
 
     Examples:
       | PATH | TOTAL |
-      | /1   | 9     |
+      | /1   | 10    |
       | /2   | 4     |
       | /3   | 1     |
 
@@ -18,4 +18,4 @@ Feature: Goal page
     Given I am on "/testing-goal-by-target"
     Then I should see "Targets"
     And I should see 5 "goal target" elements
-    And I should see 9 "goal indicator" elements
+    And I should see 10 "goal indicator" elements

--- a/tests/features/HighContrast.feature
+++ b/tests/features/HighContrast.feature
@@ -8,4 +8,4 @@ Feature: High contrast mode
     Given I am on the homepage
     And I click on "the high-contrast button"
     Then the "body.contrast-high" element should exist
-    Then I should see 3 "high-contrast goal icon" elements
+    Then I should see 4 "high-contrast goal icon" elements

--- a/tests/features/HighContrast.feature
+++ b/tests/features/HighContrast.feature
@@ -8,4 +8,4 @@ Feature: High contrast mode
     Given I am on the homepage
     And I click on "the high-contrast button"
     Then the "body.contrast-high" element should exist
-    Then I should see 17 "high-contrast goal icon" elements
+    Then I should see 3 "high-contrast goal icon" elements

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -10,8 +10,8 @@ Feature: Homepage
   Scenario: The heading text can be customised
     Then I should see "My custom frontpage heading"
 
-  Scenario: All 17 goal icons are visible
-    Then I should see 17 "goal icon" elements
+  Scenario: All available goal icons are visible
+    Then I should see 3 "goal icon" elements
 
   Scenario: The download-all button is available
     Then I should see "Download all data"

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -11,7 +11,7 @@ Feature: Homepage
     Then I should see "My custom frontpage heading"
 
   Scenario: All available goal icons are visible
-    Then I should see 3 "goal icon" elements
+    Then I should see 4 "goal icon" elements
 
   Scenario: The download-all button is available
     Then I should see "Download all data"

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -7,5 +7,5 @@ Feature: Reporting status page
   Background:
     Given I am on "/reporting-status"
 
-  Scenario: All available are listed
+  Scenario: All available goals are listed
     Then I should see 3 "goal status" elements

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -8,4 +8,4 @@ Feature: Reporting status page
     Given I am on "/reporting-status"
 
   Scenario: All available goals are listed
-    Then I should see 3 "goal status" elements
+    Then I should see 4 "goal status" elements

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -7,5 +7,5 @@ Feature: Reporting status page
   Background:
     Given I am on "/reporting-status"
 
-  Scenario: All 17 goals are listed
-    Then I should see 17 "goal status" elements
+  Scenario: All available are listed
+    Then I should see 3 "goal status" elements

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -36,7 +36,7 @@ Feature: Search
     And I fill in "the search box" with "FAO"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "1 results found"
+    Then I should see "3 results found"
 
   Scenario: The "did you mean" feature suggests alternative searches
     Given I am on the homepage

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -6,21 +6,21 @@ Feature: Search
 
   Scenario: Search index includes goals
     Given I am on the homepage
-    And I fill in "the search box" with "poverty"
+    And I fill in "the search box" with "hunger"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "6 results found"
-    And I follow "End poverty in all its forms everywhere"
-    Then I should be on "/1/"
+    Then I should see "1 results found"
+    And I follow "End hunger, achieve food security and improved nutrition and promote sustainable agriculture"
+    Then I should be on "/2/"
 
   Scenario: Search index includes indicators
     Given I am on the homepage
-    And I fill in "the search box" with "emissions"
+    And I fill in "the search box" with "mortality"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "2 results found"
-    And I follow "CO2 emission per unit of value added"
-    Then I should be on "/9-4-1/"
+    Then I should see "1 results found"
+    And I follow "Maternal mortality ratio"
+    Then I should be on "/3-1-1/"
 
   Scenario: Search index includes pages
     Given I am on the homepage
@@ -33,7 +33,7 @@ Feature: Search
 
   Scenario: Search indexes can include extra fields
     Given I am on the homepage
-    And I fill in "the search box" with "UNODA"
+    And I fill in "the search box" with "FAO"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
     Then I should see "1 results found"


### PR DESCRIPTION
The purpose of this is only to speed up the automated testing process. A side-benefit is that it also speeds up the "make serve" local development tool. The downside is that only Goals 1-3 are available on the test site, but I don't think that's necessarily a problem. This PR adjusts all the automated tests so that they work with the smaller set of indicators.

I'll see how long this PR takes to test, and edit this comment to report on how much faster it actually is.

EDIT:
* For automated PR tests, this reduces the time from 7 minutes to 5 (saves 2 minutes)
* For local development, this reduces the 'make serve' from 115 seconds to 40 seconds (saves 75 seconds)