### PR TITLE
Move colored bar to top of page

### DIFF
--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -1,3 +1,8 @@
+body{
+  background: $vanilla url('../img/sdgbg.png') top left repeat-x;
+  padding-top: 15px;
+}
+
 #skiplink {
   position: absolute;
   top: 0;
@@ -15,7 +20,6 @@
 }
 
 header {
-  background: $vanilla url('../img/sdgbg.png') bottom left repeat-x;
   .container {
     min-height: 113px;
     .navbar-default {


### PR DESCRIPTION
This pull request moves the colo(u)red banner from the bottom of the header to the very top of the page

## Screenshots

Desktop:

![image](https://user-images.githubusercontent.com/478770/80982458-41f81b80-8e23-11ea-82b7-63500d931ec6.png)

Mobile:

![image](https://user-images.githubusercontent.com/478770/80982655-8683b700-8e23-11ea-994c-d63dbb94896a.png)
