### PR TITLE
Black text for tab links

### DIFF
--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -378,16 +378,16 @@
     border: 0;
     padding: 0;
     margin: 5px;
-    
+
     &:not(#goal-18){
       box-shadow: 5px 5px 5px 0px rgba(5,5,5,0.3);
-  
+
       &:hover{
         box-shadow: 5px 5px 5px 0px rgba(5,5,5,0.6);
       }
     }
   }
-  
+
   &.goal-indicators {
     @include indicatorcards;
     &.goal-by-target {
@@ -413,6 +413,7 @@
       border: none;
       a {
         border: none;
+        color: black;
       }
       &.active {
         a {


### PR DESCRIPTION
This fixes part of #488 by giving the tabs black text, for more contrast.

@SavvasStephanides @phillipgardiner

![Screenshot from 2020-02-14 11-40-18](https://user-images.githubusercontent.com/1319083/74550166-ed798a00-4f1e-11ea-81aa-563287bf9ab9.png)

