### PR TITLE
[Expert review] Goal page styling updates

### DIFF
--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -30,6 +30,7 @@
       text-decoration: none;
       &:hover {
         background: transparent;
+        text-decoration: underline;
       }
     }
 

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -396,11 +396,11 @@
       .indicator-cards a {
         padding: 0;
         margin-bottom: 2.5rem;
-        color: #044b88;
 
         .tags li{
           color: black;
         }
+        
       }
       .indicator-cards.target {
         margin-bottom: 2.5rem;


### PR DESCRIPTION
This change implements the recommendations by @phillipgardiner:

### Sets the goal page link colour back to site default

![image](https://user-images.githubusercontent.com/478770/78897877-c648c000-7a6a-11ea-9c36-eb7855e54fe6.png)

### Adds an underline hover effect on goal page links

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/478770/78898473-c5fcf480-7a6b-11ea-8982-c08ffdbc8e63.gif)

