### PR TITLE
Look for translated builds when rendering the no-javascript headline

### DIFF
--- a/_includes/components/headline.html
+++ b/_includes/components/headline.html
@@ -1,4 +1,7 @@
 {% assign sdg_headline_data = site.data.headlines[page.indicator.slug] %}
+{% if site.data[page.language].headlines[page.indicator.slug] %}
+  {% assign sdg_headline_data = site.data[page.language].headlines[page.indicator.slug] %}
+{% endif %}
 
 <div id="headlineTable">
 


### PR DESCRIPTION
We have a data table that is rendered in HTML, but hidden with javascript. However, it wasn't compatible with the "translated builds" approach, where the data repo has separate builds for each language. This fixes that.

Side benefit: this fixes the pa11y complaint about layout tables mentioned in #488 