### PR TITLE
Fix for the edge case of local data with untranslated builds

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -33,8 +33,13 @@ $(function() {
           $(obj).append($('<img />').attr('src', $(obj).data('img')));
       });
 
+      var remoteUrl = '/comb/' + domData.id + '.json';
+      if (opensdg.remoteDataBaseUrl !== '/') {
+        remoteUrl = opensdg.remoteDataBaseUrl + remoteUrl;
+      }
+
       $.ajax({
-        url: opensdg.remoteDataBaseUrl + '/comb/' + domData.id + '.json',
+        url: remoteUrl,
         success: function(res) {
 
           $('.async-loading').remove();


### PR DESCRIPTION
This resolves an issue with the edge case of a site using local data (instead of remote data) and untranslated builds. The problem was the the javascript variable `remoteDataBaseUrl` was just `/`, and this was getting concatenated with `/comb/etc...` to make: `//comb/etc...`. Browsers were interpreting that as `https://comb/etc...` was was causing those requests to fail.