### PR TITLE
Use some status-related Sass variables

### DIFF
--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -1,7 +1,9 @@
 .notapplicable {
   background: $status-backgroundColor-notapplicable;
 }
-
+.notstarted {
+  background: $status-backgroundColor-notstarted;
+}
 .inprogress {
   background-color: $status-backgroundColor-inprogress;
 }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -1,13 +1,17 @@
 .notapplicable {
+  background-color: $status-backgroundColor-notapplicable;
   background: $status-backgroundColor-notapplicable;
 }
 .notstarted {
+  background-color: $status-backgroundColor-notstarted;
   background: $status-backgroundColor-notstarted;
 }
 .inprogress {
+  background-color: $status-backgroundColor-inprogress;
   background: $status-backgroundColor-inprogress;
 }
 .complete {
+  background-color: $status-backgroundColor-complete;
   background: $status-backgroundColor-complete;
 }
 
@@ -138,21 +142,25 @@ body.contrast-high {
   }
 
   .complete{
+    background-color: $status-backgroundColor-complete-highContrast;
     background: $status-backgroundColor-complete-highContrast;
     color: $status-color-complete-highContrast !important;
   }
 
   .inprogress{
+    background-color: $status-backgroundColor-inprogress-highContrast;
     background: $status-backgroundColor-inprogress-highContrast;
     color: $status-color-inprogress-highContrast;
   }
 
   .notstarted{
+    background-color: $status-backgroundColor-notstarted-highContrast;
     background: $status-backgroundColor-notstarted-highContrast;
     color: $status-color-notstarted-highContrast !important;
   }
 
   .notapplicable{
+    background-color: $status-backgroundColor-notapplicable-highContrast;
     background: $status-backgroundColor-notapplicable-highContrast;
     color: $status-color-notapplicable-highContrast !important;
   }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -5,10 +5,10 @@
   background: $status-backgroundColor-notstarted;
 }
 .inprogress {
-  background-color: $status-backgroundColor-inprogress;
+  background: $status-backgroundColor-inprogress;
 }
 .complete {
-  background-color: $status-backgroundColor-complete;
+  background: $status-backgroundColor-complete;
 }
 
 #main-content {
@@ -41,6 +41,9 @@
         }
         &.inprogress {
           color: $status-color-inprogress;
+        }
+        &.notstarted {
+          color: $status-color-notstarted;
         }
         &.notapplicable {
           color: $status-color-notapplicable;
@@ -135,20 +138,22 @@ body.contrast-high {
   }
 
   .complete{
-    background-color: $status-backgroundColor-complete-highContrast;
+    background: $status-backgroundColor-complete-highContrast;
     color: $status-color-complete-highContrast !important;
   }
 
   .inprogress{
-    background-color: $status-backgroundColor-inprogress-highContrast;
+    background: $status-backgroundColor-inprogress-highContrast;
     color: $status-color-inprogress-highContrast;
   }
 
   .notstarted{
+    background: $status-backgroundColor-notstarted-highContrast;
     color: $status-color-notstarted-highContrast !important;
   }
 
   .notapplicable{
+    background: $status-backgroundColor-notapplicable-highContrast;
     color: $status-color-notapplicable-highContrast !important;
   }
 


### PR DESCRIPTION
We have a few Sass variables for the status types, which we're not using:
* $status-backgroundColor-notstarted
* $status-color-notstarted
* $status-backgroundColor-notstarted-highContrast
* $status-backgroundColor-notapplicable-highContrast

This PR adds usage of those variables. It also tweaks our Sass to always use "background" instead of "background-color", so that users can override with more complex backgrounds like gradients.