### PR TITLE
Bugfix for search "boost" functionality

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -145,7 +145,7 @@ var indicatorSearch = function() {
   function getSearchFieldOptions(field) {
     var opts = {}
     if (opensdg.searchIndexBoost[field]) {
-      opts['boost'] = intval(opensdg.searchIndexBoost[field])
+      opts['boost'] = parseInt(opensdg.searchIndexBoost[field])
     }
     return opts
   }


### PR DESCRIPTION
This was never working apparently, because I used a PHP function instead of the corresponding Javascript function.