### PR TITLE
Move units above subcategories and promote to H4 instead of H5

### DIFF
--- a/_includes/components/units-template.html
+++ b/_includes/components/units-template.html
@@ -1,6 +1,6 @@
 <script type="text/template" id="units_template">
   <% if(units.length) { %>
-    <h5>{{ page.t.indicator.units_type }}</h5>
+    <h4>{{ page.t.indicator.units_type }}</h4>
     <% _.each(units, function(unitsItem, index) { %>
       <% var checked = (selectedUnit) ? (selectedUnit==unitsItem) : (index==0); %>
       <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <%=checked ? 'checked' : ''%> /> <%=translations.t(unitsItem)%></label>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -82,6 +82,7 @@
 
     {% if show_data %}
     <div id="indicator-sidebar" class="col-md-3">
+      <div id="units"></div>
       <div id="toolbar">
         <span id="series-help">
           <h4>{{ page.t.indicator.sub_categories }}</h4>
@@ -92,7 +93,6 @@
           <p class="async-loading" data-img="{{ site.baseurl }}/assets/img/loading-small.gif"></p>
         </div>
       </div>
-      <div id="units"></div>
     </div>
     <div id="indicator-main" class="col-md-9">
     {% else %}

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -288,6 +288,7 @@
   }
   #units {
     clear: left;
+    margin-bottom: 20px;
 
     label {
       font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
Fixes #601 

This is a simple change, but I also changed the "Units type" header from an H5 to an H4, because otherwise it would be smaller than "Sub-categories" (which is an H4). Here's a screenshot:

![units-above-subcategories](https://user-images.githubusercontent.com/1319083/78165006-b0a71b00-7418-11ea-8934-0309497c13b2.png)
