### PR TITLE
CircleCI updates in docs

### DIFF
--- a/docs/automation/circle-ci.md
+++ b/docs/automation/circle-ci.md
@@ -17,8 +17,8 @@ CircleCI is a "continuous integration" (CI) cloud service. It is useful for Open
 
 ## Set-up
 
-CircleCI's tight integration with Github repositories makes it relatively simple to set up. The [Quick start](../quick-start.md) page details the process of using CircleCI with Open SDG.
+CircleCI's tight integration with Github repositories makes it relatively simple to set up.
 
 ## Usage
 
-Using CircleCI involves putting a configuration file (`.circleci/config.yml`) in your repository. The [site starter](https://github.com/open-sdg/open-sdg-site-starter) and [data starter](https://github.com/open-sdg/open-sdg-data-starter) repositories include working configurations.
+Using CircleCI involves putting a configuration file (`.circleci/config.yml`) in your repository.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,10 +8,10 @@ That said, the platform does require some server-side technologies to *build* th
 
 ## Automation services
 
-The easiest way to perform these builds is to use a free automation service like TravisCI or CircleCI. Alternatives such as self-hosted Jenkins are possible, but require more maintenance and likely would not be free.
+The easiest way to perform these builds is to use a free automation service like Github Actions, TravisCI, or CircleCI. Alternatives such as self-hosted Jenkins are possible, but require more maintenance and likely would not be free.
 
 > Note that the "starter" repositories are pre-configured for to handle all of
-> the tasks mentioned in this document, using CircleCI for automation.
+> the tasks mentioned in this document, using Github Actions for automation.
 
 ## Hosting providers
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ That said, the platform does require some server-side technologies to *build* th
 
 The easiest way to perform these builds is to use a free automation service like Github Actions, TravisCI, or CircleCI. Alternatives such as self-hosted Jenkins are possible, but require more maintenance and likely would not be free.
 
-> Note that the "starter" repositories are pre-configured for to handle all of
+> Note that the "starter" repositories are pre-configured to handle all of
 > the tasks mentioned in this document, using Github Actions for automation.
 
 ## Hosting providers

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -24,24 +24,21 @@ All the services described here can be used without paying fees.
 
 ### Github.com
 
-[Github.com](https://github.com) provides 2 key functions:
+[Github.com](https://github.com) provides 3 key functions:
 
 1. Git repository: As a Git "remote," Github.com will be the central location for all maintenance and development, both for the platform and its content, data, and metadata.
 1. Platform hosting: Through the free "Github Pages" offering, Github.com will provide free hosting of the platform.
+1. Automation: Through the free "Github Actions" offering, Github.com also provides automation services. This allows the platform to be automatically "built" in response to simple workflows. The key ones are:
+
+    * When code is pushed to the "develop" Git branch, build and deploy to staging.
+    * When code is pushed to the "master" Git branch, build and deploy to production.
+    * When a Github pull request is created, run tests against the new code.
+
+    Although these docs will focus on Github Actions, other automation services like [CircleCI](https://circleci.com) and [TravisCI](https://travis-ci.org) are equivalent. Or for a more do-it-yourself approach: open-source [Jenkins](https://jenkins.io).
 
 ### Prose.io
 
 [Prose.io](https://prose.io) provides a data management interface, which allows non-technical data providers to update data and metadata, using only their web browser.
-
-### CircleCI (or similar)
-
-[CircleCI](https://circleci.com/) allows the platform to be automatically "built" in response to simple workflows. The key ones are:
-
-* When code is pushed to the "develop" Git branch, build and deploy to staging.
-* When code is pushed to the "master" Git branch, build and deploy to production.
-* When a Github pull request is created, run tests against the new code.
-
-Although these docs will focus on CircleCI, other services like [TravisCI](https://travis-ci.org) are equivalent. Or for a more do-it-yourself approach: open-source [Jenkins](https://jenkins.io).
 
 ## Expertise
 


### PR DESCRIPTION
Some references to CircleCI need to be updated, since we've switched the starter repos to Github Actions.