### PR TITLE
Allow goal banner color and footer background to be overriden

### DIFF
--- a/_sass/components/_goal_banner.scss
+++ b/_sass/components/_goal_banner.scss
@@ -1,0 +1,14 @@
+@for $i from 1 through length($goal-banner-background-colors) {
+  $background-c: nth($goal-banner-background-colors, $i);
+  .goal-#{$i} {
+    &.heading {
+      background-color: $background-c;
+    }
+  }
+}
+
+.heading[class*="goal-"] {
+  h1, p {
+    color: $goal-banner-color;
+  }
+}

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -1,7 +1,6 @@
 @for $i from 1 through length($goal-colors) {
   $c: nth($goal-colors, $i);
   $dark-c: darken($c, 20%);
-  $background-c: nth($goal-banner-background-colors, $i);
   .goal-#{$i} {
     padding-top: 30px;
     padding-bottom: 30px;
@@ -12,9 +11,6 @@
           color: $dark-c;
         }
       }
-    }
-    &.heading {
-      background-color: $background-c;
     }
   }
   .goal-tiles #goal-#{$i} {

--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -79,6 +79,12 @@ body.contrast-high {
     border-color: $high-contrast-dark-color;
   }
 
+  .heading[class*="goal-"] {
+    h1, p {
+      color: $high-contrast-light-color;
+    }
+  }
+
   p, h2, h3, h4, span, td, th, a#text {
     color: $high-contrast-light-color;
   }

--- a/_sass/layouts/_footer.scss
+++ b/_sass/layouts/_footer.scss
@@ -1,6 +1,7 @@
 footer {
   clear: left;
   color: $footer-color;
+  background-color: $footer-background-color;
   position: absolute;
   bottom: 0;
   width: 100%;

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -12,6 +12,7 @@
 @import "components/disclaimer";
 @import "components/download_buttons";
 @import "components/goal_tiles";
+@import "components/goal_banner";
 @import "components/language_toggle";
 @import "components/loader";
 @import "components/maps";

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,5 +1,6 @@
 $goal-colors: #E52B3D #DDA63A #4C9F38 #C42130 #FF3E24 #28BCE1 #FCC30B #A21942 #FD6925 #DD1367 #FD9C27 #BF8B2E #417D46 #0A96D8 #57BE2F #00689C #1F4A6A !default;
 $goal-banner-background-colors: white white white white white white white white white white white white white white white white white !default;
+$goal-banner-color: black !default;
 
 $text-color: #333 !default;
 $text-dark-color: black !default;
@@ -8,6 +9,7 @@ $background-color: white !default;
 $link-color: #337ab7 !default;
 $dark-highlight: #0275d8 !default;
 $footer-color: #000000 !default;
+$footer-background-color: white !default;
 
 $high-contrast-dark-color: black !default;
 $high-contrast-light-color: white !default;


### PR DESCRIPTION
This is to make it easier for countries to keep their existing (pre-1.0.0) goal banner and footer styles. I also moved some goal-banner stuff into a dedicated file, instead of having in the goal-tiles file.