### PR TITLE
Backwards compatibility for code mobile search button text

### DIFF
--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -1,5 +1,14 @@
 $(function() {
 
+  // @deprecated start
+  if (typeof translations.search === 'undefined') {
+    translations.search = { search: 'Search' };
+  }
+  if (typeof translations.general === 'undefined') {
+    translations.general = { hide: 'Hide' };
+  }
+  // @deprecated end
+
   var topLevelSearchLink = $('.top-level span:eq(1), .top-level button:eq(1)');
 
   var resetForSmallerViewport = function() {


### PR DESCRIPTION
In #762 we made a change to an include file, scripts.html. It didn't occur to me at the time, but if a country were overriding that file, then they would get a Javascript error after upgrading, whenever a user tapped the mobile search button. Since we don't want any breaking changes, we need to always provide backwards compatibility code. This is too late for 1.0.2, but better late than never.

I've put `@deprecated start` and `@deprecated end` around this backwards compatibility code. The idea is that, in version 2.0.0, we would simply delete all chunks of code marked `@deprecated`.