### PR TITLE
Simplify goals layout and allow configurable intro

### DIFF
--- a/_includes/components/goals-introduction.html
+++ b/_includes/components/goals-introduction.html
@@ -1,0 +1,13 @@
+<h1>
+  {% if site.goals_page.title %}
+    {{ site.goals_page.title | t }}
+  {% else %}
+    {{ page.t.general.goals }}
+  {% endif %}
+</h1>
+
+{% if site.goals_page.description %}
+<div class="goals-page-description">
+  {{ site.goals_page.description | t }}
+</div>
+{% endif %}

--- a/_layouts/goals.html
+++ b/_layouts/goals.html
@@ -1,13 +1,28 @@
----
-layout: frontpage
----
-{% comment %}
-Currently the "frontpage.html" layout is serving 2 purposes:
+{% include head.html %}
+{% include header.html %}
+<div id="main-content" class="container" role="main">
 
-1. A front page
-2. A landing page for the 17 goals
+    {% include components/goals-introduction.html %}
 
-This file is named "goals.html" to indicate that this is only serving purpose
-#2 above. For now, this merely replicates "frontpage.html". But in the future
-it will diverge.
-{% endcomment %}
+    <div class="goal-tiles">
+    {% for goal in page.goals %}
+        {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
+            <div class="col-xs-4 col-md-2">
+                <a href="{{ goal.url }}">
+                    <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
+              </a>
+            </div>
+        {% cycle 'end row' : '', '', '', '', '', '</div>' %}
+    {% endfor %}
+    {% comment %}
+        If there were exactly 17 goals, "pad" it with 1 more, to make it come
+        out more symmetrically.
+    {% endcomment %}
+    {% if page.goals.size == 17 %}
+        <div class="col-xs-4 col-md-2">
+            <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+        </div>
+    {% endif %}
+    </div>
+</div>
+{% include footer.html %}

--- a/_layouts/goals.html
+++ b/_layouts/goals.html
@@ -5,24 +5,24 @@
     {% include components/goals-introduction.html %}
 
     <div class="goal-tiles">
-    {% for goal in page.goals %}
-        {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
+        <div class="row no-gutters">
+            {% for goal in page.goals %}
             <div class="col-xs-4 col-md-2">
                 <a href="{{ goal.url }}">
                     <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
-              </a>
+                </a>
             </div>
-        {% cycle 'end row' : '', '', '', '', '', '</div>' %}
-    {% endfor %}
-    {% comment %}
-        If there were exactly 17 goals, "pad" it with 1 more, to make it come
-        out more symmetrically.
-    {% endcomment %}
-    {% if page.goals.size == 17 %}
-        <div class="col-xs-4 col-md-2">
-            <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+            {% endfor %}
+            {% comment %}
+            If there were exactly 17 goals, "pad" it with 1 more, to make it come
+            out more symmetrically.
+            {% endcomment %}
+            {% if page.goals.size == 17 %}
+            <div class="col-xs-4 col-md-2">
+                <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+            </div>
+            {% endif %}
         </div>
-    {% endif %}
     </div>
 </div>
 {% include footer.html %}

--- a/_sass/layouts/_goals.scss
+++ b/_sass/layouts/_goals.scss
@@ -1,0 +1,11 @@
+.layout-goals {
+  .goals-page-description {
+    margin-bottom: 20px;
+  }
+}
+
+.layout-goals.contrast-high {
+  .goals-page-description {
+    color: $color-light-highContrast;
+  }
+}

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -33,3 +33,4 @@
 @import "layouts/homeintro";
 @import "layouts/goal-by-target-vertical";
 @import "layouts/frontpage_alt";
+@import "layouts/goals";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,6 +260,23 @@ frontpage_introduction_banner:
 goal_image_base: https://open-sdg.github.io/sdg-translations/assets/img/goals
 ```
 
+### goals_page
+
+_Optional_: This setting controls certain aspects of the `goals` layout. The available settings are:
+
+* `title`: Controls the title of the goals page. Defaults to "Goals".
+* `description`: Controls the introductory text under the title. If omitted there will be no introductory text.
+
+Here is an example of using these settings:
+
+```yaml
+goals_page:
+    title: title goes here
+    description: description goes here
+```
+
+As always, for multilingual support, these settings can refer to translation keys.
+
 ### graph_color_set
 
 _Optional_: This setting can be used to customize the color set used in the charts. There are four possible entries:

--- a/tests/accessibility/pa11yci-contrast.json
+++ b/tests/accessibility/pa11yci-contrast.json
@@ -10,6 +10,7 @@
         "http://127.0.0.1:4000/4/",
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
-        "http://127.0.0.1:4000/testing-goal-by-target/"
+        "http://127.0.0.1:4000/testing-goal-by-target/",
+        "http://127.0.0.1:4000/frontpage-legacy/"
     ]
 }

--- a/tests/accessibility/pa11yci-contrast.json
+++ b/tests/accessibility/pa11yci-contrast.json
@@ -11,6 +11,7 @@
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
         "http://127.0.0.1:4000/testing-goal-by-target/",
-        "http://127.0.0.1:4000/frontpage-legacy/"
+        "http://127.0.0.1:4000/frontpage-legacy/",
+        "http://127.0.0.1:4000/goals/"
     ]
 }

--- a/tests/accessibility/pa11yci-desktop.json
+++ b/tests/accessibility/pa11yci-desktop.json
@@ -6,6 +6,7 @@
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
         "http://127.0.0.1:4000/testing-goal-by-target/",
-        "http://127.0.0.1:4000/frontpage-legacy/"
+        "http://127.0.0.1:4000/frontpage-legacy/",
+        "http://127.0.0.1:4000/goals/"
     ]
 }

--- a/tests/accessibility/pa11yci-desktop.json
+++ b/tests/accessibility/pa11yci-desktop.json
@@ -5,6 +5,7 @@
         "http://127.0.0.1:4000/4/",
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
-        "http://127.0.0.1:4000/testing-goal-by-target/"
+        "http://127.0.0.1:4000/testing-goal-by-target/",
+        "http://127.0.0.1:4000/frontpage-legacy/"
     ]
 }

--- a/tests/accessibility/pa11yci-mobile.json
+++ b/tests/accessibility/pa11yci-mobile.json
@@ -12,6 +12,7 @@
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
         "http://127.0.0.1:4000/testing-goal-by-target/",
-        "http://127.0.0.1:4000/frontpage-legacy/"
+        "http://127.0.0.1:4000/frontpage-legacy/",
+        "http://127.0.0.1:4000/goals/"
     ]
 }

--- a/tests/accessibility/pa11yci-mobile.json
+++ b/tests/accessibility/pa11yci-mobile.json
@@ -11,6 +11,7 @@
         "http://127.0.0.1:4000/4/",
         "http://127.0.0.1:4000/1-1-1/",
         "http://127.0.0.1:4000/reporting-status/",
-        "http://127.0.0.1:4000/testing-goal-by-target/"
+        "http://127.0.0.1:4000/testing-goal-by-target/",
+        "http://127.0.0.1:4000/frontpage-legacy/"
     ]
 }

--- a/tests/data/custom-translations/en/custom.yml
+++ b/tests/data/custom-translations/en/custom.yml
@@ -4,3 +4,5 @@ category: My English custom category
 disclaimer_message: This is my disclaimer message.
 reporting_status_title: My reporting status title
 reporting_status_description: My reporting status description
+goals_page_title: My goals page title
+goals_page_description: My goals page description

--- a/tests/data/custom-translations/en/custom.yml
+++ b/tests/data/custom-translations/en/custom.yml
@@ -6,3 +6,4 @@ reporting_status_title: My reporting status title
 reporting_status_description: My reporting status description
 goals_page_title: My goals page title
 goals_page_description: My goals page description
+frontpage_introduction_banner_title: My frontpage introduction banner title

--- a/tests/data/custom-translations/es/custom.yml
+++ b/tests/data/custom-translations/es/custom.yml
@@ -6,3 +6,4 @@ reporting_status_title: My Spanish reporting status title
 reporting_status_description: My Spanish reporting status description
 goals_page_title: My Spanish goals page title
 goals_page_description: My Spanish goals page description
+frontpage_introduction_banner_title: My Spanish frontpage introduction banner title

--- a/tests/data/custom-translations/es/custom.yml
+++ b/tests/data/custom-translations/es/custom.yml
@@ -4,3 +4,5 @@ category: My Spanish custom category
 disclaimer_message: This is my Spanish disclaimer message.
 reporting_status_title: My Spanish reporting status title
 reporting_status_description: My Spanish reporting status description
+goals_page_title: My Spanish goals page title
+goals_page_description: My Spanish goals page description

--- a/tests/data/custom-translations/fr/custom.yml
+++ b/tests/data/custom-translations/fr/custom.yml
@@ -6,3 +6,4 @@ reporting_status_title: My French Canadian reporting status title
 reporting_status_description: My French Canadian reporting status description
 goals_page_title: My French Canadian goals page title
 goals_page_description: My French Canadian goals page description
+frontpage_introduction_banner_title: My French Canadian frontpage introduction banner title

--- a/tests/data/custom-translations/fr/custom.yml
+++ b/tests/data/custom-translations/fr/custom.yml
@@ -4,3 +4,5 @@ category: My French Canadian custom category
 disclaimer_message: This is my French Canadian disclaimer message.
 reporting_status_title: My French Canadian reporting status title
 reporting_status_description: My French Canadian reporting status description
+goals_page_title: My French Canadian goals page title
+goals_page_description: My French Canadian goals page description

--- a/tests/features/Homepage.feature
+++ b/tests/features/Homepage.feature
@@ -12,19 +12,19 @@ Feature: Homepage
     And I should see "My frontpage introduction banner description"
 
   Scenario: The heading text can be customised
-    Then I should see "My custom frontpage heading"
+    Then I should see "My custom frontpage goals grid title"
 
   Scenario: All available goal icons are visible
     Then I should see 4 "goal icon" elements
 
-  Scenario: The download-all button is available
+  Scenario: Additional content is shown below the goals
     Then I should see "Download all data"
-
-  Scenario: An alternate homepage is available as well
-    And I am on "/frontpage-alt"
-    Then I should see "My frontpage introduction banner title"
-    And I should see "My frontpage introduction banner description"
-    And I should see "The Sustainable Development Goals"
-    And I should see "Download all data"
     And I should see "Useful resources"
     And I should see "Publications"
+
+  Scenario: A legacy homepage is available as well
+    And I am on "/frontpage-legacy"
+    Then I should see "My frontpage introduction banner title"
+    And I should see "My frontpage introduction banner description"
+    And I should see "My custom frontpage heading"
+    And I should see 4 "goal icon" elements

--- a/tests/features/LanguageSwitcher.feature
+++ b/tests/features/LanguageSwitcher.feature
@@ -6,10 +6,10 @@ Feature: Language switcher
 
   Scenario: Language switcher works on the homepage
     Given I am on the homepage
-    Then I should see "My custom frontpage instructions"
+    Then I should see "My frontpage introduction banner title"
     And I click on "the language toggle dropdown"
     And I follow "the first language option"
-    Then I should see "My Spanish frontpage instructions"
+    Then I should see "My Spanish frontpage introduction banner title"
 
   Scenario: Lanugage switcher works on a goal page
     Given I am on "/1"
@@ -30,4 +30,4 @@ Feature: Language switcher
     And I click on "the language toggle dropdown"
     And I follow "the last language option"
     Then I should be on "/fr-CA/"
-    And I should see "My French Canadian frontpage instructions"
+    And I should see "My French Canadian frontpage introduction banner title"

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -146,6 +146,10 @@ reporting_status:
   title: custom.reporting_status_title
   description: custom.reporting_status_description
 
+goals_page:
+  title: custom.goals_page_title
+  description: custom.goals_page_description
+
 frontpage_goals_grid:
   title: The Sustainable Development Goals
   description: Click on each [goal](../goals) for data for Sustainable Development Goal global indicators.

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -18,10 +18,10 @@ create_goals:
   layout: goal
 create_pages:
   pages:
-    - folder: /frontpage-alt
-      layout: frontpage-alt
+    - folder: /frontpage-legacy
+      layout: frontpage
     - folder: /
-      layout: goals
+      layout: frontpage-alt
     - folder: /goals
       layout: goals
     - folder: /reporting-status
@@ -73,8 +73,8 @@ menu:
     translation_key: menu.reporting_status
   - path: about
     translation_key: menu.about
-  - path: frontpage-alt
-    translation_key: Alternate frontpage
+  - path: frontpage-legacy
+    translation_key: Legacy frontpage
 
 footer_menu:
   - path: mailto:test@example.com
@@ -135,7 +135,7 @@ date_formats:
     fr: '%d %B %Y'
 
 frontpage_introduction_banner:
-  title: My frontpage introduction banner title
+  title: custom.frontpage_introduction_banner_title
   description: My frontpage introduction banner description
 
 disclaimer:
@@ -151,8 +151,8 @@ goals_page:
   description: custom.goals_page_description
 
 frontpage_goals_grid:
-  title: The Sustainable Development Goals
-  description: Click on each [goal](../goals) for data for Sustainable Development Goal global indicators.
+  title: My custom frontpage goals grid title
+  description: Click on each [goal](goals) for data for Sustainable Development Goal global indicators.
 
 frontpage_cards:
   - title: Download all data


### PR DESCRIPTION
This will fail testing at the moment, but demonstrates a quick example of simplifying the goals layout and configuring its intro.