### PR TITLE
Safety code for the checks for start values

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -62,6 +62,7 @@ var indicatorModel = function (options) {
   this.footerFields = helpers.footerFields(this);
   this.colors = opensdg.chartColors(this.indicatorId);
   this.maxDatasetCount = 2 * this.colors.length;
+  this.hasStartValues = Array.isArray(this.startValues) && this.startValues.length > 0;
 
   this.clearSelectedFields = function() {
     this.selectedFields = [];
@@ -114,7 +115,7 @@ var indicatorModel = function (options) {
       // Decide on a starting unit.
       if (this.hasUnits) {
         var startingUnit = this.selectedUnit;
-        if (this.startValues) {
+        if (this.hasStartValues) {
           var unitInStartValues = helpers.getUnitFromStartValues(this.startValues);
           if (unitInStartValues) {
             startingUnit = unitInStartValues;
@@ -136,7 +137,7 @@ var indicatorModel = function (options) {
 
       // Decide on starting field values.
       var startingFields = this.selectedFields;
-      if (this.startValues) {
+      if (this.hasStartValues) {
         startingFields = helpers.selectFieldsFromStartValues(this.startValues, this.selectableFields);
       }
       else {

--- a/_includes/polyfills.html
+++ b/_includes/polyfills.html
@@ -1,2 +1,2 @@
-<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=Promise%2CArray.prototype.forEach%2CString.prototype.includes%2CURLSearchParams%2CCustomEvent%2CArray.prototype.includes%2CArray.prototype.filter%2CArray.prototype.some%2CArray.prototype.find%2CObject.assign"></script>
+<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=Promise%2CArray.prototype.forEach%2CString.prototype.includes%2CURLSearchParams%2CCustomEvent%2CArray.prototype.includes%2CArray.prototype.filter%2CArray.prototype.some%2CArray.prototype.find%2CObject.assign%2CArray.isArray"></script>
 <script crossorigin="anonymous" src="https://cdnjs.cloudflare.com/ajax/libs/javascript-canvas-to-blob/3.15.0/js/canvas-to-blob.min.js"></script>


### PR DESCRIPTION
@SavvasStephanides This should avoid javascript errors when an indicator has `data_start_values:` in the metadata (without any values).