### PR TITLE
Font size 14px for long contrast switcher

### DIFF
--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -137,6 +137,7 @@ body.long {
     a {
       margin: auto;
       text-decoration: none;
+      font-size: 14px;
     }
   }
 


### PR DESCRIPTION
In case you want to see different sizes, here's an animation starting at 16px (the current size) and going  down to 15px, 14px, 13px, and 12px:

![captured (2)](https://user-images.githubusercontent.com/1319083/78799478-2fa3d280-7988-11ea-9fd8-6d2291922891.gif)
