### PR TITLE
Line height fix for Firefox search icon

### DIFF
--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -157,8 +157,9 @@ header {
   }
 }
 #search-btn {
+  line-height: 15px;
   height: 34px;
-  }
+}
 
 .table {
   .table-value {


### PR DESCRIPTION
This is a long-standing issue that only seems to happen in Firefox, which I have been meaning to investigate. This is a screenshot of the problem:

![screenshot-127 0 0 1_4000-2020 07 31-23_35_32](https://user-images.githubusercontent.com/1319083/89093255-a5dca280-d386-11ea-9614-556b25508983.png)

This is a screenshot with this PR.

![screenshot-127 0 0 1_4000-2020 07 31-23_34_40](https://user-images.githubusercontent.com/1319083/89093249-9a897700-d386-11ea-8776-ef50799a4fff.png)

Testing in IE, Chrome, etc will be needed.
