### PR TITLE
Make the introduction banner work in high contrast

### DIFF
--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -160,3 +160,7 @@ body.long {
     }
   }
 }
+
+body.contrast-high .site-intro .description{
+  color: white;
+}

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -7,6 +7,10 @@ Feature: Homepage
   Background:
     Given I am on the homepage
 
+  Scenario: The introduction banner appears on the page
+    Then I should see "My frontpage introduction banner title"
+    And I should see "My frontpage introduction banner description"
+
   Scenario: The heading text can be customised
     Then I should see "My custom frontpage heading"
 

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -129,3 +129,7 @@ date_formats:
     en: '%B %d, %Y'
     es: '%d de %B de %Y'
     fr: '%d %B %Y'
+
+frontpage_introduction_banner:
+  title: My frontpage introduction banner title
+  description: My frontpage introduction banner description    


### PR DESCRIPTION
This sets the introduction banner text to white while in high contrast, fixing the bad contrast issue

### Screenshot:

Before:

![image](https://user-images.githubusercontent.com/478770/77328077-f75b8d80-6d13-11ea-9eda-36f016c945b9.png)

After:

![image](https://user-images.githubusercontent.com/478770/77327656-74d2ce00-6d13-11ea-907c-b4907a98907f.png)
