### PR TITLE
Move sources into single column and add more test details

### DIFF
--- a/_includes/components/sources.html
+++ b/_includes/components/sources.html
@@ -12,7 +12,7 @@
   {% for i in (1..n_sources) %}
     {% assign src_active = "source_active_" | append: i %}
     {% assign src_scope = "source_" | append: i %}
-    <div class="col-md-6">
+    <div>
       {% if n_sources > 1 %}
         <h4>{{ page.t.indicator.source }} {{ i }}</h4>
       {% endif %}

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -195,7 +195,7 @@
         </ul>
 
         <!-- Tab panes -->
-        <div class="tab-content">
+        <div class="tab-content metadata-tabs">
           {% if site.metadata_tabs %}
             {% for tab in site.metadata_tabs %}
             {% assign tab_key = tab[0] %}

--- a/_sass/components/_metadata.scss
+++ b/_sass/components/_metadata.scss
@@ -1,0 +1,7 @@
+.metadata-tabs {
+  #sources {
+    td {
+      min-width: 60%;
+    }
+  }
+}

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -18,6 +18,7 @@
 @import "components/notices";
 @import "components/spacers";
 @import "components/tabs";
+@import "components/metadata";
 @import "components/high_contrast";
 @import "layouts/header";
 @import "layouts/footer";

--- a/tests/data/meta/1-1-1.md
+++ b/tests/data/meta/1-1-1.md
@@ -16,18 +16,17 @@ published: true
 reporting_status: complete
 sdg_goal: '1'
 source_active_1: true
-source_active_2: false
+source_active_2: true
 source_active_3: false
-source_active_4: true
-source_active_5: true
-source_active_6: true
-source_organisation_1: My organisation
-source_url_3: Link to source
-source_url_text_1: Link to source
-source_url_text_2: Link to Source
-source_url_text_4: Link to source
-source_url_text_5: Link to source
-source_url_text_6: Link to source
+source_organisation_1: My first organisation
+source_organisation_2: My second organisation
+source_organisation_3: My third organisation
+source_url_1: https://example.com
+source_url_2: https://example.com
+source_url_3: https://example.com
+source_url_text_1: Link to first source
+source_url_text_2: Link to second source
+source_url_text_3: Link to third source
 target_name: global_targets.1-1-title
 target_id: '1.1'
 title: Untitled

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -28,7 +28,12 @@ Feature: Indicator
     And I click on "the National metadata tab"
     Then I should see "Data last updated"
     And I click on "the Sources metadata tab"
-    And I should see "My organisation"
+    Then I should see "My first organisation"
+    And I should see "Link to first source"
+    And I should see "My second organisation"
+    And I should see "Link to second source"
+    And I should not see "My third organisation"
+    And I should not see "Link to third source"
 
   Scenario: The metadata tab titles and blurbs can both be configured
     Then I should see "My national metadata title"


### PR DESCRIPTION
This is in response to the feedback in #504. It converts the Sources tab into a single column, and tries to ensure the field/value widths are uniform. (It also adds a bit more detailed tests.)

![sources-single-column](https://user-images.githubusercontent.com/1319083/77756669-09844700-7006-11ea-9e17-faeb29c12cf0.png)
