### PR TITLE
Underline breadcrumb links

### DIFF
--- a/_sass/components/_breadcrumbs.scss
+++ b/_sass/components/_breadcrumbs.scss
@@ -2,6 +2,7 @@
   margin-bottom: 15px;
   a {
     color: darken(#337ab7, 10%);
+    text-decoration: underline;
   }
   &>.active {
     display: inline;
@@ -12,7 +13,7 @@
 body.contrast-high {
   .breadcrumb {
     background: $high-contrast-light-color;
-    a {
+    li, a {
       color: $high-contrast-dark-color !important;
     }
   }


### PR DESCRIPTION
Fixes #689 

This underlines breadcrumb links, which helps to make the links distinguishable in high-contrast mode, and generally makes it more obvious that they are links.

It also ensures that the last (non-link) breadcrumb is darker (black) when in high-contrast mode (instead of `#333` as it is now).