### PR TITLE
Fix color for bar charts with headlines

### DIFF
--- a/_includes/assets/js/model/chartHelpers.js
+++ b/_includes/assets/js/model/chartHelpers.js
@@ -42,8 +42,6 @@ function getDatasets(headline, data, combinations, years, defaultLabel, colors, 
   }, this);
   datasets.sort(function(a, b) { return a.label > b.label; });
   if (headline.length > 0) {
-    color = getHeadlineColor();
-    background = getHeadlineBackground();
     dataset = makeHeadlineDataset(years, headline, defaultLabel);
     datasets.unshift(dataset);
   }
@@ -189,15 +187,6 @@ function getHeadlineColor() {
 }
 
 /**
- * @return {string} CSS value for headline background
- *
- * TODO: Make this dynamic to support high-contrast.
- */
-function getHeadlineBackground() {
-  return HEADLINE_BACKGROUND_COLOR;
-}
-
-/**
  * @param {Array} years
  * @param {Array} rows
  * @param {string} label
@@ -208,7 +197,7 @@ function makeHeadlineDataset(years, rows, label) {
   return Object.assign(dataset, {
     label: label,
     borderColor: getHeadlineColor(),
-    backgroundColor: getHeadlineBackground(),
+    backgroundColor: getHeadlineColor(),
     pointBorderColor: getHeadlineColor(),
     data: prepareDataForDataset(years, rows),
   });

--- a/_includes/assets/js/model/constants.js
+++ b/_includes/assets/js/model/constants.js
@@ -6,4 +6,3 @@ var GEOCODE_COLUMN = 'GeoCode';
 var YEAR_COLUMN = 'Year';
 var VALUE_COLUMN = 'Value';
 var HEADLINE_COLOR = '#777777';
-var HEADLINE_BACKGROUND_COLOR = '#FFFFFF';


### PR DESCRIPTION
Since the indicatorModel.js refactor, bar charts with headlines are displaying white bars instead of the correct color. In doing the indicatorModel.js refactor I misinterpreted what the background color was for - it turns out that it's for the color of the bars.