### PR TITLE
Use lunr-languages plugin, or simple fallback search, for non-english languages

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -9,9 +9,14 @@ var indicatorSearch = function() {
     // Add commas as an additional token separator. This is helpful because in
     // SDG metadata many times there are acronyms separated only by commas, and
     // we want to be able to search by any of the individual acronyms.
-    lunr.tokenizer.separator = /[\s\-,]+/
+    if (opensdg.language == 'en') {
+      lunr.tokenizer.separator = /[\s\-,]+/
+    }
 
     var searchIndex = lunr(function () {
+      if (opensdg.language != 'en' && lunr[opensdg.language]) {
+        this.use(lunr[opensdg.language]);
+      }
       this.ref('url');
       // Index the expected fields.
       this.field('title', getSearchFieldOptions('title'));

--- a/_includes/javascript-variables.html
+++ b/_includes/javascript-variables.html
@@ -19,6 +19,8 @@ var opensdg = {
     // Alterations go here.
     return value;
   },
+
+  language: '{{ page.language }}',
 };
 
 // For backwards compatibility, some of these might need to be global.

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -55,4 +55,8 @@ opensdg.searchIndexExtraFields = [];
 </div>
 
 <script src="https://unpkg.com/lunr/lunr.min.js"></script>
+{% if page.language != 'en' %}
+  <script src="https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/lunr.stemmer.support.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/lunr.{{ page.language }}.js"></script>
+{% endif %}
 {% include footer.html %}


### PR DESCRIPTION
Fixes #480 

This works for languages covered by lunr-languages. See here for a list: https://github.com/MihaiValentin/lunr-languages/

This also provides a fallback search functionality for any other languages.