### PR TITLE
Allow translation of indicator content

### DIFF
--- a/_includes/components/indicator-content.html
+++ b/_includes/components/indicator-content.html
@@ -1,3 +1,3 @@
 <div id="page-content">
-  {{ page.indicator.page_content | markdownify }}
+  {{ page.indicator.page_content | strip | t | markdownify }}
 </div>


### PR DESCRIPTION
This is to support the translation of the indicator content (in the metadata files, the stuff below the `---`).

This would allow something like this:

```
my_field: my value
my_other_field: my other value
---
indicator_descriptions.1-1-1
```

Then if there was a translation file called "indicator_descriptions.yml" containing an item for "1-1-1", then that translation would get used for the indicator content.

This is a quick fix to help with the fact that the "subfolder" approach to translation was removed recently. We should follow up with:
1. Tests and documentation for this functionality
2. Revisiting whether the subfolder approach could be supported