### PR TITLE
Use the selected unit when calculating minimum field values

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -141,7 +141,7 @@ var indicatorModel = function (options) {
       }
       else {
         if (headline.length === 0) {
-          startingFields = helpers.selectMinimumStartingFields(this.data, this.selectableFields);
+          startingFields = helpers.selectMinimumStartingFields(this.data, this.selectableFields, this.selectedUnit);
         }
       }
       if (startingFields.length > 0) {
@@ -172,7 +172,7 @@ var indicatorModel = function (options) {
       });
     }
 
-    if (selectionUpdateNeeded) {
+    if (selectionUpdateNeeded || options.unitsChangeSeries) {
       this.updateFieldStates(this.selectedFields);
     }
 

--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -238,10 +238,17 @@ function selectFieldsFromStartValues(startValues, selectableFieldNames) {
 /**
  * @param {Array} rows
  * @param {Array} selectableFieldNames Field names
+ * @param {string} selectedUnit
  * @return {Array} Field items
  */
-function selectMinimumStartingFields(rows, selectableFieldNames) {
-  var filteredData = rows.filter(function(row) {
+function selectMinimumStartingFields(rows, selectableFieldNames, selectedUnit) {
+  var filteredData = rows;
+  if (selectedUnit) {
+    filteredData = filteredData.filter(function(row) {
+      return row[UNIT_COLUMN] === selectedUnit;
+    });
+  }
+  filteredData = filteredData.filter(function(row) {
     return selectableFieldNames.some(function(fieldName) {
       return row[fieldName];
     });


### PR DESCRIPTION
This partially address #688. Specifically this makes sure that starting disaggregations will take into account a particular unit, when necessary. What was happening was that a starting unit was getting selected, and then the starting fields were getting selected, but they didn't always match.