### PR TITLE
Convert all colors to "default" Sass variables

### DIFF
--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -44,7 +44,7 @@
       padding: 5px 0;
 
       &.status {
-        color: black;
+        color: $text-dark-color;
         font-weight: normal;
         border: none;
         padding: 4px;
@@ -55,13 +55,13 @@
         font-size: 12px;
 
         &.complete, &.inprogress{
-          color: white;
+          color: $text-on-dark-background-color;
         }
         &.notstarted{
-          border: 1px solid black;
+          border: 1px solid $text-dark-color;
         }
       }
-      
+
     }
 
     .tags {

--- a/_sass/base/_tables.scss
+++ b/_sass/base/_tables.scss
@@ -1,20 +1,20 @@
 .table-hover {
   tbody tr:hover {
-    background: darken(white, 12%);
+    background: darken($background-color, 12%);
   }
 }
 
 #page-content {
 
-  border-top: 1px solid #faebcc;
-  border-bottom: 1px solid #faebcc;
+  border-top: 1px solid $indicator-content-rule-color;
+  border-bottom: 1px solid $indicator-content-rule-color;
   padding-top: 10px;
 
   table {
     margin-top: 5px;
     margin-bottom: 5px;
     border-style: solid;
-    border-color: $footer-color;
+    border-color: $text-dark-color;
     border-width: 1px;
   }
 
@@ -25,6 +25,6 @@
 
   thead {
     padding-bottom: 10px;
-    border-bottom: 1pt solid $footer-color;
+    border-bottom: 1pt solid $text-dark-color;
   }
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -11,7 +11,6 @@ h3{ font-size: 24px;}
 .heading {
   a {
     background: transparent;
-    color: #888;
     display: block;
     &:hover {
       text-decoration: none;
@@ -20,7 +19,7 @@ h3{ font-size: 24px;}
   h1,
 	h2,
   h3 {
-    color: black;
+    color: $text-dark-color;
   }
   h1 {
     margin-top: 12px;
@@ -39,7 +38,7 @@ h3{ font-size: 24px;}
 }
 
 #main-content {
-  background: white;
+  background: $background-color;
   padding-top: 15px;
   padding-bottom: 15px;
 
@@ -52,7 +51,7 @@ h3{ font-size: 24px;}
     margin-right: 5px;
   }
   .alert {
-    color: black;
+    color: $text-dark-color;
   }
   .alert a {
     display: inline;

--- a/_sass/components/_breadcrumbs.scss
+++ b/_sass/components/_breadcrumbs.scss
@@ -5,15 +5,15 @@
   }
   &>.active {
     display: inline;
-    color: black;
+    color: $text-color;
   }
 }
 
 body.contrast-high {
   .breadcrumb {
-    background: white;
+    background: $high-contrast-light-color;
     a {
-      color: black !important;
+      color: $high-contrast-dark-color !important;
     }
   }
 }

--- a/_sass/components/_disclaimer.scss
+++ b/_sass/components/_disclaimer.scss
@@ -1,13 +1,13 @@
 #disclaimer {
 
   .phase-tag {
-    background: #005ea5;
-    color: white;
+    background: $disclaimer-tag-color;
+    color: $text-on-dark-background-color;
     text-transform: uppercase;
     padding: 2px 5px;
   }
   .disclaimer-alert {
-    color: #3D3D3D;
+    color: $disclaimer-text-color;
     margin-bottom: 10px;
     padding: 12px 10px 10px 0;
     border-bottom: 1px solid #BBBBBB;

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -2,10 +2,10 @@
   margin-top: 1.5rem;
   margin-right: 0.8rem;
   border: none !important;
-  background: #0F8243 !important;
+  background: $button-color !important;
 
   &:hover, &:active, &:focus {
-    background: #0b5d30 !important;
+    background: $button-pressed-color !important;
   }
 }
 
@@ -42,15 +42,15 @@ h5 + .btn-download {
 }
 
 body.contrast-high {
-  .btn { background: white !important; color: black !important;
+  .btn { background: $high-contrast-light-color !important; color: $high-contrast-dark-color !important;
     &:hover {
-      background: yellow !important;
+      background: $high-contrast-highlight-color !important;
     }
     &:focus {
-      background: yellow !important;
+      background: $high-contrast-highlight-color !important;
     }
   }
   #zip-download-info {
-    color: white;
+    color: $high-contrast-light-color;
   }
 }

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -1,6 +1,7 @@
 @for $i from 1 through length($goal-colors) {
   $c: nth($goal-colors, $i);
   $dark-c: darken($c, 20%);
+  $background-c: nth($goal-banner-background-colors, $i);
   .goal-#{$i} {
     padding-top: 30px;
     padding-bottom: 30px;
@@ -11,6 +12,9 @@
           color: $dark-c;
         }
       }
+    }
+    &.heading {
+      background-color: $background-c;
     }
   }
   .goal-tiles #goal-#{$i} {

--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -199,3 +199,19 @@ body.contrast-high {
     }
   }
 }
+
+body.contrast-high {
+  #map {
+    // Temporary code until high-contrast mode is implemented for maps.
+    a {
+      color: $high-contrast-dark-color;
+    }
+    .selection-legend {
+      .legend-values, #selection-list {
+        li, span {
+          color: $high-contrast-dark-color;
+        }
+      }
+    }
+  }
+}

--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -23,17 +23,17 @@
 
     &.contrast-default {
       display: none;
-      background: white;
+      background: $high-contrast-light-color;
       a {
-        color: black;
+        color: $high-contrast-dark-color;
       }
     }
 
     &.contrast-high {
       display: block;
-      background: black;
+      background: $high-contrast-dark-color;
       a {
-        color: yellow;
+        color: $high-contrast-highlight-color;
       }
     }
   }
@@ -53,46 +53,46 @@ body.contrast-high {
     }
   }
 
-  background-color: black;
+  background-color: $high-contrast-dark-color;
   .table {
-    background: black;
+    background: $high-contrast-dark-color;
   }
 
   .table-hover {
     tbody tr:hover {
-      background: yellow;
+      background: $high-contrast-highlight-color;
       td {
-        color: black;
+        color: $high-contrast-dark-color;
       }
       th {
-        color: black;
+        color: $high-contrast-dark-color;
       }
       a {
-        color: blue;
+        color: $link-color;
         text-decoration: underline;
       }
     }
   }
 
   .container, #main-content, header, footer, #disclaimer, .heading {
-    background: black;
-    border-color: black;
+    background: $high-contrast-dark-color;
+    border-color: $high-contrast-dark-color;
   }
 
   p, h2, h3, h4, span, td, th, a#text {
-    color: white;
+    color: $high-contrast-light-color;
   }
 
   li, a {
-    color: yellow;
+    color: $high-contrast-highlight-color;
   }
 
   h1 {
-    color: white;
+    color: $high-contrast-light-color;
   }
 
   li.contrast-default a {
-    color: black !important;
+    color: $high-contrast-dark-color !important;
   }
 }
 
@@ -167,27 +167,27 @@ body.long {
 }
 
 body.contrast-high .site-intro .description{
-  color: white;
+  color: $high-contrast-light-color;
 }
 
 body.contrast-high #main-content .no-gutters img:not(#goal-18):hover {
-  box-shadow: 0px 0px 0px 5px yellow;
+  box-shadow: 0px 0px 0px 5px $high-contrast-highlight-color;
 }
 
 body.contrast-high footer a {
-  color: white;
+  color: $high-contrast-light-color;
   &:hover, &:focus {
-    color: yellow;
+    color: $high-contrast-highlight-color;
   }
 }
 
 body.contrast-high #disclaimer {
   .phase-tag {
-    background: white;
-    color: black;
+    background: $high-contrast-light-color;
+    color: $high-contrast-dark-color;
   }
   .disclaimer-alert {
-    color: white;
+    color: $high-contrast-light-color;
   }
 }
 

--- a/_sass/components/_language_toggle.scss
+++ b/_sass/components/_language_toggle.scss
@@ -6,12 +6,10 @@
   position: absolute;
   z-index: 999;
   left: 12px;
-  color: #222;
-  background: #fff;
+  background: $background-color;
   border-radius: 3px;
-  box-shadow: 0px 0px 2px 0px #a6a6a6;
+  box-shadow: 0px 0px 2px 0px $language-toggle-shadow-color;
   padding: .2em 1em .2em .2em;
-  text-shadow: #f5f5f5 0 1px 0;
   li {
     padding: 5px;
     padding-left: 0;
@@ -54,9 +52,9 @@
 .contrast-high {
   .language-toggle-mobile, ul.navbar-nav {
     .language-options a {
-      color: black;
+      color: $high-contrast-dark-color;
       &:hover {
-        color: black;
+        color: $high-contrast-dark-color;
       }
     }
   }

--- a/_sass/components/_loader.scss
+++ b/_sass/components/_loader.scss
@@ -1,7 +1,7 @@
 .loader {
   svg path,
   svg rect{
-    fill: #FF6700;
+    fill: $loader-color;
   }
 }
 

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -1,117 +1,3 @@
-// Legacy map styles.
-// @TODO: Can this section be removed?
-#main-content {
-  #map {
-    position: relative;
-    width: 590px;
-  }
-
-  g.tick {
-    line {
-      stroke: rgb(0, 0, 0);
-    }
-    text {
-      fill: rgb(0, 0, 0);
-    }
-  }
-
-  line.track {
-    stroke: rgb(0, 0, 0);
-  }
-
-  g.parameter-value {
-    path {
-      stroke: rgb(0, 0, 0);
-    }
-  }
-
-  .background {
-    fill: #e5f3ff;
-    pointer-events: all;
-  }
-
-  .map-layer {
-    fill: #fff;
-    stroke: #aaa;
-  }
-
-  .tooltip {
-    color: #222;
-    background: #fff;
-    border-radius: 3px;
-    box-shadow: 0px 0px 2px 0px #a6a6a6;
-    padding: .2em;
-    text-shadow: #f5f5f5 0 1px 0;
-    opacity: 0.9;
-    position: absolute;
-    min-width: 180px;
-
-    &.hidden {
-      display: none;
-    }
-
-    h2 {
-      margin: 4px 0;
-
-    }
-
-    table {
-      width: 100%;
-    }
-  }
-
-  #resetButton {
-    position: absolute;
-    top: 13px;
-    right: 12px;
-    background: #444;
-    color: white;
-    border: none;
-    padding: 5px 10px;
-    display: none;
-
-    &:hover {
-      background: #000;
-    }
-
-    i {
-      font-size: 12px;
-      margin-right: 4px;
-    }
-  }
-
-  #key {
-    display: block;
-    margin-top: -5px;
-  }
-
-  #slider {
-    position: absolute;
-    top: 0;
-  }
-
-  #infoPanel {
-    position: absolute;
-    bottom: 40px;
-    left: 0;
-    right: 0;
-    min-height: 100px;
-    background: rgba(0, 0, 0, 0.75);
-    width: 590px;
-    display: none;
-    padding: 10px;
-    color: white;
-
-    h2 {
-      margin: 0 0 20px 0;
-    }
-
-    table {
-      width: 100%;
-    }
-  }
-}
-
 // Leaflet map styles.
 #main-content {
   #map {
@@ -122,7 +8,7 @@
       position: relative;
       height: 100%;
       width: 100%;
-      background: white;
+      background: $background-color;
       z-index: 99999;
       display: flex;
       align-items: center;
@@ -148,7 +34,7 @@
       }
     }
     .disaggregation-select-container {
-      background: white;
+      background: $background-color;
       padding: 5px;
       border: 2px solid rgba(0,0,0,0.3);
       border-radius: 5px;
@@ -181,19 +67,19 @@
           z-index: 1;
           &.left {
             border-width: 20px 0 0 20px;
-            border-color: transparent transparent transparent white;
+            border-color: transparent transparent transparent $background-color;
             left: 0;
           }
           &.right {
             border-width: 0 0 20px 20px;
-            border-color: transparent transparent white transparent;
+            border-color: transparent transparent $background-color transparent;
             right: 1px;
-            box-shadow: 1px 1px 1px 0px #666;
+            box-shadow: 1px 1px 1px 0px $map-legend-shadow-color;
           }
         }
         .legend-value {
           padding: 0 4px;
-          background: white;
+          background: $background-color;
           position: absolute;
           z-index: 2;
           &.left {
@@ -202,7 +88,7 @@
           &.right {
             right: 1px;
           }
-          box-shadow: 1px 1px 1px 0px #666;
+          box-shadow: 1px 1px 1px 0px $map-legend-shadow-color;
         }
       }
       #selection-list {
@@ -223,7 +109,7 @@
           }
           .selection-bar {
             border-radius: 2px 0 0 2px;
-            background: white;
+            background: $map-legend-bar-color;
             z-index: 1;
           }
           .selection-name {
@@ -232,7 +118,7 @@
           }
           &.no-value {
             .selection-name {
-              background: repeating-linear-gradient(45deg, #FFF, #FFF 2px, #CCC 2px, #CCC 4px);
+              background: $map-legend-no-value-color;
             }
             .selection-bar, .selection-value {
               display: none;
@@ -241,7 +127,7 @@
           .selection-value {
             z-index: 2;
             margin-right: 5px;
-            background-color: #ddd;
+            background-color: $map-legend-value-color;
             padding: 3px;
             border-radius: 2px;
           }

--- a/_sass/components/_notices.scss
+++ b/_sass/components/_notices.scss
@@ -1,11 +1,11 @@
 .danger {
-  background-color: #E27874;
+  background-color: $danger-color;
 }
 .warning {
-  background-color: #f0ad4e;
+  background-color: $warning-color;
 }
 .success {
-  background-color: #5cb85c;
+  background-color: $success-color;
 }
 
 .data-notice {
@@ -19,19 +19,19 @@ body.contrast-high {
     .alert {
       div {
         p, h4 {
-          color: black;
+          color: $high-contrast-dark-color;
 	      }
       }
     }
   }
 
   .danger {
-    background-color: red;
+    background-color: $high-contrast-danger-color;
   }
   .warning {
-    background-color: yellow;
+    background-color: $high-contrast-highlight-color;
   }
   .success {
-    background-color: green;
+    background-color: $high-contrast-success-color;
   }
 }

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -1,8 +1,16 @@
 body.contrast-high {
-  .nav-tabs { border-color: yellow; }
+  .nav-tabs {
+    border-color: $high-contrast-highlight-color;
+  }
 
-  #main-content .nav-tabs .nav-item.active a { background: yellow; color: black; border-color: yellow; }
+  #main-content .nav-tabs .nav-item.active a {
+    background: $high-contrast-highlight-color;
+    color: $high-contrast-dark-color;
+    border-color: $high-contrast-highlight-color; }
 
-  a.nav-link:focus { background: white; color: black; }
+  a.nav-link:focus {
+    background: $high-contrast-light-color;
+    color: $high-contrast-dark-color;
+  }
 
 }

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -2,37 +2,37 @@ body.contrast-high {
   .goal-indicators {
     div {
       span {
-        border-color: white !important;
-        color: white !important;
+        border-color: $high-contrast-light-color !important;
+        color: $high-contrast-light-color !important;
       }
     }
     .indicator-cards {
       &.target {
-        color: white !important;
+        color: $high-contrast-light-color !important;
       }
       span.status, .tags li{
-        color: black !important;
+        color: $high-contrast-dark-color !important;
       }
 
       span.status{
         &.complete,
         &.notapplicable{
-          color: black !important;
+          color: $high-contrast-dark-color !important;
         }
 
         &.notstarted,
         &.inprogress{
-          color: white !important;
+          color: $high-contrast-dark-color !important;
         }
       }
 
       span.status.notstarted{
-        color: white !important;
-        border: 1px solid white !important;
+        color: $high-contrast-light-color !important;
+        border: 1px solid $high-contrast-light-color !important;
       }
     }
   }
   #main-content.goal-indicators.goal-by-target .indicator-cards a{
-    color: yellow;
+    color: $high-contrast-highlight-color;
   }
 }

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -1,5 +1,5 @@
 body{
-  background: $vanilla url('../img/sdgbg.png') top left repeat-x;
+  background: $background-color url('../img/sdgbg.png') top left repeat-x;
   padding-top: 15px;
 }
 
@@ -12,10 +12,10 @@ body{
   left: 50%;
   margin-left: -125px;
   padding: 10px;
-  background: white;
+  background: $background-color;
   text-align: center;
-  border: 1px solid black;
-  color: black;
+  border: 1px solid $text-dark-color;
+  color: $text-dark-color;
   display: block;
 }
 
@@ -55,15 +55,15 @@ header {
       a {
         padding: 2px;
         margin: 2px 15px;
-        color: #595959;
+        color: $menu-link-color;
         font-size: 16px;
 
       }
 
       &.active a {
-        border-bottom: 2px solid #333;
+        border-bottom: 2px solid $text-color;
         background: transparent;
-        color: #333;
+        color: $text-color;
 
         &:hover {
           background: transparent;
@@ -92,16 +92,16 @@ header {
       }
 
       &.contrast-default {
-        background: white;
+        background: $high-contrast-light-color;
         a {
-          color: black;
+          color: $high-contrast-dark-color;
         }
       }
 
       &.contrast-high {
-        background: black;
+        background: $high-contrast-dark-color;
         a {
-          color: yellow;
+          color: $high-contrast-highlight-color;
         }
       }
       &:not(.contrast) {
@@ -187,8 +187,8 @@ header {
     clear: left;
 
     &.navbar-default {
-      color: #E5E6E7;
-      background: #414042;
+      color: $menu-mobile-link-color;
+      background: $menu-mobile-link-background-color;
       margin-bottom: 10px;
       width: 100%;
       float: none;
@@ -205,17 +205,17 @@ header {
         cursor: pointer;
 
         &.active {
-          background: #58595B;
+          background: $menu-mobile-link-active-background-color;
         }
 
         span {
-          color: #E5E6E7;
+          color: $menu-mobile-link-color;
           display: block;
           padding: 15px;
         }
 
       	button {
-          color: #E5E6E7;
+          color: $menu-mobile-link-color;
           display: block;
           padding: 15px;
           border: 0;
@@ -228,7 +228,7 @@ header {
     }
 
     & .menu-target {
-      background: #58595B;
+      background: $menu-mobile-dropdown-color;
     }
 
     ul.navbar-nav {
@@ -243,23 +243,23 @@ header {
         cursor: pointer;
         a {
           display: block;
-          background: #58595B;
+          background: $menu-mobile-dropdown-color;
           padding: 6px 0 6px;
-          color: #E5E6E7;
+          color: $menu-mobile-link-color;
           font-size: 15px;
 
           &:hover {
-            color: #E5E6E7;
+            color: $menu-mobile-link-color;
           }
         }
 
         &.active a {
           border: none;
-          color: #fff;
+          color: $menu-mobile-link-active-color;
           font-weight: bold;
 
           &:hover {
-            color: #fff;
+            color: $menu-mobile-link-active-color;
           }
         }
 
@@ -277,7 +277,7 @@ header {
       label {
         top: 23px;
         left: 25px;
-        color: black;
+        color: $text-dark-color;
       }
 
       button {
@@ -289,7 +289,7 @@ header {
 
       input {
         width: 100%;
-        color: #333;
+        color: $text-color;
         margin-top: 0;
 
         &:focus {
@@ -324,21 +324,21 @@ body.contrast-high {
   .navbar {
     li {
       a {
-        color: white;
+        color: $high-contrast-light-color;
         &:hover, &:focus {
-          color: yellow;
+          color: $high-contrast-highlight-color;
         }
       }
     }
     li.active {
       a {
-        color: yellow;
-        border-color: yellow;
+        color: $high-contrast-highlight-color;
+        border-color: $high-contrast-highlight-color;
         &:hover {
-          color: yellow;
+          color: $high-contrast-highlight-color;
         }
         &:focus {
-          color: yellow;
+          color: $high-contrast-highlight-color;
         }
       }
     }
@@ -346,20 +346,20 @@ body.contrast-high {
 
   @media screen and (max-width: 768px) {
     .navbar.navbar-default {
-      background: black;
-      color: white;
+      background: $high-contrast-dark-color;
+      color: $high-contrast-light-color;
     }
     .navbar .top-level li.active {
-      background: white;
+      background: $high-contrast-light-color;
       span {
-        color: black;
+        color: $high-contrast-dark-color;
       }
     }
     .navbar .menu-target {
-      background: black;
+      background: $high-contrast-dark-color;
     }
     .navbar ul.navbar-nav li a {
-      background: black;
+      background: $high-contrast-dark-color;
     }
   }
 }

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -37,9 +37,9 @@
   #toolbar {
     button {
       width: 100%;
-      background-color: #fff;
+      background-color: $background-color;
       position: relative;
-      border: 1px solid #ccc;
+      border: 1px solid $horizontal-rule-color;
       text-align: left;
       padding: 10px 7px 14px 7px;
       font-size: 0.875em;
@@ -53,8 +53,8 @@
       }
 
       &.disabled {
-        color: #777;
-        background: #ccc;
+        color: $indicator-disabled-color;
+        background: $indicator-disabled-background-color;
       }
 
     }
@@ -78,7 +78,7 @@
     margin-top: 10px;
 
     label {
-      background-color: #fff;
+      background-color: $background-color;
       padding: 7px;
       display: block;
       font-weight: normal;
@@ -92,21 +92,21 @@
         right: 6px;
       }
       &:hover {
-        border-color: #acacac;
+        border-color: $indicator-field-border-hover-color;
       }
       &.disabled {
-        color: #888;
+        color: $indicator-disabled-color;
         cursor: not-allowed;
         &:hover {
-          border-color: #ccc;
+          border-color: $indicator-disabled-background-color;
         }
       }
       &.possible {
-        background-color: #dedede;
+        background-color: $indicator-possible-background-color;
       }
       &.excluded {
-        background-color: #666;
-        color: white;
+        background-color: $indicator-excluded-background-color;
+        color: $text-on-dark-background-color;
 
         & input {
           display: none;
@@ -129,7 +129,7 @@
 
     .bar {
       height: 7px;
-      border: 1px solid #dedede;
+      border: 1px solid $indicator-field-border-color;
       margin: 2px;
       padding: 0;
       position: relative;
@@ -139,19 +139,19 @@
         float: left;
       }
       .selected {
-        background-color: #555;
+        background-color: $indicator-selected-background-color;
       }
 
       .default {
-        background-color: white;
+        background-color: $background-color;
       }
 
       .possible {
-        background-color: #dedede;
+        background-color: $indicator-possible-background-color;
       }
 
       .excluded {
-        background-color: #666;
+        background-color: $indicator-excluded-background-color;
       }
     }
 
@@ -159,24 +159,24 @@
       position: relative;
       cursor: pointer;
       width: 100%;
-      border: 1px solid #ccc;
+      border: 1px solid $indicator-selector-border-color;
       display: inline-block;
       margin-right: 8px;
       margin-bottom: 10px;
 
       &:hover {
-        border-color: #555;
+        border-color: $indicator-selector-hover-border-color;
       }
 
       .no-data-hint,
       .variable-hint {
         display: none;
         padding-left: 7px;
-        color: #666;
+        color: $indicator-hint-color;
       }
 
       .variable-options {
-        background-color: white;
+        background-color: $background-color;
         display: none;
         position: static;
         z-index: 100;
@@ -192,9 +192,9 @@
 
         button {
           width: auto;
-          background-color: #fff;
-          border: 1px solid #555;
-          color: #000;
+          background-color: $background-color;
+          border: 1px solid $indicator-field-button-border-color;
+          color: $text-dark-color;
           float: none;
           position: static;
           text-align: center;
@@ -205,7 +205,7 @@
           border-radius: 4px;
 
           &:hover {
-            background: #f5f3f3;
+            background: $indicator-field-button-hover-background-color;
           }
         }
 
@@ -216,7 +216,7 @@
           font-size: 1.3em;
 
           &:not(:first-child) {
-            border-top: 1px solid #cdcdcd;
+            border-top: 1px solid $indicator-field-label-border;
           }
 
           input {
@@ -226,14 +226,14 @@
           }
 
           &:hover {
-            background: #f5f3f3;
+            background: $indicator-field-button-hover-background-color;
           }
 
           &[data-has-data="false"] {
             display: none;
             cursor: default;
             &:hover {
-              background: white;
+              background: $background-color;
             }
             input {
               display: none;
@@ -265,7 +265,7 @@
           label {
             cursor: default;
             &:hover {
-              background: white;
+              background: $background-color;
             }
           }
         }
@@ -291,7 +291,7 @@
 
     label {
       font-weight: normal;
-      border: 1px solid #ccc;
+      border: 1px solid $indicator-selector-border-color;
       padding: 10px;
       margin-right: 8px;
       cursor: pointer;
@@ -306,7 +306,7 @@
     font-size: 1.2em;
     line-height: 1.2em;
     vertical-align: middle;
-    background: #FFCC0B;
+    background: $indicator-dataset-size-warning;
     border-radius: 4px;
     padding: 5px;
 
@@ -333,13 +333,13 @@
       font-size: 13px;
       list-style-type: none;
       display: inline-block;
-      color: #666;
+      color: $indicator-legend-color;
       line-height: 18px;
       cursor: pointer;
       padding: 5px;
 
       &:hover {
-        background: #eee;
+        background: $indicator-legend-hover-background-color;
       }
 
       &.notshown {
@@ -379,10 +379,10 @@
     margin: 5px 10px 5px 0;
 
     &:not(#goal-18){
-      box-shadow: 5px 5px 5px 0px rgba(5,5,5,0.3);
+      box-shadow: 5px 5px 5px 0px $goal-tiles-shadow-color;
 
       &:hover{
-        box-shadow: 5px 5px 5px 0px rgba(5,5,5,0.6);
+        box-shadow: 5px 5px 5px 0px $goal-tiles-hover-shadow-color;
       }
     }
   }
@@ -395,7 +395,7 @@
         margin-bottom: 2.5rem;
 
         .tags li{
-          color: black;
+          color: $text-dark-color;
         }
 
       }
@@ -405,7 +405,7 @@
       }
     }
     .indicator-cards .tags li{
-      color: black;
+      color: $text-dark-color;
     }
   }
   .goal-indicators:after {
@@ -414,23 +414,23 @@
     clear: both;
   }
   .nav-tabs {
-    border-bottom: 1px solid #888;
+    border-bottom: 1px solid $indicator-tabs-border-color;
     .nav-item {
       background: none;
       border: none;
       a {
         border: none;
-        color: black;
+        color: $text-dark-color;
       }
       &.active {
         a {
-          border: 1px solid #888;
+          border: 1px solid $indicator-tabs-border-color;
           border-bottom: 0;
         }
       }
       &:not(.active){
         a{
-          background-color: #eeeeee;
+          background-color: $indicator-tabs-inactive-background-color;
           &:hover{
             text-decoration: underline;
           }
@@ -439,7 +439,7 @@
     }
   }
   .tab-content {
-    border: 1px solid #888;
+    border: 1px solid $indicator-tabs-border-color;
     padding: 15px;
     border-top:  0;
 
@@ -528,59 +528,59 @@
 
 body.contrast-high {
   #main-content #fields label {
-    background: black;
-    color: white;
+    background: $high-contrast-dark-color;
+    color: $high-contrast-light-color;
     &:hover {
-      background: white;
-      color: black;
+      background: $high-contrast-light-color;
+      color: $high-contrast-dark-color;
     }
     &:focus {
-      background: white;
-      color: black;
+      background: $high-contrast-light-color;
+      color: $high-contrast-dark-color;
     }
   }
 
   #toolbar {
     button {
-      background-color: black !important;
-      border-color: white;
-      color: white;
+      background-color: $high-contrast-dark-color !important;
+      border-color: $high-contrast-light-color;
+      color: $high-contrast-light-color;
     }
   }
 
   .variable-options {
-    background: black;
-    color: white;
+    background: $high-contrast-dark-color;
+    color: $high-contrast-light-color;
     div {
-      background: black;
-      color: white;
+      background: $high-contrast-dark-color;
+      color: $high-contrast-light-color;
     }
     button {
-      background: black;
-      color: white !important;
-      border-color: white;
+      background: $high-contrast-dark-color;
+      color: $high-contrast-light-color !important;
+      border-color: $high-contrast-light-color;
     }
   }
 
-  #main-content #fields .bar .selected { background-color: white; }
+  #main-content #fields .bar .selected { background-color: $high-contrast-light-color; }
 
-  #main-content #fields .variable-selector .variable-hint { color: white; }
+  #main-content #fields .variable-selector .variable-hint { color: $high-contrast-light-color; }
 
   caption {
-    color: white;
+    color: $high-contrast-light-color;
   }
 
   div#units {
-    color: white;
+    color: $high-contrast-light-color;
   }
 
   #legend {
     li {
-      color: white !important;
+      color: $high-contrast-light-color !important;
       border: 1px solid transparent;
       &:hover {
         background: transparent !important;
-        border: 1px solid white;
+        border: 1px solid $high-contrast-light-color;
       }
     }
   }

--- a/_sass/layouts/_news.scss
+++ b/_sass/layouts/_news.scss
@@ -2,7 +2,7 @@
   @include tags;
   li {
     a {
-      color: black;
+      color: $text-dark-color;
     }
   }
 }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -1,19 +1,12 @@
 .notapplicable {
-  background-color: #ccc;
-  background: repeating-linear-gradient(
-    135deg,
-    #ccc,
-    white 10px,
-    #ccc 10px,
-    white 20px
-  );
+  background: $status-notapplicable-background-color;
 }
 
 .inprogress {
-  background-color: #757575;
+  background-color: $status-inprogress-background-color;
 }
 .complete {
-  background-color: #2B2B2B;
+  background-color: $status-complete-background-color;
 }
 
 #main-content {
@@ -32,28 +25,28 @@
         margin-right: 3px;
         padding: 2px 5px;
         border-radius: 4px;
-        
+
         width: 40px;
         text-align: center;
         font-size: 16px;
 
         &.notstarted{
-          border: 1px solid #000000;
-          color: black;
+          border: 1px solid $text-dark-color;
+          color: $text-dark-color;
         }
         &.complete, &.inprogress{
-          color: white;
+          color: $text-on-dark-background-color;
         }
       }
     }
   }
   .value {
-    color: #333;
+    color: $text-color;
     font-weight: bold;
     margin-left: 3px;
   }
   .goal-stats {
-    border: 1px solid #000000;
+    border: 1px solid $text-dark-color;
     font-size: 0;
     margin-top:10px;
     & span {
@@ -69,7 +62,7 @@
     clear: left;
     margin-bottom: 4px;
     padding-bottom: 4px;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid $horizontal-rule-color;
     .total {
        line-height: 24px;
        vertical-align: middle;
@@ -82,7 +75,7 @@
        margin-left: 10px;
        margin-top: -2px;
        border-radius: 4px;
-       border: 1px solid #ccc;
+       border: 1px solid $horizontal-rule-color;
     }
   }
   .frame {
@@ -116,38 +109,38 @@
 body.contrast-high {
 
   .goal-stats{
-    border: 1px solid white !important;
+    border: 1px solid $high-contrast-light-color !important;
   }
 
   .statuses {
     strong {
-      color: white;
+      color: $high-contrast-light-color;
     }
     .value {
-      color: white !important;
+      color: $high-contrast-light-color !important;
     }
-    
+
   }
 
   .summary .statuses .notstarted{
-    border: 1px solid white !important;
+    border: 1px solid $high-contrast-light-color !important;
   }
 
   .complete{
-    background-color: white;
-    color: black !important;
+    background-color: $high-contrast-light-color;
+    color: $high-contrast-dark-color !important;
   }
 
   .inprogress{
-    background-color: #767676;
+    background-color: $high-contrast-medium-color;
   }
 
   .notstarted{
-    color: white !important;
+    color: $high-contrast-light-color !important;
   }
 
   .notapplicable{
-    color: black !important;
+    color: $high-contrast-dark-color !important;
   }
-  
+
 }

--- a/_sass/layouts/_search.scss
+++ b/_sass/layouts/_search.scss
@@ -7,7 +7,7 @@
 #search-results {
 
   span.match {
-    background-color: yellow;
+    background-color: $search-highlight-color;
   }
 
   margin-top: 20px;
@@ -24,7 +24,7 @@
         font-size: 18px;
       }
       .url {
-        color: green;
+        color: $search-url-color;
         font-size: 16px;
       }
       &:hover {
@@ -41,17 +41,17 @@ body.contrast-high {
   #search-results {
 
     span.match {
-      color: black !important;
+      color: $high-contrast-dark-color !important;
     }
 
     .search-result {
       a {
         .url {
-          color: yellow !important;
+          color: $high-contrast-highlight-color !important;
         }
       }
       .content {
-        color: white !important;
+        color: $high-contrast-light-color !important;
       }
     }
   }

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,0 +1,7 @@
+/**
+ * variables.scss
+ *
+ * This file left blank intentionally. Implementations of Open SDG can use
+ * a similarly named file to override any "default" variables in the "variables"
+ * folder.
+ */

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,6 +1,7 @@
 $dark-highlight: #0275d8 !default;
 $footer-color: #000000 !default;
 $goal-colors: #E52B3D #DDA63A #4C9F38 #C42130 #FF3E24 #28BCE1 #FCC30B #A21942 #FD6925 #DD1367 #FD9C27 #BF8B2E #417D46 #0A96D8 #57BE2F #00689C #1F4A6A !default;
+$goal-banner-background-colors: white white white white white white white white white white white white white white white white white !default;
 $menu-hover-border-bottom: #aaaaaa !default;
 
 $text-color: #333 !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,26 +1,26 @@
-$dark-highlight: #0275d8 !default;
-$footer-color: #000000 !default;
 $goal-colors: #E52B3D #DDA63A #4C9F38 #C42130 #FF3E24 #28BCE1 #FCC30B #A21942 #FD6925 #DD1367 #FD9C27 #BF8B2E #417D46 #0A96D8 #57BE2F #00689C #1F4A6A !default;
 $goal-banner-background-colors: white white white white white white white white white white white white white white white white white !default;
-$menu-hover-border-bottom: #aaaaaa !default;
 
 $text-color: #333 !default;
 $text-dark-color: black !default;
 $text-on-dark-background-color: white !default;
 $background-color: white !default;
 $link-color: #337ab7 !default;
+$dark-highlight: #0275d8 !default;
+$footer-color: #000000 !default;
 
 $high-contrast-dark-color: black !default;
 $high-contrast-light-color: white !default;
 $high-contrast-highlight-color: yellow !default;
 $high-contrast-success-color: green !default;
 $high-contrast-danger-color: red !default;
-$high-contrast-medium-color: #767676;
+$high-contrast-medium-color: #767676 !default;
 
 $danger-color: #E27874 !default;
 $warning-color: #f0ad4e !default;
 $success-color: #5cb85c !default;
 
+$menu-hover-border-bottom: #aaaaaa !default;
 $menu-link-color: #595959 !default;
 $menu-mobile-link-color: #E5E6E7 !default;
 $menu-mobile-link-background-color: #414042 !default;
@@ -38,11 +38,10 @@ $status-notstarted-background-color: white !default;
 $status-notapplicable-background-color: repeating-linear-gradient(135deg, #ccc, white 10px, #ccc 10px, white 20px) !default;
 
 $horizontal-rule-color: #ccc !default;
+$indicator-content-rule-color: #faebcc !default;
 
 $search-highlight-color: yellow !default;
 $search-url-color: green !default;
-
-$indicator-content-rule-color: #faebcc !default;
 
 $disclaimer-tag-color: #005ea5 !default;
 $disclaimer-text-color: #3D3D3D !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,5 +1,82 @@
-$dark-highlight : #0275d8;
-$vanilla: #fff;
-$footer-color : #000000;
-$goal-colors : #E52B3D #DDA63A #4C9F38 #C42130 #FF3E24 #28BCE1 #FCC30B #A21942 #FD6925 #DD1367 #FD9C27 #BF8B2E #417D46 #0A96D8 #57BE2F #00689C #1F4A6A;
-$menu-hover-border-bottom: #aaaaaa;
+$dark-highlight: #0275d8 !default;
+$footer-color: #000000 !default;
+$goal-colors: #E52B3D #DDA63A #4C9F38 #C42130 #FF3E24 #28BCE1 #FCC30B #A21942 #FD6925 #DD1367 #FD9C27 #BF8B2E #417D46 #0A96D8 #57BE2F #00689C #1F4A6A !default;
+$menu-hover-border-bottom: #aaaaaa !default;
+
+$text-color: #333 !default;
+$text-dark-color: black !default;
+$text-on-dark-background-color: white !default;
+$background-color: white !default;
+$link-color: #337ab7 !default;
+
+$high-contrast-dark-color: black !default;
+$high-contrast-light-color: white !default;
+$high-contrast-highlight-color: yellow !default;
+$high-contrast-success-color: green !default;
+$high-contrast-danger-color: red !default;
+$high-contrast-medium-color: #767676;
+
+$danger-color: #E27874 !default;
+$warning-color: #f0ad4e !default;
+$success-color: #5cb85c !default;
+
+$menu-link-color: #595959 !default;
+$menu-mobile-link-color: #E5E6E7 !default;
+$menu-mobile-link-background-color: #414042 !default;
+$menu-mobile-link-active-color: white !default;
+$menu-mobile-link-active-background-color: #58595B !default;
+$menu-mobile-dropdown-color: #58595B !default;
+
+$status-complete-color: $text-on-dark-background-color !default;
+$status-inprogress-color: $text-on-dark-background-color !default;
+$status-notstarted-color: $text-color !default;
+$status-notapplicable-color: $text-color !default;
+$status-complete-background-color: #2B2B2B !default;
+$status-inprogress-background-color: #757575 !default;
+$status-notstarted-background-color: white !default;
+$status-notapplicable-background-color: repeating-linear-gradient(135deg, #ccc, white 10px, #ccc 10px, white 20px) !default;
+
+$horizontal-rule-color: #ccc !default;
+
+$search-highlight-color: yellow !default;
+$search-url-color: green !default;
+
+$indicator-content-rule-color: #faebcc !default;
+
+$disclaimer-tag-color: #005ea5 !default;
+$disclaimer-text-color: #3D3D3D !default;
+
+$button-color: #0F8243 !default;
+$button-pressed-color: #0b5d30 !default;
+
+$goal-tiles-shadow-color: rgba(5,5,5,0.3) !default;
+$goal-tiles-hover-shadow-color: rgba(5,5,5,0.6) !default;
+
+$language-toggle-shadow-color: #a6a6a6 !default;
+
+$map-legend-shadow-color: #666 !default;
+$map-legend-no-value-color: repeating-linear-gradient(45deg, #FFF, #FFF 2px, #CCC 2px, #CCC 4px) !default;
+$map-legend-value-color: #ddd !default;
+$map-legend-bar-color: white !default;
+
+$loader-color: #FF6700 !default;
+
+$indicator-disabled-color: #777 !default;
+$indicator-disabled-background-color: #ccc !default;
+$indicator-field-border-hover-color: #acacac !default;
+$indicator-selected-background-color: #555 !default;
+$indicator-possible-background-color: #dedede !default;
+$indicator-excluded-background-color: #666 !default;
+$indicator-field-border-color: #dedede !default;
+$indicator-selector-border-color: #ccc !default;
+$indicator-selector-hover-border-color: #555 !default;
+$indicator-hint-color: #666 !default;
+$indicator-field-button-border-color: #555 !default;
+$indicator-field-button-hover-background-color: #f5f3f3 !default;
+$indicator-field-label-border: #cdcdcd !default;
+$indicator-dataset-size-warning: #FFCC0B !default;
+$indicator-legend-color: #666 !default;
+$indicator-legend-hover-background-color: #eee !default;
+
+$indicator-tabs-border-color: #888 !default;
+$indicator-tabs-inactive-background-color: #eeeeee !default;

--- a/_sass/variables/_dimensions.scss
+++ b/_sass/variables/_dimensions.scss
@@ -1,3 +1,3 @@
-$navbar-height : 175;
-$disclaimer-height: 40;
-$collapsed-navbar-height: $navbar-height - 30;
+$navbar-height : 175 !default;
+$disclaimer-height: 40 !default;
+$collapsed-navbar-height: $navbar-height - 30 !default;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,5 +1,6 @@
 ---
 ---
 
+@import "variables";
 @import "open-sdg";
 @import "custom";


### PR DESCRIPTION
This is yet another refactorish PR that I'd like to get into version 1.0.0 if possible, though this one should be completely safe, so long as I didn't make any typos. I've gone through the Sass code and converted any colors into Sass variables, which I've put into the _sass/variables/_colors.scss file as "default". This allows users to easily override those variables, by including a _sass/variables.scss file (which we could add to the site starter).

In addition to allowing easier customisation, this opens the door to a future "skins" feature, where we could provide several out-of-the-box skins of the platform, each of which would be a file overriding these Sass variables.

Next steps could include something similar with dimensions (paddings, margins, etc) though I don't intend to try to do that for version 1.0.0.

I did my best to interpret the purposes of the various colors and name the variables appropriately, but feedback is welcome.

Fixes #691 