### PR TITLE
Support translations in the reporting status extra fields

### DIFF
--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -4,16 +4,21 @@
 {%- assign indicator_singular = page.t.general.indicator | downcase -%}
 {%- assign indicators_plural = page.t.general.indicators | downcase -%}
 
+{% assign reporting_data = site.data.reporting %}
+{% if site.data[page.language].reporting %}
+  {% assign reporting_data = site.data[page.language].reporting %}
+{% endif %}
+
 <div id="main-content" class="container reportingstatus">
 
   {%- assign extra_fields = false -%}
-  {%- for extra_field in site.data.reporting.extra_fields -%}
+  {%- for extra_field in reporting_data.extra_fields -%}
     {%- assign extra_fields = true -%}
   {%- endfor -%}
 
   <h1>{{ page.t.status.reporting_status }}</h1>
 
-  {%- assign overall = site.data.reporting.overall -%}
+  {%- assign overall = reporting_data.overall -%}
   <div class="goal goal-overall">
       <div class="details">
         <h2 class="status-goal">
@@ -48,7 +53,7 @@
     <li role="presentation" class="nav-item active">
       <a class="nav-link" data-toggle="tab" href="#goalsview" aria-controls="goals" role="tab" {% include autotrack.html preset="tab_reporting_status_goals" category="Tab change" action="Change reporting status view" label="Change reporting status view to goals" %}>{{ page.t.status.status_by_goal }}</a>
     </li>
-    {% for extra_field in site.data.reporting.extra_fields %}
+    {% for extra_field in reporting_data.extra_fields %}
     {% assign extra_field_name = extra_field[0] %}
     {% assign extra_field_translated = extra_field_name | translate_metadata_field %}
     {% assign extra_field_autotrack = 'Change reporting status view to ' | append: extra_field_name %}
@@ -65,7 +70,7 @@
   <div class="tab-content reporting-status-view">
     <div role="tabpanel" class="tab-pane active" id="goalsview">
   {% endif %}
-  {%- for goalreport in site.data.reporting.goals -%}
+  {%- for goalreport in reporting_data.goals -%}
     {%- assign goal = goalreport.goal | downcase | sdg_lookup -%}
     <div class="goal">
         <div class="frame">
@@ -104,7 +109,7 @@
   {%- endfor -%}
   {% if extra_fields %}
     </div>
-    {%- for extra_field in site.data.reporting.extra_fields -%}
+    {%- for extra_field in reporting_data.extra_fields -%}
     {% assign extra_field_name = extra_field[0] %}
     <div role="tabpanel" class="tab-pane" id="{{ extra_field_name }}view">
       {%- for fieldreport in extra_field[1] -%}

--- a/tests/data/custom-translations/en/metadata.yml
+++ b/tests/data/custom-translations/en/metadata.yml
@@ -1,2 +1,3 @@
 indicator-name-key: This is a non-translated indicator name
 computation-units-key: This is a non-translated unit of measurement
+custodian-agency-key: This is a non-translated custodian agency

--- a/tests/data/custom-translations/es/metadata.yml
+++ b/tests/data/custom-translations/es/metadata.yml
@@ -1,2 +1,3 @@
 indicator-name-key: This is a translated indicator name via translation key
 computation-units-key: This is a translated unit of measurement via translation key
+custodian-agency-key: This is a translated custodian agency via translation key

--- a/tests/data/meta/1-3-1.md
+++ b/tests/data/meta/1-3-1.md
@@ -14,6 +14,6 @@ reporting_status: complete
 sdg_goal: '1'
 target_name: global_targets.1-3-title
 target_id: '1.3'
-un_custodian_agency: ILO
+un_custodian_agency: metadata.custodian-agency-key
 un_designated_tier: '2'
 ---

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -9,3 +9,11 @@ Feature: Reporting status page
 
   Scenario: All available goals are listed
     Then I should see 4 "goal status" elements
+
+  Scenario: Extra fields can be used to group status and are properly translated
+    And I click on "the second reporting status tab"
+    Then I should see "This is a non-translated custodian agency"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    And I click on "the second reporting status tab"
+    Then I should see "This is a translated custodian agency"

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -26,6 +26,7 @@ const driver = new mink.Mink({
     "the first language option": ".nav .language-options li:first-child a",
     "the last language option": ".nav .language-options li:last-child a",
     "goal status": ".goal .frame",
+    "the second reporting status tab": ".nav-tabs.reporting-status-view li:last-child a",
     "the search box": ".navbar #indicator_search",
     "disaggregation filter": ".variable-selector",
     "the filter drop-down button": ".variable-selector .accessBtn",


### PR DESCRIPTION
Fixes #766 

The reporting status layout was hardcoded to use `site.data.reporting`, which is always populated with the default language. This change looks for translated builds in the current language (eg, `site.data.en.reporting`), and if found, uses that instead. This also adds an automated test for this feature.