### PR TITLE
High-contrast fixes for chart grids/ticks

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -73,46 +73,55 @@ var accessibilitySwitcher = function() {
     }).html(getContrastToggleLabel(contrast).replace(" ", "<br/>")).click(function() {
       setActiveContrast($(this).data('contrast'));
       imageFix(contrast);
+      broadcastContrastChange(contrast, this);
     })));
   });
-  
-function getContrastToggleLabel(identifier){
-  var contrastType = "{{ site.contrast_type }}"
-  if(contrastType === "long") {
-    if(identifier === "default"){	
-      return translations.header.default_contrast; 	
-    }	
-    else if(identifier === "high"){	
-      return translations.header.high_contrast;	
+
+  function broadcastContrastChange(contrast, elem) {
+    var event = new CustomEvent('contrastChange', {
+      bubbles: true,
+      detail: contrast
+    });
+    elem.dispatchEvent(event);
+  }
+
+  function getContrastToggleLabel(identifier){
+    var contrastType = "{{ site.contrast_type }}"
+    if(contrastType === "long") {
+      if(identifier === "default"){
+        return translations.header.default_contrast;
+      }
+      else if(identifier === "high"){
+        return translations.header.high_contrast;
+      }
+    }
+    else {
+      return 'A'
     }
   }
-  else {
-    return 'A'
-  }
-}
 
-function getContrastToggleTitle(identifier){	
-  if(identifier === "default"){	
-    return translations.header.disable_high_contrast; 	
-  }	
-  else if(identifier === "high"){	
-    return translations.header.enable_high_contrast;	
-  }	
-}
-  
-  
-function imageFix(contrast) {
-  if (contrast == 'high')  {
-    _.each($('img:not([src*=high-contrast])'), function(goalImage){
-      if ($(goalImage).attr('src').slice(0, 35) != "https://platform-cdn.sharethis.com/") {
-      $(goalImage).attr('src', $(goalImage).attr('src').replace('img/', 'img/high-contrast/'));
-      }})
-  } else {
-    // Remove high-contrast
-    _.each($('img[src*=high-contrast]'), function(goalImage){
-      $(goalImage).attr('src', $(goalImage).attr('src').replace('high-contrast/', ''));
-    })
+  function getContrastToggleTitle(identifier){
+    if(identifier === "default"){
+      return translations.header.disable_high_contrast;
+    }
+    else if(identifier === "high"){
+      return translations.header.enable_high_contrast;
+    }
   }
-};
+
+
+  function imageFix(contrast) {
+    if (contrast == 'high')  {
+      _.each($('img:not([src*=high-contrast])'), function(goalImage){
+        if ($(goalImage).attr('src').slice(0, 35) != "https://platform-cdn.sharethis.com/") {
+        $(goalImage).attr('src', $(goalImage).attr('src').replace('img/', 'img/high-contrast/'));
+        }})
+    } else {
+      // Remove high-contrast
+      _.each($('img[src*=high-contrast]'), function(goalImage){
+        $(goalImage).attr('src', $(goalImage).attr('src').replace('high-contrast/', ''));
+      })
+    }
+  };
 
 };

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -353,6 +353,8 @@ var indicatorView = function (model, options) {
   this.createPlot = function (chartInfo) {
 
     var that = this;
+    var gridColor = that.getGridColor();
+    var tickColor = that.getTickColor();
 
     var chartConfig = {
       type: this._model.graphType,
@@ -368,12 +370,19 @@ var indicatorView = function (model, options) {
           xAxes: [{
             maxBarThickness: 150,
             gridLines: {
-              color: '#ddd',
-            }
+              color: gridColor,
+            },
+            ticks: {
+              fontColor: tickColor,
+            },
           }],
           yAxes: [{
+            gridLines: {
+              color: gridColor,
+            },
             ticks: {
-              suggestedMin: 0
+              suggestedMin: 0,
+              fontColor: tickColor,
             },
             scaleLabel: {
               display: this._model.selectedUnit ? translations.t(this._model.selectedUnit) : this._model.measurementUnit,
@@ -409,6 +418,16 @@ var indicatorView = function (model, options) {
     this.alterChartConfig(chartConfig, chartInfo);
 
     this._chartInstance = new Chart($(this._rootElement).find('canvas'), chartConfig);
+
+    window.addEventListener('contrastChange', function(e) {
+      var gridColor = that.getGridColor(e.detail);
+      var tickColor = that.getTickColor(e.detail);
+      view_obj._chartInstance.options.scales.yAxes[0].gridLines.color = gridColor;
+      view_obj._chartInstance.options.scales.yAxes[0].ticks.fontColor = tickColor;
+      view_obj._chartInstance.options.scales.xAxes[0].gridLines.color = gridColor;
+      view_obj._chartInstance.options.scales.xAxes[0].ticks.fontColor = tickColor;
+      view_obj._chartInstance.update();
+    });
 
     Chart.pluginService.register({
       afterDraw: function(chart) {
@@ -475,6 +494,23 @@ var indicatorView = function (model, options) {
     });
 
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
+  };
+
+  this.getGridColor = function(contrast=null) {
+    return this.isHighContrast(contrast) ? '#222' : '#ddd';
+  };
+
+  this.getTickColor = function(contrast=null) {
+    return this.isHighContrast(contrast) ? '#fff' : '#000';
+  }
+
+  this.isHighContrast = function(contrast=null) {
+    if (contrast) {
+      return contrast === 'high';
+    }
+    else {
+      return $('body').hasClass('contrast-high');
+    }
   };
 
   this.toCsv = function (tableData) {

--- a/_includes/polyfills.html
+++ b/_includes/polyfills.html
@@ -1,2 +1,2 @@
-<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=Promise%2CArray.prototype.forEach%2CString.prototype.includes%2CURLSearchParams"></script>
+<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=Promise%2CArray.prototype.forEach%2CString.prototype.includes%2CURLSearchParams%2CCustomEvent"></script>
 <script crossorigin="anonymous" src="https://cdnjs.cloudflare.com/ajax/libs/javascript-canvas-to-blob/3.15.0/js/canvas-to-blob.min.js"></script>

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -570,10 +570,10 @@ body.contrast-high {
   #legend {
     li {
       color: white !important;
-      &:first-child {
-        .swatch {
-          background-color: white !important;
-        }
+      border: 1px solid transparent;
+      &:hover {
+        background: transparent !important;
+        border: 1px solid white;
       }
     }
   }


### PR DESCRIPTION
Fixes #579 

This sets the following colors:

Normal contrast:
* Grid lines: `#ddd`
* Axis labels: `#000`

![expert-review--chart-contrast--normal](https://user-images.githubusercontent.com/1319083/77772070-eebdcc80-701d-11ea-90aa-5fe6f075db78.png)

High contrast:
* Grid lines: `#222`
* Axis labels: `#fff`

![expert-review--chart-contrast--high](https://user-images.githubusercontent.com/1319083/77772083-f4b3ad80-701d-11ea-9ffe-5f44094bbbc5.png)

Let me know if I should tweak those colors.

Side notes:
1. This fixes a problem where we were setting the swatch for headlines to white, but it needs to stay grey.
2. This fixes a problem where the swatch hover color was bad in high-contrast mode
3. There are a few random white-space/indentation fixes in accessibility.js.
4. There is still an issue with the headline color, which right now is hardcoded to 777777 (see [here](https://github.com/open-sdg/open-sdg/blob/master/_includes/assets/js/indicatorModel.js#L192)). Really that should be white/black depending on the contrast mode, probably. But at least it appears to be meeting the accessibility minimums. I didn't change that here because it is a difficult problem would take some time to figure out.