### PR TITLE
Documentation link fixes and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/site/Gemfile.lock
 site-starter
 data-starter
 venv
+/site
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,19 @@ build: clean
 	# Install the Node.js depedencies.
 	cd tests && npm install
 
+build.docs:
+	pip install mkdocs
+	mkdocs build
+
 serve: build
 	cd site-starter && bundle exec jekyll serve --skip-initial-build
 
 serve.detached: build
 	# Serve the Jekyll site at http://127.0.0.1:4000/
 	cd site-starter && bundle exec jekyll serve --detach --skip-initial-build
+
+serve.docs: build.docs
+	mkdocs serve
 
 test.html: serve.detached
 	# HTML proofer.
@@ -58,5 +65,9 @@ test.accessibility: serve.detached
 	cd tests && npx pa11y-ci --config accessibility/pa11yci-desktop.json
 	cd tests && npx pa11y-ci --config accessibility/pa11yci-mobile.json
 	cd tests && npx pa11y-ci --config accessibility/pa11yci-contrast.json
+
+test.docs: build.docs
+	gem install html-proofer
+	htmlproofer site
 
 test: test.html test.features test.accessibility

--- a/docs/about.md
+++ b/docs/about.md
@@ -19,10 +19,10 @@ An NRP tool facilitates national reporting by improving communication:
 
 # What does the NRP cost?
 
-Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](https://open-sdg.readthedocs.io/en/latest/quick-start/) for details on how to set up the platform using free automation from [CircleCI](https://circleci.com) and free hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
+Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](./quick-start.md) for details on how to set up the platform using free automation from [CircleCI](https://circleci.com) and free hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
 
 # What are the IT requirements?
 
-For a high-level summary of the technologies used by this platform, see [here](https://open-sdg.readthedocs.io/en/latest/requirements/).
+For a high-level summary of the technologies used by this platform, see [here](./requirements.md).
 
-There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed [here](https://open-sdg.readthedocs.io/en/latest/development/).
+There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed [here](./development.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 In addition to the [usual Jekyll configuration options](https://jekyllrb.com/docs/configuration/), there are many options specific to Open SDG. These are detailed below, along with usage examples.
 
-_Note about "strings": Many of the settings detailed here contain human-readable "strings" (ie, text). In most cases, they can be replaced by [translation keys](https://open-sdg.readthedocs.io/en/latest/translation/) for better multilingual support. For example, "Indicator" could be replaced with "general.indicator"._
+_Note about "strings": Many of the settings detailed here contain human-readable "strings" (ie, text). In most cases, they can be replaced by [translation keys](./translation.md) for better multilingual support. For example, "Indicator" could be replaced with "general.indicator"._
 
 ## Required settings
 
@@ -45,7 +45,7 @@ environment: staging
 
 ### footer_menu
 
-This **required** setting controls the footer menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](https://open-sdg.readthedocs.io/en/latest/translation/).
+This **required** setting controls the footer menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](./translation.md).
 
 The following example provides a footer menu matching older versions of Open SDG, which included options for social media and email contacts.
 
@@ -100,7 +100,7 @@ metadata_edit_url: http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md
 
 ### menu
 
-This **required** setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](https://open-sdg.readthedocs.io/en/latest/translation/).
+This **required** setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](./translation.md).
 
 ```nohighlight
 menu:
@@ -124,7 +124,7 @@ plugins:
 
 ### remote_data_prefix
 
-This **required** setting tells the platform where to find your hosted [data repository](https://open-sdg.readthedocs.io/en/latest/glossary/#data-repository).
+This **required** setting tells the platform where to find your hosted [data repository](./glossary/#data-repository).
 
 ```nohighlight
 remote_data_prefix: https://my-github-org.github.io/my-data-repository
@@ -148,7 +148,7 @@ remote_theme: open-sdg/open-sdg
 
 ### analytics
 
-This optional setting can contain another (indented) setting, `ga_prod`, which should be a [Google Analytics tracking ID](https://support.google.com/analytics/answer/1008080?hl=en#GAID). If these settings are used, usage statistics will be sent to Google Analytics. For more information about this, see the [analytics](https://open-sdg.readthedocs.io/en/latest/analytics/) page.
+This optional setting can contain another (indented) setting, `ga_prod`, which should be a [Google Analytics tracking ID](https://support.google.com/analytics/answer/1008080?hl=en#GAID). If these settings are used, usage statistics will be sent to Google Analytics. For more information about this, see the [analytics](./analytics.md) page.
 
 ```nohighlight
 analytics:
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to use [this](https://open-sdg.readthedocs.io/en/latest/configuration/#custom_css) approach instead.
+NOTE: This approach is deprecated. It is recommended to use [this](./configuration/#custom_css) approach instead.
 
 ### custom_js
 
@@ -285,7 +285,7 @@ While the "keys" above, such as "national" and "global", are arbitrary, the "sou
 
 ### non_global_metadata
 
-This optional setting can be used to control the text of the tab containing non-global metadata. The default text is "National Metadata", but if you are implementing a sub-national platform, you could use "Local Metadata", or similar. Note that using a [translation key](https://open-sdg.readthedocs.io/en/latest/translation/) is recommended for better multilingual support.
+This optional setting can be used to control the text of the tab containing non-global metadata. The default text is "National Metadata", but if you are implementing a sub-national platform, you could use "Local Metadata", or similar. Note that using a [translation key](./translation.md) is recommended for better multilingual support.
 
 ```nohighlight
 non_global_metadata: indicator.national_metadata
@@ -331,7 +331,7 @@ search_index_extra_fields:
 
 ### sharethis_property
 
-This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](https://open-sdg.readthedocs.io/en/latest/social-media-sharing/) page.
+This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](./social-media-sharing.md) page.
 
 ### frontpage_introduction_banner
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ plugins:
 
 ### remote_data_prefix
 
-This **required** setting tells the platform where to find your hosted [data repository](./glossary/#data-repository).
+This **required** setting tells the platform where to find your hosted [data repository](./glossary.md#data-repository).
 
 ```nohighlight
 remote_data_prefix: https://my-github-org.github.io/my-data-repository
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to use [this](./configuration/#custom_css) approach instead.
+NOTE: This approach is deprecated. It is recommended to use [this](./configuration.md#custom_css) approach instead.
 
 ### custom_js
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -17,7 +17,7 @@ Open SDG includes two alternative [layouts](https://jekyllrb.com/docs/step-by-st
 1. [`goal`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal.html) - Indicators are displayed in a responsive grid
 1. [`goal-by-target`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal-by-target.html) - Targets on the left, and indicators on the right
 
-If you are using the `create_goals` setting, you can change the layout as described [here](./configuration/#create_goals).
+If you are using the `create_goals` setting, you can change the layout as described [here](./configuration.md#create_goals).
 
 Otherwise you can set the layout by adjusting the [front matter](https://jekyllrb.com/docs/front-matter/) of the goal file. For example, to use the goal-by-target layout, you would need this in the goal's front matter:
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -4,7 +4,7 @@
 
 Jekyll configuration is stored at the root of the site repository in a YAML file called `_config.yml`. General documentation about Jekyll configuration can be found [here](https://jekyllrb.com/docs/configuration/).
 
-In addition to general Jekyll configurations, Open SDG needs some specific configurations. For more information on these, please see the [configuration page](https://open-sdg.readthedocs.io/en/latest/configuration/).
+In addition to general Jekyll configurations, Open SDG needs some specific configurations. For more information on these, please see the [configuration page](./configuration.md).
 
 ## Optional features
 
@@ -17,7 +17,7 @@ Open SDG includes two alternative [layouts](https://jekyllrb.com/docs/step-by-st
 1. [`goal`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal.html) - Indicators are displayed in a responsive grid
 1. [`goal-by-target`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal-by-target.html) - Targets on the left, and indicators on the right
 
-If you are using the `create_goals` setting, you can change the layout as described [here](https://open-sdg.readthedocs.io/en/latest/configuration/#create_goals).
+If you are using the `create_goals` setting, you can change the layout as described [here](./configuration/#create_goals).
 
 Otherwise you can set the layout by adjusting the [front matter](https://jekyllrb.com/docs/front-matter/) of the goal file. For example, to use the goal-by-target layout, you would need this in the goal's front matter:
 
@@ -124,7 +124,7 @@ The following variables can be used on any page:
 
 * `page.t`
 
-    The translations for the current language. More detail on this is available [here](https://open-sdg.readthedocs.io/en/latest/configuration/).
+    The translations for the current language. More detail on this is available [here](./configuration.md).
 
     Usage example - printing the translation of the word "Goal" (which is available with the key "goal" in the "general" group:
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,6 +1,6 @@
 <h1>Data sources</h1>
 
-Out of the box, the [data starter](https://github.com/open-sdg/open-sdg-data-starter) includes the data and metadata as [CSV](https://open-sdg.readthedocs.io/en/latest/data-format/) and [YAML](https://open-sdg.readthedocs.io/en/latest/metadata-format/) files, respectively.
+Out of the box, the [data starter](https://github.com/open-sdg/open-sdg-data-starter) includes the data and metadata as [CSV](./data-format.md) and [YAML](./metadata-format.md) files, respectively.
 
 ## SDG Build
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,7 +73,7 @@ The pre-processing works fine for version anything greater than or equal to 3.4.
 
 ## Building the site
 
-After you have gone through the [quick start](https://open-sdg.readthedocs.io/en/latest/quick-start/) to implement the platform, you will be ready to `clone` the site repository. On the command line, change your directory (`cd`) to the relevant area of your computer where you wish to store the website files and type:
+After you have gone through the [quick start](./quick-start.md) to implement the platform, you will be ready to `clone` the site repository. On the command line, change your directory (`cd`) to the relevant area of your computer where you wish to store the website files and type:
 
 ```
 git clone https://github.com/{#NAME}/open-sdg-site-starter.git

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,12 +2,12 @@
 
 ## Is the Open SDG platform free to reuse?
 
-Yes. Open SDG is open source and is free for anyone to reuse. See the [What does the NRP cost?](https://open-sdg.readthedocs.io/en/latest/about/#what-does-the-nrp-cost) section for
+Yes. Open SDG is open source and is free for anyone to reuse. See the [What does the NRP cost?](./about.md#what-does-the-nrp-cost) section for
 more information.
 
 ## How do I copy the Open SDG platform?
 
-The [Quick start](https://open-sdg.readthedocs.io/en/latest/quick-start/) guide gives technical
+The [Quick start](./quick-start.md) guide gives technical
 instructions on the quickest way to get a copy of the open-sdg platform up and running.
 
 ## How long would it take to set up a copy of Open SDG
@@ -17,7 +17,7 @@ With the right skills, it should take less than a day to set up a standard copy,
 ## Can the Open SDG platform be customised?
 
 Yes. Copies of Open SDG can be adapted to local needs – technical developer resource will
-be needed to do this. The [Customisation](https://open-sdg.readthedocs.io/en/latest/customisation/) section gives detailed technical guidance.
+be needed to do this. The [Customisation](./customisation.md) section gives detailed technical guidance.
 
 ## Are maps available in Open SDG?
 
@@ -25,7 +25,7 @@ Yes. Maps can be automatically generated from the data if GeoCodes are included 
 - [Map for UK indicator 3.a.1](https://sustainabledevelopment-uk.github.io/3-a-1/) ('Prevalence of tobacco use among persons aged 15 years and older')
 - [Map for Rwanda indicator 1.2.1](https://sustainabledevelopment-rwanda.github.io/1-2-1/) (1.2.1: 'Proportion of population living below the national poverty line')
 
-Maps from other systems or publications can also be embedded. See the [Maps](https://open-sdg.readthedocs.io/en/latest/maps/) section
+Maps from other systems or publications can also be embedded. See the [Maps](./maps.md) section
 for more information, and the UK [Mapping guidance](https://github.com/ONSdigital/sdg-indicators/wiki/Mapping) for step-by-step instructions on setting up a map.
 
 ## Can content from other websites be embedded in Open SDG?
@@ -37,7 +37,7 @@ Yes, content can be embedded into the indicator page using HTML.
 ## Can the Open SDG platform be translated into other languages?
 
 Yes – Open SDG has been designed to be multilingual. As well as English, many elements
-are already available in French and Spanish. The [Translation](https://open-sdg.readthedocs.io/en/latest/translation/) section gives more technical information, including
+are already available in French and Spanish. The [Translation](./translation.md) section gives more technical information, including
 how to add a language.
 
 ## Can I use Open SDG with other databases?
@@ -68,14 +68,14 @@ With the **double-repository** approach, site content is kept separate from data
 2. Activity logs on the site repository do not appear on the data repository, and vice versa. This helps make the process of maintenance and review easier.
 3. Having the data and site in separate repositories adds a layer of protection against accidental version control problems.
 
-The double-repository approach is detailed in the [Quick Start](https://open-sdg.readthedocs.io/en/latest/quick-start/) with the help of the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) template projects.
+The double-repository approach is detailed in the [Quick Start](./quick-start.md) with the help of the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) template projects.
 
 By contrast, with the **single-repository** approach, site content and data/metadata are contained with the same single repository. This approach can be useful for local testing and development, as it simplifies the architecture of the platform. The benefits include:
 
 1. Faster quick-start process
 2. Simpler workflow for testing out changes locally
 
-The single-repository is exemplified in the [simple starter](https://github.com/open-sdg/open-sdg-simpler-starter) template project.
+The single-repository is exemplified in the [simple starter](https://github.com/open-sdg/open-sdg-simple-starter) template project.
 
 ## Can content from other websites be embedded in Open SDG?
 

--- a/docs/making-updates.md
+++ b/docs/making-updates.md
@@ -13,7 +13,7 @@ These steps have four pre-requisites:
     If you do not already have one, go [here](https://github.com) now to sign up for your free account.
 4. A working implementation of Open SDG (hereafter referred to as the "staging site")
 
-    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are [here](../quick-start/).
+    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are [here](./quick-start.md).
 
 ## GitHub.com login
 

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -1,10 +1,10 @@
 <h1>Metadata format</h1>
 
-In your [data repository](https://open-sdg.readthedocs.io/en/latest/glossary/#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
+In your [data repository](./glossary/#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
 
 ## Note about translation keys
 
-Metadata values can either be filled in with normal text ("My field value") or with [translation keys](https://open-sdg.readthedocs.io/en/latest/glossary/#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
+Metadata values can either be filled in with normal text ("My field value") or with [translation keys](./glossary/#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
 
 As an optional shorthand, if the translation key is in the `data` group, then the group can be omitted. For example, the translation key `data.female` can be written as simply `female`.
 
@@ -221,7 +221,7 @@ You may think that it would make more sense for the `label` property above to co
 
 ## Metadata tabs
 
-The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](https://open-sdg.readthedocs.io/en/latest/configuration/#metadata_tabs).
+The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](./configuration/#metadata_tabs).
 
 ## Reserved metadata fields
 

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -1,10 +1,10 @@
 <h1>Metadata format</h1>
 
-In your [data repository](./glossary/#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
+In your [data repository](./glossary.md#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
 
 ## Note about translation keys
 
-Metadata values can either be filled in with normal text ("My field value") or with [translation keys](./glossary/#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
+Metadata values can either be filled in with normal text ("My field value") or with [translation keys](./glossary.md#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
 
 As an optional shorthand, if the translation key is in the `data` group, then the group can be omitted. For example, the translation key `data.female` can be written as simply `female`.
 
@@ -221,7 +221,7 @@ You may think that it would make more sense for the `label` property above to co
 
 ## Metadata tabs
 
-The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](./configuration/#metadata_tabs).
+The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](./configuration.md#metadata_tabs).
 
 ## Reserved metadata fields
 

--- a/docs/open-sdg-features.md
+++ b/docs/open-sdg-features.md
@@ -17,7 +17,7 @@ Some examples of data being shown on maps are:
 * [3.2.1 on Rwanda's Open SDG platform](https://sustainabledevelopment-rwanda.github.io/3-2-1/)
 * [3.c.1 on UK's Open SDG platform](https://sustainabledevelopment-uk.github.io/3-a-1/)
 
-For guidance on how set up your site and data in order to be able to display data on a map (as well as on a chart and table), see the [Maps page](https://open-sdg.readthedocs.io/en/latest/maps/).
+For guidance on how set up your site and data in order to be able to display data on a map (as well as on a chart and table), see the [Maps page](./maps.md).
 
 ## Embedded content
 Another way of showing data/information on a indicator page is by embedding content from other websites/applications.
@@ -26,14 +26,14 @@ An examples of embedded content as main content is a [macro-economic dashboard o
 
 Content can also be embedded on a data tab next to the Chart and Table tabs.
 
-Embedded features are configured in the metadata files. See the [*Embedded feature metadata* section on the Metadata format page](https://open-sdg.readthedocs.io/en/latest/metadata-format/#embedded-feature-metadata) for more guidance.
+Embedded features are configured in the metadata files. See the [*Embedded feature metadata* section on the Metadata format page](./metadata-format.md#embedded-feature-metadata) for more guidance.
 
 ## Targets on goal pages
 By default, targets are not shown on the goal pages. An example of this is the [UK Open SDG platform](https://sustainabledevelopment-uk.github.io/1/).
 
 However, Open SDG platforms can be configured to show targets on the goal pages. An example of this is [Armenia's Open SDG platform](https://armstat.github.io/sdg-site-armenia/1/)
 
-For guidance on how to display targets on your goal pages, see the [*Optional feature: Goal page layouts* section on the Customisations page](https://open-sdg.readthedocs.io/en/latest/customisation/#optional-feature-goal-page-layouts).
+For guidance on how to display targets on your goal pages, see the [*Optional feature: Goal page layouts* section on the Customisations page](./customisation/#optional-feature-goal-page-layouts).
 
 ## Reporting status options
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, **Not applicable**, can be used.
@@ -44,7 +44,7 @@ An example of removing one of the options is the [UK's Reporting status page](ht
 
 An example of using the **Not applicable** option is [Rwanda's Reporting status page](https://sustainabledevelopment-rwanda.github.io/reporting-status/).
 
-For details, see [here](https://open-sdg.readthedocs.io/en/latest/reporting-status/).
+For details, see [here](./reporting-status/).
 
 ## Display data for national indicators as well as global indicators
 One way of displaying national indicators on an Open SDG platform is by adding them in the same section as the global indicators and tagging them as national. An example of this is [Armenia's platform](https://armstat.github.io/sdg-site-armenia/1/).
@@ -54,7 +54,7 @@ Another way of displaying national indicators is by having them on separate page
 ## Contrast button
 By default, two buttons show to allow you to toggle between different contrast levels - the [US site](https://sdg.data.gov/) is an example of using this option. However, you can choose to user a more accessible contrast toggle button - the [UK site](https://sustainabledevelopment-uk.github.io/) is an example of using this option.
 
-For guidance on how to use the more accessible contrast button, see the [*contrast_type* section on the Configuration page](https://open-sdg.readthedocs.io/en/latest/configuration/#contrast_type).
+For guidance on how to use the more accessible contrast button, see the [*contrast_type* section on the Configuration page](./configuration/#contrast_type).
 
 ## Add pages
 By default, there are four pages which show in the menu bar: Reporting status, About, Guidance and FAQ.
@@ -65,14 +65,14 @@ An example of menu items being added is [UK's site](https://sustainabledevelopme
 
 Even though only four pages are linked to in the menu by default, there are other pages provided for use (e.g. Contacts, News) as well as the option to easily create your own pages.
 
-For guidance on how to add more pages to the menu, see the [*menu* section of the Configuration page](https://open-sdg.readthedocs.io/en/latest/configuration/#menu).
+For guidance on how to add more pages to the menu, see the [*menu* section of the Configuration page](./configuration/#menu).
 
 ## Filter by disaggregation
 Open SDG platforms allow data to be displayed in a way in which it can be filtered by disaggregation. This allows user to compare different breakdowns for a particular indicator.
 
 An example of providing disaggregation filtering is [indicator 5.2.2 on the UK site](https://sustainabledevelopment-uk.github.io/5-2-2/).
 
-This feature is configured with the data files. For guidance on how to provide disaggregation filtering, see the [Data format page](https://open-sdg.readthedocs.io/en/latest/data-format/).
+This feature is configured with the data files. For guidance on how to provide disaggregation filtering, see the [Data format page](./data-format.md).
 
 ## News, posts, and categories
 Open SDG includes the ability to post news and updates to your site. In all respects, this functionality matches what is described in [this Jekyll documentation](https://jekyllrb.com/docs/posts/).

--- a/docs/open-sdg-features.md
+++ b/docs/open-sdg-features.md
@@ -33,7 +33,7 @@ By default, targets are not shown on the goal pages. An example of this is the [
 
 However, Open SDG platforms can be configured to show targets on the goal pages. An example of this is [Armenia's Open SDG platform](https://armstat.github.io/sdg-site-armenia/1/)
 
-For guidance on how to display targets on your goal pages, see the [*Optional feature: Goal page layouts* section on the Customisations page](./customisation/#optional-feature-goal-page-layouts).
+For guidance on how to display targets on your goal pages, see the [*Optional feature: Goal page layouts* section on the Customisations page](./customisation.md#optional-feature-goal-page-layouts).
 
 ## Reporting status options
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, **Not applicable**, can be used.
@@ -44,7 +44,7 @@ An example of removing one of the options is the [UK's Reporting status page](ht
 
 An example of using the **Not applicable** option is [Rwanda's Reporting status page](https://sustainabledevelopment-rwanda.github.io/reporting-status/).
 
-For details, see [here](./reporting-status/).
+For details, see [here](./reporting-status.md).
 
 ## Display data for national indicators as well as global indicators
 One way of displaying national indicators on an Open SDG platform is by adding them in the same section as the global indicators and tagging them as national. An example of this is [Armenia's platform](https://armstat.github.io/sdg-site-armenia/1/).
@@ -54,7 +54,7 @@ Another way of displaying national indicators is by having them on separate page
 ## Contrast button
 By default, two buttons show to allow you to toggle between different contrast levels - the [US site](https://sdg.data.gov/) is an example of using this option. However, you can choose to user a more accessible contrast toggle button - the [UK site](https://sustainabledevelopment-uk.github.io/) is an example of using this option.
 
-For guidance on how to use the more accessible contrast button, see the [*contrast_type* section on the Configuration page](./configuration/#contrast_type).
+For guidance on how to use the more accessible contrast button, see the [*contrast_type* section on the Configuration page](./configuration.md#contrast_type).
 
 ## Add pages
 By default, there are four pages which show in the menu bar: Reporting status, About, Guidance and FAQ.
@@ -65,7 +65,7 @@ An example of menu items being added is [UK's site](https://sustainabledevelopme
 
 Even though only four pages are linked to in the menu by default, there are other pages provided for use (e.g. Contacts, News) as well as the option to easily create your own pages.
 
-For guidance on how to add more pages to the menu, see the [*menu* section of the Configuration page](./configuration/#menu).
+For guidance on how to add more pages to the menu, see the [*menu* section of the Configuration page](./configuration.md#menu).
 
 ## Filter by disaggregation
 Open SDG platforms allow data to be displayed in a way in which it can be filtered by disaggregation. This allows user to compare different breakdowns for a particular indicator.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -112,6 +112,6 @@ At this point, any new proposed file changes in the repositories will trigger th
 
 ## Possible next steps?
 
-1. [Add data and metadata to the data repository](../making-updates/)
-1. [Tweak and customise the site repository as needed](../customisation/)
-1. [Set up separate "production" environments](../deployment/)
+1. [Add data and metadata to the data repository](./making-updates.md)
+1. [Tweak and customise the site repository as needed](./customisation.md)
+1. [Set up separate "production" environments](./deployment.md)

--- a/docs/reporting-status.md
+++ b/docs/reporting-status.md
@@ -6,11 +6,11 @@ Out of the box, Open SDG provides a page showing the "reporting status" of all t
 
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, such as **Not applicable**, can be used.
 
-The options available can be controlled by adjusting the [schema file](https://open-sdg.readthedocs.io/en/latest/metadata-format/#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
+The options available can be controlled by adjusting the [schema file](./metadata-format/#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
 
 ## Color-coding
 
-The horizontal bars on the reporting status page have color-coded segments. The default options mentioned above are already color-coded for green, yellow, and red, respectively. That color-coding is controlled in CSS code in [this section](https://github.com/open-sdg/open-sdg/blob/master/assets/css/default.scss#L640).
+The horizontal bars on the reporting status page have color-coded segments. The default options mentioned above are already color-coded for green, yellow, and red, respectively. That color-coding is controlled in CSS code in [this file](https://github.com/open-sdg/open-sdg/blob/master/_sass/layouts/_reporting_status.scss).
 
 To color-code your custom options, add your own CSS code (such as in a `custom.scss` file) using a class name that is the same as the option value. For example, if your custom options are configured like so:
 

--- a/docs/reporting-status.md
+++ b/docs/reporting-status.md
@@ -6,7 +6,7 @@ Out of the box, Open SDG provides a page showing the "reporting status" of all t
 
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, such as **Not applicable**, can be used.
 
-The options available can be controlled by adjusting the [schema file](./metadata-format/#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
+The options available can be controlled by adjusting the [schema file](./metadata-format.md#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
 
 ## Color-coding
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -6,7 +6,7 @@ This platform is designed to be multilingual, and leverages the translations bei
 
 This document provides an overview of how the platform accomplishes this, and how it can be extended.
 
-Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](https://open-sdg.readthedocs.io/en/latest/glossary/#translation-keys) for a definition.
+Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](./glossary/#translation-keys) for a definition.
 
 ## Translation data
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -6,7 +6,7 @@ This platform is designed to be multilingual, and leverages the translations bei
 
 This document provides an overview of how the platform accomplishes this, and how it can be extended.
 
-Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](./glossary/#translation-keys) for a definition.
+Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](./glossary.md#translation-keys) for a definition.
 
 ## Translation data
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,7 +30,7 @@ In most cases, the worst that will happen is that you will miss out on any impro
 
 1. When possible, avoid overriding files. Prefer configuration changes and style changes, if possible, over overrides of files.
 2. If an override is necessary, try to override `_includes` files before overriding `_layouts` files. The `_includes` files are smaller and easier to maintain.
-3. When performing an upgrade, check the [changelog](./changelog/) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
+3. When performing an upgrade, check the [changelog](./changelog.md) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
 
 ### jekyll-open-sdg-plugins
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,7 +30,7 @@ In most cases, the worst that will happen is that you will miss out on any impro
 
 1. When possible, avoid overriding files. Prefer configuration changes and style changes, if possible, over overrides of files.
 2. If an override is necessary, try to override `_includes` files before overriding `_layouts` files. The `_includes` files are smaller and easier to maintain.
-3. When performing an upgrade, check the [changelog](https://open-sdg.readthedocs.io/en/latest/changelog/) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
+3. When performing an upgrade, check the [changelog](./changelog/) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
 
 ### jekyll-open-sdg-plugins
 


### PR DESCRIPTION
This changes a lot of links in the documentation to relative instead of absolute. It also adds to the Makefile some commands for serving/testing the documentation.

A follow-up ticket could easily make the documentation tests part of the normal PR tests.