### PR TITLE
Configurable reporting status title and description

### DIFF
--- a/_includes/components/reporting-status-introduction.html
+++ b/_includes/components/reporting-status-introduction.html
@@ -1,0 +1,11 @@
+<h1>
+  {% if site.reporting_status.title %}
+    {{ site.reporting_status.title | t }}
+  {% else %}
+    {{ page.t.status.reporting_status }}
+  {% endif %}
+</h1>
+
+{% if site.reporting_status.description %}
+<p class="lead-copy">{{ site.reporting_status.description | t }}</p>
+{% endif %}

--- a/_includes/components/reporting-status-introduction.html
+++ b/_includes/components/reporting-status-introduction.html
@@ -7,5 +7,7 @@
 </h1>
 
 {% if site.reporting_status.description %}
-<p class="lead-copy">{{ site.reporting_status.description | t }}</p>
+<div class="reporting-status-description">
+  {{ site.reporting_status.description | t }}
+</div>
 {% endif %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -11,12 +11,12 @@
 
 <div id="main-content" class="container reportingstatus">
 
+  {% include components/reporting-status-introduction.html %}
+
   {%- assign extra_fields = false -%}
   {%- for extra_field in reporting_data.extra_fields -%}
     {%- assign extra_fields = true -%}
   {%- endfor -%}
-
-  <h1>{{ page.t.status.reporting_status }}</h1>
 
   {%- assign overall = reporting_data.overall -%}
   <div class="goal goal-overall">

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -165,4 +165,8 @@ body.contrast-high {
     color: $status-color-notapplicable-highContrast !important;
   }
 
+  .reporting-status-description {
+    color: $color-light-highContrast;
+  }
+
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -345,6 +345,23 @@ This is far safer and more recommended than using the latest version, such as th
 remote_theme: open-sdg/open-sdg
 ```
 
+### reporting_status
+
+_Optional_: This setting adds controls certain aspects of the reporting status page. The available settings are:
+
+* `title`: Controls the title of the reporting status page. Defaults to "Reporting status".
+* `description`: Controls the introductory text under the title. If omitted there will be no introductory text.
+
+Here is an example of using these settings:
+
+```yaml
+reporting_status:
+    title: title goes here
+    description: description goes here
+```
+
+As always, for multilingual support, these settings can refer to translation keys.
+
 ### search_index_boost
 
 _Optional_: This setting can be used to give a "boost" to one or more fields in the search index. The boost number should be a positive integer. The higher the number, the more "relevant" that field will be in search results. If omitted, the following defaults will be used:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,7 +347,7 @@ remote_theme: open-sdg/open-sdg
 
 ### reporting_status
 
-_Optional_: This setting adds controls certain aspects of the reporting status page. The available settings are:
+_Optional_: This setting controls certain aspects of the reporting status page. The available settings are:
 
 * `title`: Controls the title of the reporting status page. Defaults to "Reporting status".
 * `description`: Controls the introductory text under the title. If omitted there will be no introductory text.

--- a/tests/data/custom-translations/en/custom.yml
+++ b/tests/data/custom-translations/en/custom.yml
@@ -2,3 +2,5 @@ frontpage_heading: My custom frontpage heading
 frontpage_instructions: My custom frontpage instructions
 category: My English custom category
 disclaimer_message: This is my disclaimer message.
+reporting_status_title: My reporting status title
+reporting_status_description: My reporting status description

--- a/tests/data/custom-translations/es/custom.yml
+++ b/tests/data/custom-translations/es/custom.yml
@@ -2,3 +2,5 @@ frontpage_heading: My Spanish frontpage heading
 frontpage_instructions: My Spanish frontpage instructions
 category: My Spanish custom category
 disclaimer_message: This is my Spanish disclaimer message.
+reporting_status_title: My Spanish reporting status title
+reporting_status_description: My Spanish reporting status description

--- a/tests/data/custom-translations/fr/custom.yml
+++ b/tests/data/custom-translations/fr/custom.yml
@@ -2,3 +2,5 @@ frontpage_heading: My French Canadian frontpage heading
 frontpage_instructions: My French Canadian frontpage instructions
 category: My French Canadian custom category
 disclaimer_message: This is my French Canadian disclaimer message.
+reporting_status_title: My French Canadian reporting status title
+reporting_status_description: My French Canadian reporting status description

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -17,3 +17,11 @@ Feature: Reporting status page
     And I follow "the first language option"
     And I click on "the second reporting status tab"
     Then I should see "This is a translated custodian agency"
+
+  Scenario: The title and description of the reporting status page can be configured
+    Then I should see "My reporting status title"
+    And I should see "My reporting status description"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "My Spanish reporting status title"
+    And I should see "My Spanish reporting status description"

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -125,3 +125,7 @@ frontpage_introduction_banner:
 disclaimer:
   phase: header.alpha
   message: custom.disclaimer_message
+
+reporting_status:
+  title: custom.reporting_status_title
+  description: custom.reporting_status_description


### PR DESCRIPTION
Fixes #638 

Here is a screenshot:
![reporting-status-title-and-description](https://user-images.githubusercontent.com/1319083/87959886-88076780-ca81-11ea-8482-3f053f773faa.png)

@phillipgardiner What do you think? I used the "lead-copy" class to make the intro text a bit bigger, like in the frontpage banner.