### PR TITLE
Bulk download link beneath the homepage grid

### DIFF
--- a/_includes/components/download-all-data.html
+++ b/_includes/components/download-all-data.html
@@ -1,0 +1,13 @@
+<div class="zip-download-container">
+    <a href="{{ page.remote_data_prefix }}/zip/all_indicators.zip"
+       class="btn btn-primary btn-download" aria-describedby="zip-download-info">
+        {{ page.t.frontpage.download_all }}
+    </a>
+    <div id="zip-download-info">
+        {{ page.t.frontpage.zip_file }} - {{ site.data.zip.size_human }}
+        {% if site.data.zip.timestamp %}
+            <br>
+            {{ page.t.metadata_fields.national_data_update_url }} - {{ site.data.zip.timestamp | t_date: 'standard' }}
+        {% endif %}
+    </div>
+</div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -35,5 +35,15 @@
         </div>
     {% endif %}
     </div>
+    <div class="zip-download-container">
+        <a href="{{ page.remote_data_prefix | append: '/zip/all_indicators.zip' }}" class="btn btn-primary btn-download">
+            {{ page.t.frontpage.download_all }} - {{ site.data.zip.size_human }}
+        </a>
+        {% if site.data.zip.timestamp %}
+        <div class="zip-date">
+            {{ page.t.metadata_fields.national_data_update_url }} - {{ site.data.zip.timestamp | t_date: 'standard' }}
+        </div>
+        {% endif %}
+    </div>
 </div>
 {% include footer.html %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -35,15 +35,6 @@
         </div>
     {% endif %}
     </div>
-    <div class="zip-download-container">
-        <a href="{{ page.remote_data_prefix | append: '/zip/all_indicators.zip' }}" class="btn btn-primary btn-download">
-            {{ page.t.frontpage.download_all }} - {{ site.data.zip.size_human }}
-        </a>
-        {% if site.data.zip.timestamp %}
-        <div class="zip-date">
-            {{ page.t.metadata_fields.national_data_update_url }} - {{ site.data.zip.timestamp | t_date: 'standard' }}
-        </div>
-        {% endif %}
-    </div>
+    {% include components/download-all-data.html %}
 </div>
 {% include footer.html %}

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -32,8 +32,9 @@ h5 + .btn-download {
 
 .zip-download-container {
   margin-top: 20px;
-  .zip-date {
-    padding: 10px;
+  #zip-download-info {
+    margin-top: 5px;
+    margin-left: 10px;
   }
 }
 

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -30,6 +30,13 @@ h5 + .btn-download {
   }
 }
 
+.zip-download-container {
+  margin-top: 20px;
+  .zip-date {
+    padding: 10px;
+  }
+}
+
 body.contrast-high {
   .btn { background: white !important; color: black !important;
     &:hover {

--- a/tests/data/config_data.yml
+++ b/tests/data/config_data.yml
@@ -18,5 +18,5 @@ src_dir: ''
 
 # Links to Git repositories with translation data.
 translations:
-  - https://github.com/open-sdg/translations-un-sdg.git@1.0.0-rc1
-  - https://github.com/open-sdg/translations-open-sdg.git@1.0.0-rc5
+  - https://github.com/open-sdg/translations-un-sdg.git@master
+  - https://github.com/open-sdg/translations-open-sdg.git@master

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -12,3 +12,6 @@ Feature: Homepage
 
   Scenario: All 17 goal icons are visible
     Then I should see 17 "goal icon" elements
+
+  Scenario: The download-all button is available
+    Then I should see "Download all data"


### PR DESCRIPTION
Fixes #380 

This depends on:
* The latest version of jekyll-open-sdg-plugins: 1.0.0.rc22
* The latest translations from [open-sdg/translations-open-sdg](https://github.com/open-sdg/translations-open-sdg)

The file size and last updated date come from the sdg-build library.

## Screenshots:

English:
![bulk-download-english](https://user-images.githubusercontent.com/1319083/74494874-41935880-4ea4-11ea-9e29-9c34bd368cf1.png)

French:
![bulk-download-french](https://user-images.githubusercontent.com/1319083/74494884-46580c80-4ea4-11ea-94ec-db8c2e4181e3.png)

Full page:
![screenshot-127 0 0 1_4000-2020 02 13-21_06_49](https://user-images.githubusercontent.com/1319083/74495110-e7df5e00-4ea4-11ea-82c0-8cf246547eeb.png)
