### PR TITLE
Documentation link audit and translation docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ test.docs: build.docs
 	gem install html-proofer
 	htmlproofer site
 
-test: test.html test.features test.accessibility
+test: test.html test.features test.accessibility test.docs

--- a/docs/about.md
+++ b/docs/about.md
@@ -19,10 +19,10 @@ An NRP tool facilitates national reporting by improving communication:
 
 # What does the NRP cost?
 
-Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](./quick-start.md) for details on how to set up the platform using free automation from [CircleCI](https://circleci.com) and free hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
+Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](quick-start.md) for details on how to set up the platform using free automation from [CircleCI](https://circleci.com) and free hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
 
 # What are the IT requirements?
 
-For a high-level summary of the technologies used by this platform, see [here](./requirements.md).
+For a high-level summary of the technologies used by this platform, see [here](requirements.md).
 
-There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed [here](./development.md).
+There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed [here](development.md).

--- a/docs/about.md
+++ b/docs/about.md
@@ -19,7 +19,7 @@ An NRP tool facilitates national reporting by improving communication:
 
 # What does the NRP cost?
 
-Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](quick-start.md) for details on how to set up the platform using free automation from [CircleCI](https://circleci.com) and free hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
+Absolutely nothing! You are free to use this platform and modify it in any way you feel is necessary to facilitate your country's or region's needs. This NRP is built soley upon open-source technologies and so there are no software costs. The only hardware costs are the machine(s) you choose to use to create your own version of this site. See the [quick start](quick-start.md) for details on how to set up the platform using free automation and hosting from [Github](https://github.com). Minimal staff time to copy, adapt, populate, and maintain the platform is also needed, and can be handled by part-time web developers, statisticians, and managers.
 
 # What are the IT requirements?
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -23,6 +23,6 @@ Absolutely nothing! You are free to use this platform and modify it in any way y
 
 # What are the IT requirements?
 
-For a high-level summary of the technologies used by this platform, see [here](requirements.md).
+For a high-level summary of the technologies used by this platform, see the [requirements page](requirements.md).
 
-There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed [here](development.md).
+There are ultimately two contributing users of the NRP: data managers/providers and developers. Data managers and providers do not need anything other than a computer with an internet connection and a web browser. Developers will need more software to be able to build the website on their local machine to test any changes they make before making these changes live; these requirements are detailed on the [development page](development.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@
         This contains all the content, configuration, and customisations that
         are specific to your implementation. A starter template is available <a href="https://github.com/open-sdg/open-sdg-site-starter">here</a>.
         <br><br>
-        This functions as your own custom <a href="https://jekyllrb.org">Jekyll</a>
+        This functions as your own custom <a href="https://jekyllrb.com">Jekyll</a>
         site.
       </span>
     </div>
@@ -56,8 +56,7 @@
       Automation tool
       <i tabindex="0" class="fa fa-info-circle"></i>
       <span class="info">
-        Any automation tool, such as <a href="../automation/circle-ci/">CircleCI</a>
-        or <a href="../automation/travis-ci/">TravisCI</a>, performs configured actions in response to events or schedules.
+        Any automation tool, such as <a href="../automation/github-actions/">GitHub Actions</a>, performs configured actions in response to events or schedules.
       </span>
     </div>
     <div class="node global row4" id="jekyll">

--- a/docs/automation/travis-ci.md
+++ b/docs/automation/travis-ci.md
@@ -20,10 +20,10 @@ Other than these very minor issues, TravisCI makes a good choice for Open SDG.
 
 ## Set-up
 
-TravisCI's tight integration with Github repositories makes it relatively simple to set up. More details can be found [here](https://docs.travis-ci.com/user/tutorial/).
+TravisCI's tight integration with Github repositories makes it relatively simple to set up. More details can be found in [the official TravisCI documentation](https://docs.travis-ci.com/user/tutorial/).
 
 ## Usage
 
-Using TravisCI involves putting a configuration file (`.travis.yml`) in your repository. For details on getting started, see [here](https://docs.travis-ci.com/).
+Using TravisCI involves putting a configuration file (`.travis.yml`) in your repository. For details on getting started, see the [TravisCI documentation](https://docs.travis-ci.com/).
 
 Note that although TravisCI has [dedicated support for Github Pages](https://docs.travis-ci.com/user/deployment/pages/), this approach is discouraged because it is coupled to a particular user's Github account.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,7 +190,7 @@ This optional setting can be used to automatically create 4 platform-dependent p
 * the search results page
 * the reporting status page
 
-Without this setting, you will need a file for each of these 4 pages (per language), in a `_pages` folder. This setting can include more advanced settings (see [here](https://github.com/open-sdg/jekyll-open-sdg-plugins/blob/master/lib/jekyll-open-sdg-plugins/create_pages.rb#L18)) but can also simply be set to `true`.
+Without this setting, you will need a file for each of these 4 pages (per language), in a `_pages` folder. This setting can include more advanced settings (see this [jekyll-open-sdg-plugins code](https://github.com/open-sdg/jekyll-open-sdg-plugins/blob/master/lib/jekyll-open-sdg-plugins/create_pages.rb#L18)) but can also simply be set to `true`.
 
 ```nohighlight
 create_pages: true
@@ -227,7 +227,7 @@ date_formats:
     es: "%d de %b de %Y"
 ```
 
-The `%` variables in the formats correspond to the variables listed [here](https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/DateTime.html#method-i-strftime).
+The `%` variables in the formats correspond to the variables listed in this [Ruby DateTime documentation](https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/DateTime.html#method-i-strftime).
 
 ### frontpage_heading
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation.md/#adding-custom-css).
+NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation.md#adding-custom-css).
 
 ### custom_js
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to use [this](configuration.md#custom_css) approach instead.
+NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation/#adding-custom-css).
 
 ### custom_js
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 In addition to the [usual Jekyll configuration options](https://jekyllrb.com/docs/configuration/), there are many options specific to Open SDG. These are detailed below, along with usage examples.
 
-_Note about "strings": Many of the settings detailed here contain human-readable "strings" (ie, text). In most cases, they can be replaced by [translation keys](./translation.md) for better multilingual support. For example, "Indicator" could be replaced with "general.indicator"._
+_Note about "strings": Many of the settings detailed here contain human-readable "strings" (ie, text). In most cases, they can be replaced by [translation keys](translation.md) for better multilingual support. For example, "Indicator" could be replaced with "general.indicator"._
 
 ## Required settings
 
@@ -45,7 +45,7 @@ environment: staging
 
 ### footer_menu
 
-This **required** setting controls the footer menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](./translation.md).
+This **required** setting controls the footer menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](translation.md).
 
 The following example provides a footer menu matching older versions of Open SDG, which included options for social media and email contacts.
 
@@ -100,7 +100,7 @@ metadata_edit_url: http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md
 
 ### menu
 
-This **required** setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](./translation.md).
+This **required** setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](translation.md).
 
 ```nohighlight
 menu:
@@ -124,7 +124,7 @@ plugins:
 
 ### remote_data_prefix
 
-This **required** setting tells the platform where to find your hosted [data repository](./glossary.md#data-repository).
+This **required** setting tells the platform where to find your hosted [data repository](glossary.md#data-repository).
 
 ```nohighlight
 remote_data_prefix: https://my-github-org.github.io/my-data-repository
@@ -148,7 +148,7 @@ remote_theme: open-sdg/open-sdg
 
 ### analytics
 
-This optional setting can contain another (indented) setting, `ga_prod`, which should be a [Google Analytics tracking ID](https://support.google.com/analytics/answer/1008080?hl=en#GAID). If these settings are used, usage statistics will be sent to Google Analytics. For more information about this, see the [analytics](./analytics.md) page.
+This optional setting can contain another (indented) setting, `ga_prod`, which should be a [Google Analytics tracking ID](https://support.google.com/analytics/answer/1008080?hl=en#GAID). If these settings are used, usage statistics will be sent to Google Analytics. For more information about this, see the [analytics](analytics.md) page.
 
 ```nohighlight
 analytics:
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to use [this](./configuration.md#custom_css) approach instead.
+NOTE: This approach is deprecated. It is recommended to use [this](configuration.md#custom_css) approach instead.
 
 ### custom_js
 
@@ -285,7 +285,7 @@ While the "keys" above, such as "national" and "global", are arbitrary, the "sou
 
 ### non_global_metadata
 
-This optional setting can be used to control the text of the tab containing non-global metadata. The default text is "National Metadata", but if you are implementing a sub-national platform, you could use "Local Metadata", or similar. Note that using a [translation key](./translation.md) is recommended for better multilingual support.
+This optional setting can be used to control the text of the tab containing non-global metadata. The default text is "National Metadata", but if you are implementing a sub-national platform, you could use "Local Metadata", or similar. Note that using a [translation key](translation.md) is recommended for better multilingual support.
 
 ```nohighlight
 non_global_metadata: indicator.national_metadata
@@ -331,7 +331,7 @@ search_index_extra_fields:
 
 ### sharethis_property
 
-This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](./social-media-sharing.md) page.
+This optional setting creates a [ShareThis](https://sharethis.com/platform/share-buttons/) widget along the left side of every page. It should be the [property id](https://sharethis.com/support/faq/how-do-i-find-my-property-id/) for your ShareThis account. For more information about this, see the [sharing](social-media-sharing.md) page.
 
 ### frontpage_introduction_banner
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation.md#adding-custom-css).
+NOTE: This approach is deprecated. It is recommended to instead [put your custom styles into a _sass folder](customisation.md#adding-custom-css).
 
 ### custom_js
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ custom_css:
   - /assets/css/custom.css
 ```
 
-NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation/#adding-custom-css).
+NOTE: This approach is deprecated. It is recommended to intstead [put your custom styles into a _sass folder](customisation.md/#adding-custom-css).
 
 ### custom_js
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -4,7 +4,7 @@
 
 Jekyll configuration is stored at the root of the site repository in a YAML file called `_config.yml`. General documentation about Jekyll configuration can be found [here](https://jekyllrb.com/docs/configuration/).
 
-In addition to general Jekyll configurations, Open SDG needs some specific configurations. For more information on these, please see the [configuration page](./configuration.md).
+In addition to general Jekyll configurations, Open SDG needs some specific configurations. For more information on these, please see the [configuration page](configuration.md).
 
 ## Optional features
 
@@ -17,7 +17,7 @@ Open SDG includes two alternative [layouts](https://jekyllrb.com/docs/step-by-st
 1. [`goal`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal.html) - Indicators are displayed in a responsive grid
 1. [`goal-by-target`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal-by-target.html) - Targets on the left, and indicators on the right
 
-If you are using the `create_goals` setting, you can change the layout as described [here](./configuration.md#create_goals).
+If you are using the `create_goals` setting, you can change the layout as described [here](configuration.md#create_goals).
 
 Otherwise you can set the layout by adjusting the [front matter](https://jekyllrb.com/docs/front-matter/) of the goal file. For example, to use the goal-by-target layout, you would need this in the goal's front matter:
 
@@ -124,7 +124,7 @@ The following variables can be used on any page:
 
 * `page.t`
 
-    The translations for the current language. More detail on this is available [here](./configuration.md).
+    The translations for the current language. More detail on this is available [here](configuration.md).
 
     Usage example - printing the translation of the word "Goal" (which is available with the key "goal" in the "general" group:
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -46,7 +46,7 @@ The main takeaway here is that these indivdual Javascript files are in `_include
 
 ## Adding custom CSS
 
-To add custom styles on top of the out-of-the-box Open SDG styles, it is recommended to put a `custom.scss` in your site repository's `_sass` folder. This has the effect of overriding [this file](https://github.com/open-sdg/open-sdg/blob/master/_sass/custom.scss).
+To add custom styles on top of the out-of-the-box Open SDG styles, it is recommended to put a `custom.scss` in your site repository's `_sass` folder. This has the effect of overriding [this placeholder file in the starter repository](https://github.com/open-sdg/open-sdg/blob/master/_sass/custom.scss).
 
 ## Working with Jekyll templates
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -2,7 +2,7 @@
 
 ## Jekyll configuration
 
-Jekyll configuration is stored at the root of the site repository in a YAML file called `_config.yml`. General documentation about Jekyll configuration can be found [here](https://jekyllrb.com/docs/configuration/).
+Jekyll configuration is stored at the root of the site repository in a YAML file called `_config.yml`. General documentation about Jekyll configuration can be found in the [official Jekyll documentation](https://jekyllrb.com/docs/configuration/).
 
 In addition to general Jekyll configurations, Open SDG needs some specific configurations. For more information on these, please see the [configuration page](configuration.md).
 
@@ -17,7 +17,7 @@ Open SDG includes two alternative [layouts](https://jekyllrb.com/docs/step-by-st
 1. [`goal`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal.html) - Indicators are displayed in a responsive grid
 1. [`goal-by-target`](https://github.com/open-sdg/open-sdg/blob/master/_layouts/goal-by-target.html) - Targets on the left, and indicators on the right
 
-If you are using the `create_goals` setting, you can change the layout as described [here](configuration.md#create_goals).
+If you are using the `create_goals` setting, you can change the layout as described on the [configuration page in the "create goals" section](configuration.md#create_goals).
 
 Otherwise you can set the layout by adjusting the [front matter](https://jekyllrb.com/docs/front-matter/) of the goal file. For example, to use the goal-by-target layout, you would need this in the goal's front matter:
 
@@ -124,7 +124,7 @@ The following variables can be used on any page:
 
 * `page.t`
 
-    The translations for the current language. More detail on this is available [here](configuration.md).
+    The translations for the current language. More detail on this is available on the [configuration page](configuration.md).
 
     Usage example - printing the translation of the word "Goal" (which is available with the key "goal" in the "general" group:
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,6 +1,6 @@
 <h1>Data sources</h1>
 
-Out of the box, the [data starter](https://github.com/open-sdg/open-sdg-data-starter) includes the data and metadata as [CSV](./data-format.md) and [YAML](./metadata-format.md) files, respectively.
+Out of the box, the [data starter](https://github.com/open-sdg/open-sdg-data-starter) includes the data and metadata as [CSV](data-format.md) and [YAML](metadata-format.md) files, respectively.
 
 ## SDG Build
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -8,7 +8,7 @@ This data and metadata is processed by a Python library called [sdg-build](https
 
 ## Data repository config file
 
-If you are using the out-of-the-box CSV/YAML approach mentioned above, you can take advantage of using a [configuration file](https://github.com/open-sdg/sdg-build/blob/master/docs/examples/open_sdg_config.yml) in your data repository. For an example of using this approach, see [here](https://github.com/open-sdg/sdg-build/blob/master/docs/examples/open_sdg_simple.py).
+If you are using the out-of-the-box CSV/YAML approach mentioned above, you can take advantage of using a [configuration file](https://github.com/open-sdg/sdg-build/blob/master/docs/examples/open_sdg_config.yml) in your data repository. For an example of using this approach, see [this example in the sdg-build documentation](https://github.com/open-sdg/sdg-build/blob/master/docs/examples/open_sdg_simple.py).
 
 ## Alternative data sources
 
@@ -18,8 +18,8 @@ NOTE: If using any of these alternative data sources, the "config file" approach
 
 ### SDMX
 
-Your data repository can contain SDMX files, either of the SDMX-ML or the SDMX-JSON format. Alternatively, your data repository can "point" to a remote SDMX API endpoint. Examples can be found [here](https://github.com/open-sdg/sdg-build/tree/master/docs/examples).
+Your data repository can contain SDMX files, either of the SDMX-ML or the SDMX-JSON format. Alternatively, your data repository can "point" to a remote SDMX API endpoint. Examples can be found in the [sdg-build documentation](https://github.com/open-sdg/sdg-build/tree/master/docs/examples).
 
 ### CKAN
 
-Your data repository can point to a CKAN instance containing data in a compatible format. Examples can be found [here](https://github.com/open-sdg/sdg-build/tree/master/docs/examples).
+Your data repository can point to a CKAN instance containing data in a compatible format. Examples can be found in the [sdg-build documentation](https://github.com/open-sdg/sdg-build/tree/master/docs/examples).

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,7 +73,7 @@ The pre-processing works fine for version anything greater than or equal to 3.4.
 
 ## Building the site
 
-After you have gone through the [quick start](./quick-start.md) to implement the platform, you will be ready to `clone` the site repository. On the command line, change your directory (`cd`) to the relevant area of your computer where you wish to store the website files and type:
+After you have gone through the [quick start](quick-start.md) to implement the platform, you will be ready to `clone` the site repository. On the command line, change your directory (`cd`) to the relevant area of your computer where you wish to store the website files and type:
 
 ```
 git clone https://github.com/{#NAME}/open-sdg-site-starter.git

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ The `bundler` will install the package versions as listed in the `Gemfile`.
 
 Note: we will assume you have a GitHub account for this part.
 
-We will need `git` to `clone` your forker copy of the repository. You can download and install `git` from [here](https://git-scm.com/downloads), or if you are using `Homebrew` on a Mac, just use:
+We will need `git` to `clone` your forker copy of the repository. You can download and install `git` from the [official Git download page](https://git-scm.com/downloads), or if you are using `Homebrew` on a Mac, just use:
 
 ```
 brew install git

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,11 +2,11 @@
 
 ## Is the Open SDG platform free to reuse?
 
-Yes. Open SDG is open source and is free for anyone to reuse. 
+Yes. Open SDG is open source and is free for anyone to reuse.
 
 ## How do I copy the Open SDG platform?
 
-The [Quick start](./quick-start.md) guide gives technical
+The [Quick start](quick-start.md) guide gives technical
 instructions on the quickest way to get a copy of the open-sdg platform up and running.
 
 ## How long would it take to set up a copy of Open SDG
@@ -16,18 +16,18 @@ With the right skills, it should take less than a day to set up a standard copy,
 ## Can the Open SDG platform be customised?
 
 Yes. Copies of Open SDG can be adapted to local needs – technical developer resource may
-be needed to do this. The [Customisation](./customisation.md) section gives detailed technical guidance.
+be needed to do this. The [Customisation](customisation.md) section gives detailed technical guidance.
 
 ## Can the Open SDG platform be translated into other languages?
 
-Yes. Open SDG has been designed to be multilingual. It is available in the six official UN languages (English, French, Russian, Spanish, Arabic, Chinese) and more (German, Armenian). The [Translation](./translation.md) section gives more technical information, including
+Yes. Open SDG has been designed to be multilingual. It is available in the six official UN languages (English, French, Russian, Spanish, Arabic, Chinese) and more (German, Armenian). The [Translation](translation.md) section gives more technical information, including
 how to add another language.
 
 ## Can I monitor traffic to an Open SDG platform?
 
 Yes. It's easy to start monitoring traffic as Google Analytics functionality has been built in to Open SDG. You need to sign in to Google, [create a Google Analytics account](https://analytics.google.com/analytics/web/provision/#/provision/create) and obtain a tracking code which you then store in your copy of Open SDG.
 
-See the [Analytics section](./analytics.md) for detailed instructions.
+See the [Analytics section](analytics.md) for detailed instructions.
 
 ## Are maps available in Open SDG?
 
@@ -37,7 +37,7 @@ Yes. Maps can be automatically generated from the data if GeoCodes are included 
 
 - [Map for Rwanda indicator 1.2.1](https://sustainabledevelopment-rwanda.github.io/1-2-1/) (1.2.1: 'Proportion of population living below the national poverty line')
 
-Maps from other systems or publications can also be embedded. See the [Maps](./maps.md) section
+Maps from other systems or publications can also be embedded. See the [Maps](maps.md) section
 for more information
 
 ## Can content from other websites be embedded in Open SDG?
@@ -46,7 +46,7 @@ Yes. Content can be embedded into the indicator page using HTML either within a 
 
 ## Can I use Open SDG with other databases?
 
-Open SDG is designed to read its data from CSV files. But it is possible to use scripts to "pre-process" your data, fetching it from a database and then writing it to CSV files. This will require coding expertise in a language such as Python or PHP. Within Open SDG there is already a feature to import CKAN data. 
+Open SDG is designed to read its data from CSV files. But it is possible to use scripts to "pre-process" your data, fetching it from a database and then writing it to CSV files. This will require coding expertise in a language such as Python or PHP. Within Open SDG there is already a feature to import CKAN data.
 
 ## Does Open SDG work with SDMX?
 
@@ -72,7 +72,7 @@ With the **double-repository** approach, site content is kept separate from data
 2. Activity logs on the site repository do not appear on the data repository, and vice versa. This helps make the process of maintenance and review easier.
 3. Having the data and site in separate repositories adds a layer of protection against accidental version control problems.
 
-The double-repository approach is detailed in the [Quick Start](./quick-start.md) with the help of the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) template projects.
+The double-repository approach is detailed in the [Quick Start](quick-start.md) with the help of the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) template projects.
 
 By contrast, with the **single-repository** approach, site content and data/metadata are contained with the same single repository. This approach can be useful for local testing and development, as it simplifies the architecture of the platform. The benefits include:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -36,11 +36,11 @@ The implementation of this platform involves maintaining 2 repositories:
 
 ### Data repository
 
-This is where the platform's data and metadata are managed. A "starter" repository is available [here](https://github.com/open-sdg/open-sdg-data-starter) where it can be easily forked and customised.
+This is where the platform's data and metadata are managed. A ["starter" repository](https://github.com/open-sdg/open-sdg-data-starter) is available which can be easily copied and customised.
 
 ### Site repository
 
-This is where everything else is managed, such as presentation, pages, menus, and documents.  A "starter" repository is available [here](https://github.com/open-sdg/open-sdg-site-starter) where it can be easily forked and customised.
+This is where everything else is managed, such as presentation, pages, menus, and documents.  A ["starter" repository](https://github.com/open-sdg/open-sdg-site-starter) is available which can be easily copied and customised.
 
 ## Translation keys
 

--- a/docs/hosting/aws-s3.md
+++ b/docs/hosting/aws-s3.md
@@ -27,7 +27,7 @@ This URL can be customised, of course, to any domain you own. More details are a
 
 ## Set-up
 
-As mentioned, the initial one-time setup of a static website on AWS S3 is somewhat involved. It is the subject of many blog posts, videos, and tutorials attempting to make it easier. The most authoritative source of guidance would be [Amazon's own documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html). Of particular use would be their example walkthroughs, like [this one](https://docs.aws.amazon.com/AmazonS3/latest/dev/HostingWebsiteOnS3Setup.html). Plenty of third-party guides and videos are available online as well, but try to use the most recent ones, since Amazon has changed their interface over the years.
+As mentioned, the initial one-time setup of a static website on AWS S3 is somewhat involved. It is the subject of many blog posts, videos, and tutorials attempting to make it easier. The most authoritative source of guidance would be [Amazon's own documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html). Of particular use would be this [official Amazon example walkthrough](https://docs.aws.amazon.com/AmazonS3/latest/dev/HostingWebsiteOnS3Setup.html). Plenty of third-party guides and videos are available online as well, but try to use the most recent ones, since Amazon has changed their interface over the years.
 
 ## Automation
 

--- a/docs/hosting/aws-s3.md
+++ b/docs/hosting/aws-s3.md
@@ -23,7 +23,7 @@ S3 has become a popular choice for hosting static websites, which makes it an ap
 
 Out of the box, your AWS S3 site will be viewable at a default AWS domain name. This might be something similar to: "http://www.my-bucket-name.org.s3-website-us-east-1.amazonaws.com/".
 
-This URL can be customised, of course, to any domain you own. More details are available [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html).
+This URL can be customised, of course, to any domain you own. More details are available in this [official Amazon S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html).
 
 ## Set-up
 

--- a/docs/hosting/github-pages.md
+++ b/docs/hosting/github-pages.md
@@ -24,6 +24,6 @@ As mentioned above, there is no special set-up involved in GitHub Pages, since w
 
 ## Automation
 
-The [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) repositories both include a [script](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/scripts/deploy/circleci/deploy_staging.sh) to help use GitHub Pages for hosting. Using GitHub Pages for the "production" environment can be accomplished by having a second GitHub organisation, and the starter repositories also include everything needed to do this.
+The [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) repositories both include a [GitHub Actions workflow](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/.github/workflows/deploy-to-staging.yml) to help use GitHub Pages for hosting. Using GitHub Pages for the "production" environment can be accomplished by having a second GitHub organisation, and the starter repositories also include everything needed to do this.
 
-The main hurdle in automating deployments to GitHub Pages is setting up the SSH keys to allow your automation tool to write to the GitHub repository. For a detailed walk-through of this, see the [Quick Start](../quick-start.md).
+The main hurdle in automating deployments to GitHub Pages is setting up the access tokens to allow your automation tool to write to the GitHub repository. For a detailed walk-through of this, see the [Quick Start](../quick-start.md).

--- a/docs/hosting/linux-server.md
+++ b/docs/hosting/linux-server.md
@@ -24,7 +24,7 @@ As mentioned above, there are endless ways to set up a Linux server for this pur
 * Provisioning the server using software like Ansible or Chef
 * Composing the server as microservices with Docker or Kubernetes
 
-To minimise the "cons" mentioned above, try to go with the most modern, automated, and community-supported approach possible. With that philosophy, Docker images like [this one](https://github.com/linuxserver/docker-letsencrypt) are probably your best bet.
+To minimise the "cons" mentioned above, try to go with the most modern, automated, and community-supported approach possible. With that philosophy, Docker images like [this Let's Encrypt Docker image](https://github.com/linuxserver/docker-letsencrypt) are probably your best bet.
 
 ## Automation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 <img class="wheel" alt="UN SDG Colour Wheel" src="img/SDG Wheel_Transparent.png" />
 
-[Open SDG](https://github.com/open-sdg/open-sdg) is an open source, free-to-reuse platform for managing and publishing data and statistics related to the [UN Sustainable Development Goals](https://www.un.org/sustainabledevelopment/sustainable-development-goals/) (SDGs). It is built exclusively with open-source libraries and tools and can be hosted and maintained using free services. 
+[Open SDG](https://github.com/open-sdg/open-sdg) is an open source, free-to-reuse platform for managing and publishing data and statistics related to the [UN Sustainable Development Goals](https://www.un.org/sustainabledevelopment/sustainable-development-goals/) (SDGs). It is built exclusively with open-source libraries and tools and can be hosted and maintained using free services.
 
 Key features include:
 * Machine-readable data
@@ -10,14 +10,12 @@ Key features include:
 * Multilingual: already available in the six official UN languages and more, using the [SDG Translations](https://open-sdg.github.io/sdg-translations/) resource
 * Fully customisable
 
-For more information on features see our [Open SDG Features page](https://open-sdg.readthedocs.io/en/latest/open-sdg-features/).
+For more information on features see our [Open SDG Features page](open-sdg-features.md).
 
-Have a question? Try our [Frequently Asked Questions](https://open-sdg.readthedocs.io/en/latest/faq/) page.
+Have a question? Try our [Frequently Asked Questions](faq.md) page.
 
-Interested in setting up your own version of Open SDG? Use our [Quick Start](https://open-sdg.readthedocs.io/en/latest/quick-start/) guide.
+Interested in setting up your own version of Open SDG? Use our [Quick Start](quick-start.md) guide.
 
-Want to know more about who else has Open SDG and why? See our 'Open SDG users section', including a [List of users](https://open-sdg.readthedocs.io/en/latest/community/) and various case studies.
+Want to know more about who else has Open SDG and why? See our 'Open SDG users section', including a [List of users](community.md) and various case studies.
 
-We hope this documentation is helpful for getting your Open SDG project started. If you have comments, feedback, or want to get involved with the Open SDG community then please [contact us](https://open-sdg.readthedocs.io/en/latest/support/).
-
-
+We hope this documentation is helpful for getting your Open SDG project started. If you have comments, feedback, or want to get involved with the Open SDG community then please [contact us](support.md).

--- a/docs/making-updates.md
+++ b/docs/making-updates.md
@@ -13,7 +13,7 @@ These steps have four pre-requisites:
     If you do not already have one, go [here](https://github.com) now to sign up for your free account.
 4. A working implementation of Open SDG (hereafter referred to as the "staging site")
 
-    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are [here](./quick-start.md).
+    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are [here](quick-start.md).
 
 ## GitHub.com login
 

--- a/docs/making-updates.md
+++ b/docs/making-updates.md
@@ -10,10 +10,10 @@ These steps have four pre-requisites:
 2. A web browser
 3. A [GitHub.com](https://github.com) account
 
-    If you do not already have one, go [here](https://github.com) now to sign up for your free account.
+    If you do not already have one, go to [GitHub](https://github.com) now to sign up for your free account.
 4. A working implementation of Open SDG (hereafter referred to as the "staging site")
 
-    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are [here](quick-start.md).
+    In most cases, the "staging site" will be something similar to: `https://my-org.github.io/my-site` (but with `my-org` and `my-site` changed as appropriate). If you do not have such a site available, or you are not sure, check with your team before continuing. Instructions on getting started are available on the [Quick Start page](quick-start.md).
 
 ## GitHub.com login
 

--- a/docs/metadata-file-formats.md
+++ b/docs/metadata-file-formats.md
@@ -13,7 +13,7 @@ When naming your metadata files, you should follow a set naming convention - ind
 
 ## Markdown
 
-By default, Metadata in the data starter repository are Markdown files which contain YAML and Markdown. These files should be maintained in the way as described on the [Metadata format page](./metadata-format.md)
+By default, Metadata in the data starter repository are Markdown files which contain YAML and Markdown. These files should be maintained in the way as described on the [Metadata format page](metadata-format.md)
 
 ## Excel and CSV
 
@@ -57,8 +57,8 @@ Unfortunately, there are some metadata fields which can't be set in an Excel or 
 
 These are fields that require a list:
 
-- tag* 
-- data_start_values (see the [Starting values section on the Metadata format page](metadata-format/#starting-values) for more information about this field.)
-- graph_titles (see graph_titles under the [mandatory fields section on the Metadata format page](./metadata-format/#mandatory-for-statistical-indicators) for more information about this field.)
+- tag*
+- data_start_values (see the [Starting values section on the Metadata format page](metadata-format.md#starting-values) for more information about this field.)
+- graph_titles (see graph_titles under the [mandatory fields section on the Metadata format page](metadata-format.md#mandatory-for-statistical-indicators) for more information about this field.)
 
 * If you are only using one tag for an indicator, this field can be set in the Excel/CSV file. If you are using more than one tag for an indicator, this field will need to be set in a Markdown file.

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -1,10 +1,10 @@
 <h1>Metadata format</h1>
 
-In your [data repository](./glossary.md#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
+In your [data repository](glossary.md#data-repository) the metadata is maintained on an indicator-by-indicator basis. This metadata can include any number of custom fields, as defined in a [schema file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml) (see the "Schema" section below) in your data repository. Some fields, however, are mandatory and/or have specific uses in Open SDG. This page details those fields.
 
 ## Note about translation keys
 
-Metadata values can either be filled in with normal text ("My field value") or with [translation keys](./glossary.md#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
+Metadata values can either be filled in with normal text ("My field value") or with [translation keys](glossary.md#translation-keys) (my_translations.my_translation). In the examples below, we will try to demonstrate both possibilities.
 
 As an optional shorthand, if the translation key is in the `data` group, then the group can be omitted. For example, the translation key `data.female` can be written as simply `female`.
 
@@ -40,7 +40,7 @@ If the indicator is going to display a graph, the following fields are required:
           - unit: Total
             title: My alternate title for totals
 
-* `graph_type` - what type of graph to use for the indicator. [More information here](./charts.md). Examples:
+* `graph_type` - what type of graph to use for the indicator. [More information here](charts.md). Examples:
     * line
     * bar
     * binary
@@ -230,7 +230,7 @@ You may think that it would make more sense for the `label` property above to co
 
 ## Metadata tabs
 
-The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](./configuration.md#metadata_tabs).
+The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](configuration.md#metadata_tabs).
 
 ## Reserved metadata fields
 

--- a/docs/metadata-format.md
+++ b/docs/metadata-format.md
@@ -107,7 +107,7 @@ Avoid:
 
 ## Data Info
 
-Some of the metadata are not intended to be displayed on the site. These are put into a "scope" called "data" in the `_prose.yml` file. For example, see [here](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L142).
+Some of the metadata are not intended to be displayed on the site. These are put into a "scope" called "data" in the `_prose.yml` file. For example, see the [`data_non_statistical` field](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L205).
 
 Use this method to hide any fields needed, by putting them into the "data" scope.
 
@@ -198,7 +198,7 @@ You may want to display some very important information which site viewers must 
 
 ## Schema
 
-The actual fields available on each indicator is fully configurable by editing the `_prose.yml` file in your data repository. For a full list of fields available out-of-the-box in the starter repository, see [here](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml). This file also serves to control the behavior of the Prose.io service, which is the usual way that metadata is edited. (For technical information about Prose.io schema, see [here](https://github.com/prose/prose/wiki/Prose-Configuration).)
+The actual fields available on each indicator is fully configurable by editing the `_prose.yml` file in your data repository. For a full list of fields available out-of-the-box in the starter repository, see the [starter repository's `_prose.yml` file](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml). This file also serves to control the behavior of the Prose.io service, which is the usual way that metadata is edited. (For technical information about Prose.io schema, see [the official Prose.io documentation](https://github.com/prose/prose/wiki/Prose-Configuration).)
 
 ## Renaming metadata fields
 
@@ -230,7 +230,7 @@ You may think that it would make more sense for the `label` property above to co
 
 ## Metadata tabs
 
-The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see [here](configuration.md#metadata_tabs).
+The metadata fields can be displayed on indicator pages in a tabbed format. For more information, see the [configuration page in the "metadata tabs" section](configuration.md#metadata_tabs).
 
 ## Reserved metadata fields
 

--- a/docs/open-sdg-features.md
+++ b/docs/open-sdg-features.md
@@ -12,7 +12,7 @@ An example of a site using multiple languages is the [Armenian site](https://arm
 ## Monitoring traffic
 Google Analytics functionality is built in to Open SDG so it's easy to start monitoring traffic to an Open SDG platform. A number of events can be tracked straight of out the box e.g. data downloads and more custom event tracking can easily be added.
 
-For more information about using Google Analytics with an Open SDG platform, see the [Analytics section](./analytics.md).
+For more information about using Google Analytics with an Open SDG platform, see the [Analytics section](analytics.md).
 
 ## Charts
 
@@ -30,7 +30,7 @@ Some examples of data being shown on maps are:
 * [3.2.1 on Rwanda's Open SDG platform](https://sustainabledevelopment-rwanda.github.io/3-2-1/)
 * [3.c.1 on UK's Open SDG platform](https://sustainabledevelopment-uk.github.io/3-a-1/)
 
-For guidance on how set up your site and data in order to be able to display data on a map (as well as on a chart and table), see the [Maps page](./maps.md).
+For guidance on how set up your site and data in order to be able to display data on a map (as well as on a chart and table), see the [Maps page](maps.md).
 
 ## Embedded content
 Another way of showing data/information on a indicator page is by embedding content from other websites/applications.
@@ -39,14 +39,14 @@ An examples of embedded content as main content is a [macro-economic dashboard o
 
 Content can also be embedded on a data tab next to the Chart and Table tabs.
 
-Embedded features are configured in the metadata files. See the Metadata format page [Embedded feature metadata](./metadata-format.md#embedded-feature-metadata) section for more guidance.
+Embedded features are configured in the metadata files. See the Metadata format page [Embedded feature metadata](metadata-format.md#embedded-feature-metadata) section for more guidance.
 
 ## Targets on goal pages
 By default, targets are not shown on the goal pages. An example of this is the [UK Open SDG platform](https://sustainabledevelopment-uk.github.io/1/).
 
 However, Open SDG platforms can be configured to show targets on the goal pages. An example of this is [Armenia's Open SDG platform](https://armstat.github.io/sdg-site-armenia/1/)
 
-For guidance on how to display targets on your goal pages, see the Customisations page [*Optional feature: Goal page layouts*](./customisation.md#optional-feature-goal-page-layouts) section.
+For guidance on how to display targets on your goal pages, see the Customisations page [*Optional feature: Goal page layouts*](customisation.md#optional-feature-goal-page-layouts) section.
 
 ## Reporting status options
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, **Not applicable**, can be used.
@@ -57,21 +57,21 @@ An example of removing one of the options is the [UK's Reporting status page](ht
 
 An example of using the **Not applicable** option is [Rwanda's Reporting status page](https://sustainabledevelopment-rwanda.github.io/reporting-status/).
 
-For more detailed information see the [Reporting status](https://open-sdg.readthedocs.io/en/latest/reporting-status/) page.
+For more detailed information see the [Reporting status](reporting-status.md) page.
 
 ## Display data for national indicators as well as global indicators
 There are various approaches to publishing national and global indicators:
 
 * National indiators are displayed next to global indicators but are tagged as 'national' to distinguish them, for example in [Armenia's platform](https://armstat.github.io/sdg-site-armenia/1/).
 
-* Separate pages for national and global indicators within the same site, for example [Poland's platform](http://sdg.gov.pl/en). 
+* Separate pages for national and global indicators within the same site, for example [Poland's platform](http://sdg.gov.pl/en).
 
 * Separate sites for national and global indicators, for example [Germany's national indicator site](https://sustainabledevelopment-deutschland.github.io/en/) and [Germany's global indicator site](https://sustainabledevelopment-germany.github.io/en/).
 
 ## Accessibility High Contrast version
 As well as the default contrast version, Open SDG also offers a high contrast version. By default two menu buttons show, to allow users to choose between the different contrast levels, for example on the [US site](https://sdg.data.gov/). Another approach is to use a contrast toggle button, for example on the [UK site](https://sustainabledevelopment-uk.github.io/).
 
-For guidance on how to use the more accessible contrast button, see the Configuration page [contrast_type](https://open-sdg.readthedocs.io/en/latest/configuration/) section.
+For guidance on how to use the more accessible contrast button, see the Configuration page [contrast_type](configuration.md) section.
 
 ## Add pages
 By default, there are four pages which show in the menu bar: Reporting status, About, Guidance and FAQ.
@@ -82,14 +82,14 @@ An example of menu items being added is [UK's site](https://sustainabledevelopme
 
 Even though only four pages are linked to in the menu by default, there are other pages provided for use (e.g. Contacts, News) as well as the option to easily create your own pages.
 
-For guidance on how to add more pages to the menu, see the Configuration page [menu](https://open-sdg.readthedocs.io/en/latest/configuration/#menu) section.
+For guidance on how to add more pages to the menu, see the Configuration page [menu](configuration.md#menu) section.
 
 ## Filter by disaggregation
 Open SDG platforms allow data to be displayed in a way in which it can be filtered by disaggregation. This allows user to compare different breakdowns for a particular indicator.
 
 An example of providing disaggregation filtering is [indicator 5.2.2 on the UK site](https://sustainabledevelopment-uk.github.io/5-2-2/).
 
-This feature is configured with the data files. For guidance on how to provide disaggregation filtering, see the [Data format page](./data-format.md).
+This feature is configured with the data files. For guidance on how to provide disaggregation filtering, see the [Data format page](data-format.md).
 
 ## News, posts, and categories
 Open SDG includes the ability to post news and updates to your site. In all respects, this functionality matches what is described in [this Jekyll documentation](https://jekyllrb.com/docs/posts/).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,24 +8,24 @@ This document will go over the quickest way to get this platform up and running.
 > This is a good practice in general, and provides several logistical benefits.
 > However, a simpler single-repository approach may be preferred if you just
 > want to try out Open SDG locally. In this case, see
-> [here](https://github.com/open-sdg/open-sdg-simple-starter).
+> the [open-sdg-simple-starter project](https://github.com/open-sdg/open-sdg-simple-starter).
 
 ## Signing up and creating repositories
 
 1. If you don't already have a Github.com account, [go to Github.com](https://github.com/) to sign up and then log in.
-1. Go [here](https://github.com/open-sdg/open-sdg-site-starter) and click the green "Use this template" button.
+1. Go to the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and click the green "Use this template" button.
 1. Next you will be prompted to choose a name for your new repository. This will affect the URL at which you access the site later, so choose carefully. A suggestion might be: `sdg-site-australia` (adjusted for your country). Note that you can change this later if needed.
 1. Enter a description if you would like. Leave "Public" selected, and click "Create repository from template".
     * Bookmark the created repository -- this is your "__site repository__".
-1. Go [here](https://github.com/open-sdg/open-sdg-data-starter) and click the green "Use this template" button.
+1. Go to the [data starter](https://github.com/open-sdg/open-sdg-data-starter) and click the green "Use this template" button.
 1. As before, choose a name. This one should refer to "data" instead of "site" (eg, `sdg-data-australia`). As before, leave "Public" selected and click "Create repository from template".
     * Bookmark the created repository -- this is your "__data repository__".
 
 ## Creating an access token
 
-This step is temporarily necessary because of a bug involving GitHub Actions and GitHub Pages. The bug is being discussed [here](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/true).
+This step is temporarily necessary because of a bug involving GitHub Actions and GitHub Pages. The bug is being discussed in [this GitHub discussion thread](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/true).
 
-1. Create an access token described [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token). Notes:
+1. Create an access token described in [this official GitHub documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token). Notes:
     * Select the `repo` permission, as indicated in those instructions.
     * Save the token somewhere private.
 1. Copy the access token so that you can paste in the next steps.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -125,6 +125,6 @@ At this point, any new proposed file changes in the repositories will trigger th
 
 ## Possible next steps?
 
-1. [Add data and metadata to the data repository](./making-updates.md)
-1. [Tweak and customise the site repository as needed](./customisation.md)
-1. [Set up separate "production" environments](./deployment.md)
+1. [Add data and metadata to the data repository](making-updates.md)
+1. [Tweak and customise the site repository as needed](customisation.md)
+1. [Set up separate "production" environments](deployment.md)

--- a/docs/reporting-status.md
+++ b/docs/reporting-status.md
@@ -6,7 +6,7 @@ Out of the box, Open SDG provides a page showing the "reporting status" of all t
 
 By default, the reporting status options dispayed are **Complete**, **In progress** and **Exploring data sources**. However, these options can be changed to meet your needs. For example, options can be removed or another option, such as **Not applicable**, can be used.
 
-The options available can be controlled by adjusting the [schema file](./metadata-format.md#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
+The options available can be controlled by adjusting the [schema file](metadata-format.md#schema). For example, [here is the section](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/_prose.yml#L135) in the data starter repository, where you would adjust the available options for reporting status.
 
 ## Color-coding
 

--- a/docs/reporting-status.md
+++ b/docs/reporting-status.md
@@ -39,7 +39,7 @@ Then you could color-code the options by adding this in your CSS:
 
 ## Alternative groupings
 
-Apart from grouping by _goal_, you might like to show the reporting status in different ways (such as "status by _tier_", for example). To do this, your data repository needs to be configured to generate the necessary data. See the `config_data.yml` file in the data starter, [here](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/config_data.yml#L24), for an example.
+Apart from grouping by _goal_, you might like to show the reporting status in different ways (such as "status by _tier_", for example). To do this, your data repository needs to be configured to generate the necessary data. See the [`config_data.yml` file in the data starter](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/config_data.yml#L24), for an example.
 
 Note that the value of that setting in the data repository should be a list of fields which are present in your indicator metadata files.
 

--- a/docs/social-media-sharing.md
+++ b/docs/social-media-sharing.md
@@ -1,7 +1,7 @@
 <h1>Sharing pages via social media</h1>
 
 ## Sticky share buttons
-The sticky share buttons allow users to share a page of the data website via social media (Facebook and Twitter) and via email as shown [here](https://platform.sharethis.com/get-sticky-share-buttons?utm_source=googleadwords&utm_medium=cpc&utm_campaign=follow_buttons_linkedin&gclid=Cj0KCQjw1MXpBRDjARIsAHtdN-0-DX6oc9RzUh_wCU1_fvAB4rnA_adGse0PgocDQTPc3_rzLkucPocaAn1PEALw_wcB).
+The sticky share buttons allow users to share a page of the data website via social media (Facebook and Twitter) and via email as shown in the [official ShareThis documentation](https://platform.sharethis.com/get-sticky-share-buttons?utm_source=googleadwords&utm_medium=cpc&utm_campaign=follow_buttons_linkedin&gclid=Cj0KCQjw1MXpBRDjARIsAHtdN-0-DX6oc9RzUh_wCU1_fvAB4rnA_adGse0PgocDQTPc3_rzLkucPocaAn1PEALw_wcB).
 
 
 ## Configuring sticky share buttons

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -6,7 +6,7 @@ This platform is designed to be multilingual, and leverages the translations bei
 
 This document provides an overview of how the platform accomplishes this, and how it can be extended.
 
-Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](glossary.md#translation-keys) for a definition.
+Throughout this discussion of translation, there will be repeated mention of "translation keys". See the [glossary page in the "translation keys" section](glossary.md#translation-keys) for a definition.
 
 ## Translation data
 
@@ -18,7 +18,7 @@ There are 4 requirements for adding a new language to the platform
 
 1. Check that the new language is implemented in the repository mentioned above. If it is not, you can copy that repository and implement the language yourself.
     * Specifically, you will need to translate all the YAML files in [this folder](https://github.com/open-sdg/sdg-translations/tree/master/translations/en).
-2. Make sure that translated goal icons have been created. These are currently maintained [here](https://github.com/open-sdg/sdg-translations/).
+2. Make sure that translated goal icons have been created. These are currently maintained in [the sdg-translations project](https://github.com/open-sdg/sdg-translations/).
     * Specifically, you will need to produce translated versions of all the PNG files in [this folder](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/goals/en) and [this folder](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/high-contrast/goals/en) (for high contrast versions).
 3. Add the new language in the 'languages' list in your site config (`_config.yml`) and data config (`config_data.yml`) files.
 4. Create new versions of any Jekyll pages that you would like to have available in the new language. Note that the open-sdg-site-starter project includes a [script](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/scripts/batch/add_language.py) to make this easier.
@@ -135,7 +135,7 @@ These variables are available in all Jekyll documents.
 Inevitably an implementation of this platform will need to display some text that is not already included in the repositories mentioned above, and that is likely specific to a particular country. There are two recommended options for this:
 
 1. Copy/fork one of the repositories mentioned above, and maintain your translations there.
-2. Put the translations directly into your data repository, in a `translations` folder. See [here](https://github.com/open-sdg/open-sdg-data-starter/tree/develop/translations) for details.
+2. Put the translations directly into your data repository, in a `translations` folder. See [this folder in the data starter](https://github.com/open-sdg/open-sdg-data-starter/tree/develop/translations) for an example.
 
 > **NOTE**: If you make a translation that you think would be useful to others, please
 > submit it as a pull-request!

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -17,9 +17,9 @@ In order to compile the platform in multiple languages, Jekyll needs the transla
 There are 4 requirements for adding a new language to the platform
 
 1. Check that the new language is implemented in the repository mentioned above. If it is not, you can copy that repository and implement the language yourself.
-    * Specifically, you will need to translate all the YAML files in [this folder](https://github.com/open-sdg/sdg-translations/tree/master/translations/en).
+    * Specifically, you will need to translate all the YAML files in [this folder English source](https://github.com/open-sdg/sdg-translations/tree/master/translations/en).
 2. Make sure that translated goal icons have been created. These are currently maintained in [the sdg-translations project](https://github.com/open-sdg/sdg-translations/).
-    * Specifically, you will need to produce translated versions of all the PNG files in [this folder](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/goals/en) and [this folder](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/high-contrast/goals/en) (for high contrast versions).
+    * Specifically, you will need to produce translated versions of all the PNG files in [this folder of goal images](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/goals/en) and [this folder of high-contrast goal images](https://github.com/open-sdg/sdg-translations/tree/master/www/assets/img/high-contrast/goals/en) (for high contrast versions).
 3. Add the new language in the 'languages' list in your site config (`_config.yml`) and data config (`config_data.yml`) files.
 4. Create new versions of any Jekyll pages that you would like to have available in the new language. Note that the open-sdg-site-starter project includes a [script](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/scripts/batch/add_language.py) to make this easier.
 
@@ -33,7 +33,7 @@ Instead, you should see something like this:
 
 `<h1>{{ page.t.general.sdg }}</h1>`
 
-The `page.t` variable contains a nested structure of translation values, corresponding to the folder structure of the repositories mentioned above. For example, in the example above, the "general" refers to [this file](https://github.com/open-sdg/sdg-translations/blob/master/translations/en/general.yml), and the "sdg" refers to [that line within the file](https://github.com/open-sdg/sdg-translations/blob/master/translations/en/general.yml#L9).
+The `page.t` variable contains a nested structure of translation values, corresponding to the folder structure of the repositories mentioned above. For example, in the example above, the "general" refers to [this general.yml translation file](https://github.com/open-sdg/sdg-translations/blob/master/translations/en/general.yml), and the "sdg" refers to [that particular line within the translation file](https://github.com/open-sdg/sdg-translations/blob/master/translations/en/general.yml#L9).
 
 Jekyll will display translated text according to the "language" specified in the "front matter" of the current document.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -6,7 +6,7 @@ This platform is designed to be multilingual, and leverages the translations bei
 
 This document provides an overview of how the platform accomplishes this, and how it can be extended.
 
-Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](./glossary.md#translation-keys) for a definition.
+Throughout this discussion of translation, there will be repeated mention of "translation keys". See [here](glossary.md#translation-keys) for a definition.
 
 ## Translation data
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -134,8 +134,57 @@ These variables are available in all Jekyll documents.
 
 Inevitably an implementation of this platform will need to display some text that is not already included in the repositories mentioned above, and that is likely specific to a particular country. There are two recommended options for this:
 
-1. Copy/fork one of the repositories mentioned above, and maintain your translations there.
+1. Maintain your translations in a `translations` folder of any Git repository. An easy way to get started with this is to copy the [sdg-translations](https://github.com/open-sdg/sdg-translations) project and then clear out the `translations` folder. More detail on this process is below.
 2. Put the translations directly into your data repository, in a `translations` folder. See [this folder in the data starter](https://github.com/open-sdg/open-sdg-data-starter/tree/develop/translations) for an example.
+
+Whichever approach you take, make sure to adjust your data repository's configuration as needed. See this [example of a data repository's translation configuration](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/config_data.yml#L66).
 
 > **NOTE**: If you make a translation that you think would be useful to others, please
 > submit it as a pull-request!
+
+### Maintaining translation data in a separate repository
+
+An implementation of Open SDG can pull its translations from any number of Git repositories. Out of the box, the starter repositories are configured to pull translations from the [sdg-translations](https://github.com/open-sdg/sdg-translations) project. To see an example, see [that part of the data starter configuration](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/config_data.yml#L69).
+
+However as mentioned above, you likely will need custom translations of text that are specific to your region. For a direct approach, as mentioned above, you can add these translations directly to a `translations` folder in the data repository. The starter repository is configured to pull translations from this folder, if it exists (see [that part of the data starter configuration](https://github.com/open-sdg/open-sdg-data-starter/blob/develop/config_data.yml#L73)).
+
+But perhaps you would prefer to maintain your translations in a separate Git repository. The recommended approach here is to copy [sdg-translations](https://github.com/open-sdg/sdg-translations) by going there and clicking the green "Use this template" button. This will allow you to name it whatever you would like, and will give you an exact copy of sdg-translations.
+
+You likely don't want to maintain *all* of the translations in sdg-translations, so it is recommended that you clear out the contents of the `translations` folder of your copied version. Next, you can add only the translations that you need. Then, you will need to update your data repository configuration so that it pulls from sdg-translations **AND** your copied version.
+
+For example, if you named your copied version `my-github-org/my-translations-repo`, then you would update your data repository configuration from this:
+
+```
+translations:
+  - class: TranslationInputSdgTranslations
+    source: https://github.com/open-sdg/sdg-translations.git
+    tag: master
+```
+
+...to this:
+
+```
+translations:
+  - class: TranslationInputSdgTranslations
+    source: https://github.com/open-sdg/sdg-translations.git
+    tag: master
+  - class: TranslationInputSdgTranslations
+    source: https://github.com/my-github-org/my-translations-repo.git
+    tag: master
+
+```
+
+Note that because your copied version is *after* the sdg-translations entry, you can "override" anything in the sdg-translations project by duplicating (and changing) it in your copied version.
+
+Also note, as a good practice you should point at "tags" (such as "1.0.0") instead of "branches" (such as "master"). In other words, a better configuration would be something like:
+
+```
+translations:
+  - class: TranslationInputSdgTranslations
+    source: https://github.com/open-sdg/sdg-translations.git
+    tag: 1.0.0
+  - class: TranslationInputSdgTranslations
+    source: https://github.com/my-github-org/my-translations-repo.git
+    tag: 1.0.0
+
+```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,7 +30,7 @@ In most cases, the worst that will happen is that you will miss out on any impro
 
 1. When possible, avoid overriding files. Prefer configuration changes and style changes, if possible, over overrides of files.
 2. If an override is necessary, try to override `_includes` files before overriding `_layouts` files. The `_includes` files are smaller and easier to maintain.
-3. When performing an upgrade, check the [changelog](./changelog.md) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
+3. When performing an upgrade, check the [changelog](changelog.md) to see if any of your overridden files have changed. If so, read the details in the changelog to help decide if you need to make any adjustments in your overridden versions.
 
 ### jekyll-open-sdg-plugins
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ pages:
         - Maps: maps.md
         - Analytics: analytics.md
         - Reporting status: reporting-status.md
+        - Social media sharing: social-media-sharing.md
     - Automation:
         - GitHub Actions: automation/github-actions.md
         - CircleCI: automation/circle-ci.md


### PR DESCRIPTION
Fixes #599 
Fixes #612 

I've probably added too much for one PR, but here is what is in this PR:

1. Update all "here" links in the documentation to make them more descriptive
2. Update all internal links in the documentation to follow this simpler format: `[my link](my-page.md)` (instead of, for example, `[my link](https://open-sdg.readthedocs.io/en/latest/my-page/)`.
3. Add more documentation of how to fork sdg-translations
4. Fix a few broken links in the documentation, and turn on automated "HTML proofing" for the documentation, to ensure that we never add a broken link to the documentation pages