### PR TITLE
Remove goal line from indicator banner

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -14,12 +14,7 @@
         </a>
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
-        <h1>
-          <a href="{{ page.goal.url }}">
-            <span class="hidden-sm hidden-md hidden-lg">{{ page.t.general.goal }} {{ page.goal.number }}: </span>{{ page.goal.name }}
-          </a>
-        </h1>
-        <h2>{{ page.t.general.indicator }} {{ page.indicator.number }}: {{ page.indicator.name }}</h2>
+        <h1>{{ page.t.general.indicator }} {{ page.indicator.number }}: {{ page.indicator.name }}</h1>
       </div>
     </div>
   </div>

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -48,6 +48,7 @@ h6 {
   &.indicator {
     h1 {
       font-size: 24px;
+      line-height: normal;
 
       @media only screen and (max-width: 480px) {
         font-size: 0.813em;


### PR DESCRIPTION
Removes the goal line from indicator page and changes the indicator title to `<h1>`

**Note**: I tried to align the title vertically, but haven't been able to in a way that would fit both short and long titles. Let's leave it at that at the moment and revisit later.

## Screenshot:

![image](https://user-images.githubusercontent.com/478770/74924333-28ba0400-53ca-11ea-865d-ad64c12d22d6.png)
