### PR TITLE
Set aria-label on search button

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -2,7 +2,7 @@
   <form action="{{ page.baseurl }}search">
     <input name="q" id="indicator_search" title="{{ page.t.search.search }}" />
     <label for="indicator_search">
-      <button id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false" aria-label={{ page.t.search.search }}></i></button><span>{{ page.t.search.search }}:</span>
+      <button aria-label="{{ page.t.search.search }}" id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button><span>{{ page.t.search.search }}:</span>
     </label>
   </form>
 </div>


### PR DESCRIPTION
This fixes something that pa11y (see #484) is complaining about on all pages. I basically moved the aria-label from the icon to the button element. Hopefully this still satisfies the UK accessibility standards. Would love your feedback @SavvasStephanides.