### PR TITLE
Change the styling of the top banner on goal and indicator pages

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -10,7 +10,7 @@ h6 {
 .heading {
   a {
     background: transparent;
-    color: darkgrey;
+    color: #888;
     display: block;
     &:hover {
       text-decoration: none;

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -19,7 +19,7 @@ h6 {
   h1,
 	h2,
   h3 {
-    color: white;
+    color: black;
   }
   h1 {
     margin-top: 12px;

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -10,7 +10,7 @@ h6 {
 .heading {
   a {
     background: transparent;
-    color: white;
+    color: darkgrey;
     display: block;
     &:hover {
       text-decoration: none;

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -2,6 +2,8 @@
   $c: nth($goal-colors, $i);
   $dark-c: darken($c, 20%);
   .goal-#{$i} {
+    padding-top: 30px;
+    padding-bottom: 30px;
     &.goal-indicators {
       div {
         span {

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -2,10 +2,6 @@
   $c: nth($goal-colors, $i);
   $dark-c: darken($c, 20%);
   .goal-#{$i} {
-    &.heading {
-      background-color: $c;
-      border-bottom: 5px solid $dark-c;
-    }
     &.goal-indicators {
       div {
         span {


### PR DESCRIPTION
This change implements the following changes on the top banner:

* Set the background color to white
* Change the text on the banner to black
* Change the link text to dark grey (`#ddd`)
* Add some whitespace on the banner to give more prominence

[UK feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/opensdg1-topbanner/1/)

## Screenshots

### Goal page

![image](https://user-images.githubusercontent.com/478770/74016912-277ce600-498b-11ea-87f3-a94e36cc0cb1.png)

### Indicator page

![image](https://user-images.githubusercontent.com/478770/74016981-40859700-498b-11ea-9d70-8e09f24e8133.png)
