### PR TITLE
Various fixes to make more elements flush to the left

### DIFF
--- a/_sass/components/_disclaimer.scss
+++ b/_sass/components/_disclaimer.scss
@@ -10,7 +10,7 @@
   .alert {
     color: #3D3D3D;
     margin-bottom: 0;
-    padding: 10px;
+    padding: 10px 10px 10px 0;
     a {
       color: #3D3D3D;
     }

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -32,6 +32,9 @@ h5 + .btn-download {
 
 .zip-download-container {
   margin-top: 20px;
+  a.btn {
+    margin-left: 10px;
+  }
   #zip-download-info {
     margin-top: 5px;
     margin-left: 10px;

--- a/_sass/layouts/_footer.scss
+++ b/_sass/layouts/_footer.scss
@@ -25,8 +25,14 @@ footer {
     }
   }
 
-  #footerLinks ul li{
-    display: inline-block !important;
-    margin: 3px 9px !important;
+  #footerLinks ul {
+    padding-left: 0;
+    li {
+      display: inline-block;
+      margin: 3px 9px;
+      &:first-child {
+        margin-left: 0px;
+      }
+    }
   }
 }

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -28,6 +28,10 @@ header {
   display: block;
   width: 75%;
   max-width: 300px;
+  padding: 15px;
+  @media screen and (min-width: 769px) {
+    padding: 15px 15px 15px 0;
+  }
   img {
     width: 100%;
   }
@@ -98,6 +102,13 @@ header {
       &:not(.contrast) {
         a:hover{
           border-bottom: 2px solid $menu-hover-border-bottom;
+        }
+      }
+    }
+    @media screen and (min-width: 769px) {
+      > li:first-child {
+        a {
+          margin-left: 0;
         }
       }
     }

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -377,7 +377,7 @@
     width: calc(100% - 10px);
     border: 0;
     padding: 0;
-    margin: 5px;
+    margin: 5px 10px 5px 0;
 
     &:not(#goal-18){
       box-shadow: 5px 5px 5px 0px rgba(5,5,5,0.3);


### PR DESCRIPTION
Fixes #567 
Fixes #568

To fix the items above and preempt other left-alignment concerns, this is intended to make several elements flush to the left margin, at all breakpoints:
1. The "alpha" disclaimer
2. The main logo
3. The homepage goal grid
4. The main menu (it goes to the left at a particular screen width)
5. The footer menu

Note that on mobile, the background for the disclaimer and main menu need to extend all the way to the edge of the screen.

## Mobile:

![expert-review--left-alignment--mobile](https://user-images.githubusercontent.com/1319083/77668713-282d0400-6f5a-11ea-9b59-8fbd9fd5c544.png)

## Tablet:

![expert-review--left-alignment--tablet](https://user-images.githubusercontent.com/1319083/77668727-2c592180-6f5a-11ea-9f40-5a2018d8f0ea.png)

## Desktop:

![expert-review--left-alignment--desktop](https://user-images.githubusercontent.com/1319083/77668744-2feca880-6f5a-11ea-835b-57baf10e632a.png)


