### PR TITLE
Fix error message for missing map_layers

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -63,8 +63,8 @@
     this.currentDisaggregation = 0;
 
     // Require at least one geoLayer.
-    if (!options.mapLayers.length) {
-      console.log('Map disabled, no mapLayers in options.');
+    if (!options.mapLayers || !options.mapLayers.length) {
+      console.log('Map disabled - please add "map_layers" in site configuration.');
       return;
     }
 


### PR DESCRIPTION
This makes sure the map_layers warning actually appears, and also makes it more specific.