### PR TITLE
Add an introduction banner to the frontpage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -2,10 +2,12 @@
 {% include header.html %}
 <div id="main-content" class="container goal-tiles" role="main">
 
-    <div class="site-intro">
+    {% if page.t.frontpage.intro_title and page.t.frontpage.intro_description %}
+    <div class="site-intro spacer medium">
         <h1>{{ page.t.frontpage.intro_title }}</h1>
         <div class="description">{{ page.t.frontpage.intro_description }}</div>
     </div>
+    {% endif %}
 
     {% assign country_name = site.country.name | t %}
     {% assign heading_default = page.t.frontpage.heading | replace: '%name', country_name %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -4,8 +4,8 @@
 
     {% if site.homepage_introduction_banner %}
     <div class="site-intro spacer medium">
-        <h1>{{ site.homepage_introduction_banner.title }}</h1>
-        <div class="description">{{ site.homepage_introduction_banner.description }}</div>
+        <h1>{{ site.homepage_introduction_banner.title | t }}</h1>
+        <div class="description">{{ site.homepage_introduction_banner.description | t }}</div>
     </div>
     {% endif %}
 

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,8 +3,8 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     <div class="site-intro">
-        <h1>17 Goals to transform our world</h1>
-        <div class="description">The Sustainable Development Goals are a call for action by all countries – poor, rich and middle-income – to promote prosperity while protecting the planet. They recognize that ending poverty must go hand-in-hand with strategies that build economic growth and address a range of social needs including education, health, social protection, and job opportunities, while tackling climate change and environmental protection.</div>
+        <h1>{{ page.t.frontpage.intro_title }}</h1>
+        <div class="description">{{ page.t.frontpage.intro_description }}</div>
     </div>
 
     {% assign country_name = site.country.name | t %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,10 +3,8 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     <div class="site-intro">
-        <div class="container">
-            <h1>17 Goals to transform our world</h1>
-            <div class="description">The Sustainable Development Goals are a call for action by all countries – poor, rich and middle-income – to promote prosperity while protecting the planet. They recognize that ending poverty must go hand-in-hand with strategies that build economic growth and address a range of social needs including education, health, social protection, and job opportunities, while tackling climate change and environmental protection.</div>
-        </div>
+        <h1>17 Goals to transform our world</h1>
+        <div class="description">The Sustainable Development Goals are a call for action by all countries – poor, rich and middle-income – to promote prosperity while protecting the planet. They recognize that ending poverty must go hand-in-hand with strategies that build economic growth and address a range of social needs including education, health, social protection, and job opportunities, while tackling climate change and environmental protection.</div>
     </div>
 
     {% assign country_name = site.country.name | t %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,7 +3,7 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     {% if page.t.frontpage.intro_title and page.t.frontpage.intro_description %}
-    <div class="site-intro spacer medium" style="background:url('{{site.baseurl}}/public/sdg_wheel.png')">
+    <div class="site-intro spacer medium">
         <h1>{{ page.t.frontpage.intro_title }}</h1>
         <div class="description">{{ page.t.frontpage.intro_description }}</div>
     </div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -3,7 +3,7 @@
 <div id="main-content" class="container goal-tiles" role="main">
 
     {% if page.t.frontpage.intro_title and page.t.frontpage.intro_description %}
-    <div class="site-intro spacer medium">
+    <div class="site-intro spacer medium" style="background:url('{{site.baseurl}}/public/sdg_wheel.png')">
         <h1>{{ page.t.frontpage.intro_title }}</h1>
         <div class="description">{{ page.t.frontpage.intro_description }}</div>
     </div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -2,9 +2,16 @@
 {% include header.html %}
 <div id="main-content" class="container goal-tiles" role="main">
 
+    <div class="site-intro">
+        <div class="container">
+            <h1>17 Goals to transform our world</h1>
+            <div class="description">The Sustainable Development Goals are a call for action by all countries – poor, rich and middle-income – to promote prosperity while protecting the planet. They recognize that ending poverty must go hand-in-hand with strategies that build economic growth and address a range of social needs including education, health, social protection, and job opportunities, while tackling climate change and environmental protection.</div>
+        </div>
+    </div>
+
     {% assign country_name = site.country.name | t %}
     {% assign heading_default = page.t.frontpage.heading | replace: '%name', country_name %}
-    <h1 class="spacer medium">{{ site.frontpage_heading | default: heading_default | t }}</h1>
+    <h2 class="spacer medium">{{ site.frontpage_heading | default: heading_default | t }}</h2>
 
     {% assign instructions_default = page.t.frontpage.instructions | replace_first: '%before_link', '<span id="jump-to-search"><a>' | replace_first: '%after_link', '</a></span>' | replace_first: '%name', country_name %}
     <p class="spacer medium">{{ site.frontpage_instructions | default: instructions_default | t }}</p>

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,10 +1,10 @@
 .site-intro{
     .container{
         background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-        background-position: left center;
+        background-position: right center;
         background-repeat: no-repeat;
         background-size: 150px;
-        padding: 30px 30px 30px 200px;
+        padding: 30px 200px 30px 0;
 
         .description{
             margin-top:  30px;

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,14 +1,10 @@
 .site-intro{
     .container{
-        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-        background-position: right center;
-        background-repeat: no-repeat;
-        background-size: 150px;
-        padding: 30px 200px 30px 0;
 
         .description{
             margin-top:  30px;
             font-size:  21px;
+            padding-right: 200px;
         }
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -4,7 +4,7 @@
         background-position: left center;
         background-repeat: no-repeat;
         background-size: 150px;
-        padding: 30px 0 30px 200px;
+        padding: 30px 30px 30px 200px;
 
         .description{
             margin-top:  30px;

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,0 +1,5 @@
+.site-intro{
+    .container{
+        padding-left: 200px;
+    }
+}

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -3,14 +3,14 @@
     min-height: 200px;
 
     background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-    background-position: right top;
+    background-position: right 30px top;
     background-size: 200px;
     background-repeat: no-repeat;
 
     .description{
         margin-top:  30px;
         font-size:  21px;
-        
+
         text-align: justify;
         text-justify: inter-word;
     }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,5 +1,14 @@
 .site-intro{
     .container{
-        padding-left: 200px;
+        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+        background-position: left center;
+        background-repeat: no-repeat;
+        background-size: 150px;
+        padding: 30px 0 30px 200px;
+
+        .description{
+            margin-top:  30px;
+            font-size:  18px;
+        }
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,16 +1,16 @@
 .site-intro{
+    padding-right: 300px;
+    min-height: 200px;
+
+    background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+    background-position: right top;
+    background-size: 200px;
+    background-repeat: no-repeat;
 
     .description{
         margin-top:  30px;
         font-size:  21px;
-        padding-right: 300px;
-        min-height: 200px;
-
-        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-        background-position: right top;
-        background-size: 200px;
-        background-repeat: no-repeat;
-
+        
         text-align: justify;
         text-justify: inter-word;
     }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -8,6 +8,10 @@
         text-justify: inter-word;
     }
 
+    @media only screen and (max-width: 700px) {
+        padding: 0 30px 30px 30px 30px;
+    }
+
     @media only screen and (min-width: 700px) {
         padding-right: 300px;
         min-height: 180px;

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,9 +1,14 @@
 .site-intro{
-    .container{
 
-        .description{
-            margin-top:  30px;
-            font-size:  21px;
-        }
+    .description{
+        margin-top:  30px;
+        font-size:  21px;
+        padding-right: 300px;
+        min-height: 200px;
+
+        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+        background-position: right top;
+        background-size: 200px;
+        background-repeat: no-repeat;
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -4,12 +4,6 @@
         .description{
             margin-top:  30px;
             font-size:  21px;
-            padding-right: 200px;
-
-            background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-            background-position: right top;
-            background-repeat: no-repeat;
-            background-size: 150px;
         }
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,12 +1,5 @@
 .site-intro{
-    padding-right: 300px;
-    min-height: 180px;
-
-    background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-    background-position: right 60px top;
-    background-size: 180px;
-    background-repeat: no-repeat;
-
+    
     .description{
         margin-top:  30px;
         font-size:  21px;
@@ -14,4 +7,14 @@
         text-align: justify;
         text-justify: inter-word;
     }
+
+    @media only screen and (min-width: 700px) {
+        padding-right: 300px;
+        min-height: 180px;
+
+        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+        background-position: right 60px top;
+        background-size: 180px;
+        background-repeat: no-repeat;
+    }    
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -9,7 +9,7 @@
     }
 
     @media only screen and (max-width: 700px) {
-        padding: 0 30px 30px 30px 30px;
+        padding: 0 30px 30px 30px;
     }
 
     @media only screen and (min-width: 700px) {

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -1,10 +1,10 @@
 .site-intro{
     padding-right: 300px;
-    min-height: 200px;
+    min-height: 180px;
 
     background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
-    background-position: right 30px top;
-    background-size: 200px;
+    background-position: right 60px top;
+    background-size: 180px;
     background-repeat: no-repeat;
 
     .description{

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -8,7 +8,7 @@
 
         .description{
             margin-top:  30px;
-            font-size:  18px;
+            font-size:  21px;
         }
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -8,10 +8,6 @@
         text-justify: inter-word;
     }
 
-    @media only screen and (max-width: 700px) {
-        padding: 0 30px 30px 30px;
-    }
-
     @media only screen and (min-width: 700px) {
         padding-right: 300px;
         min-height: 180px;

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -5,6 +5,11 @@
             margin-top:  30px;
             font-size:  21px;
             padding-right: 200px;
+
+            background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+            background-position: right top;
+            background-repeat: no-repeat;
+            background-size: 150px;
         }
     }
 }

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -12,7 +12,7 @@
         padding-right: 300px;
         min-height: 180px;
 
-        background: url('https://sdgplatform-assets.s3.us-east-2.amazonaws.com/SDG+Wheel_Transparent.png');
+        background: url('../img/SDG Wheel_Transparent-01.png');
         background-position: right 60px top;
         background-size: 180px;
         background-repeat: no-repeat;

--- a/_sass/layouts/_homeintro.scss
+++ b/_sass/layouts/_homeintro.scss
@@ -10,5 +10,8 @@
         background-position: right top;
         background-size: 200px;
         background-repeat: no-repeat;
+
+        text-align: justify;
+        text-justify: inter-word;
     }
 }

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -26,3 +26,4 @@
 @import "layouts/news";
 @import "layouts/reporting_status";
 @import "layouts/search";
+@import "layouts/homeintro";


### PR DESCRIPTION
This change adds an introductory paragraph to the frontpage, right above the goal tiles.

The banner text is retrieved by translations, so the text for both the title and description must be added to `frontpage.yml` in order for the banner to show up (which also makes it optional).

Example `frontpage.yml`:
```yml
intro_title: 17 Goals to transform our world
intro_description: The Sustainable Development Goals are a call for action by all countries – poor, rich and middle-income – to promote prosperity while protecting the planet. They recognize that ending poverty must go hand-in-hand with strategies that build economic growth and address a range of social needs including education, health, social protection, and job opportunities, while tackling climate change and environmental protection.
```

If either of these is missing in translations, the banner will not be displayed. 

This change also changes the `<country> data for Sustainable Development Goal indicators` heading from `<h1>` to `<h2>`.

[Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/opensdg1-introbanner/)

# Screenshots

## Desktop

### Before

![image](https://user-images.githubusercontent.com/478770/74443318-dda06e00-4e6a-11ea-9e29-8dd4daa15342.png)

### After

![image](https://user-images.githubusercontent.com/478770/74443220-b77ace00-4e6a-11ea-846d-4c69e3a4f35c.png)

## Mobile

### Before

![image](https://user-images.githubusercontent.com/478770/74443538-44258c00-4e6b-11ea-8e81-5ddb87a621e5.png)

### After

![image](https://user-images.githubusercontent.com/478770/74443578-57d0f280-4e6b-11ea-842f-1284b7f6a222.png)
