### PR TITLE
Custom source-file downloads

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -42,6 +42,7 @@ var indicatorModel = function (options) {
   this.graphLimits = options.graphLimits;
   this.stackedDisaggregation = options.stackedDisaggregation;
   this.graphAnnotations = options.graphAnnotations;
+  this.indicatorDownloads = options.indicatorDownloads;
 
   // calculate some initial values:
   this.years = helpers.getUniqueValuesByProperty(helpers.YEAR_COLUMN, this.data);
@@ -282,7 +283,8 @@ var indicatorModel = function (options) {
       graphLimits: this.graphLimits,
       stackedDisaggregation: this.stackedDisaggregation,
       graphAnnotations: this.graphAnnotations,
-      chartTitle: this.chartTitle
+      chartTitle: this.chartTitle,
+      indicatorDownloads: this.indicatorDownloads,
     });
   };
 };

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -454,7 +454,7 @@ var indicatorView = function (model, options) {
 
     this.createDownloadButton(chartInfo.selectionsTable, 'Chart', chartInfo.indicatorId, '#chartSelectionDownload');
     this.createSourceButton(chartInfo.shortIndicatorId, '#chartSelectionDownload');
-    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#selectionsChart');
+    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#chartSelectionDownload');
 
     $("#btnSave").click(function() {
       var filename = chartInfo.indicatorId + '.png',
@@ -615,7 +615,7 @@ var indicatorView = function (model, options) {
     $('#tableSelectionDownload').empty();
     this.createDownloadButton(chartInfo.selectionsTable, 'Table', chartInfo.indicatorId, '#tableSelectionDownload');
     this.createSourceButton(chartInfo.shortIndicatorId, '#tableSelectionDownload');
-    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#selectionsTable');
+    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#tableSelectionDownload');
   };
 
 

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -454,6 +454,7 @@ var indicatorView = function (model, options) {
 
     this.createDownloadButton(chartInfo.selectionsTable, 'Chart', chartInfo.indicatorId, '#chartSelectionDownload');
     this.createSourceButton(chartInfo.shortIndicatorId, '#chartSelectionDownload');
+    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#selectionsChart');
 
     $("#btnSave").click(function() {
       var filename = chartInfo.indicatorId + '.png',
@@ -614,6 +615,7 @@ var indicatorView = function (model, options) {
     $('#tableSelectionDownload').empty();
     this.createDownloadButton(chartInfo.selectionsTable, 'Table', chartInfo.indicatorId, '#tableSelectionDownload');
     this.createSourceButton(chartInfo.shortIndicatorId, '#tableSelectionDownload');
+    this.createIndicatorDownloadButtons(chartInfo.indicatorDownloads, chartInfo.shortIndicatorId, '#selectionsTable');
   };
 
 
@@ -743,23 +745,25 @@ var indicatorView = function (model, options) {
       'class': 'btn btn-primary btn-download',
       'tabindex': 0
     }));
-    {% if site.data[page.language].indicator_downloads %}
-      {% for download_type in site.data[page.language].indicator_downloads %}
-        {% if site.data[page.language].indicator_downloads[download_type][page.indicator.number] %}
-          {% assign button_label = indicator_download | t %}
-          var gaLabel = '{{ button_label }}: ' + indicatorId;
-          var downloadHref = opensdg.remoteDataBaseUrl + '/{{ site.data[page.language].indicator_downloads[download_type][page.indicator.number] }}';
-          $(el).append($('<a />').text('{{ button_label }}')
-          .attr(opensdg.autotrack('indicator_download', 'Downloads', '{{ button_label }}', gaLabel))
-          .attr({
-            'href': downloadHref,
-            'title': '{{ button_label }}',
-            'class': 'btn btn-primary btn-download',
-            'tabindex': 0
-          }));
-        {% endif %}
-      {% endfor %}
-    {% endif %}
+  }
+
+  this.createIndicatorDownloadButtons = function(indicatorDownloads, indicatorId, el) {
+    if (indicatorDownloads) {
+      for (var buttonLabel of Object.keys(indicatorDownloads)) {
+        var href = indicatorDownloads[buttonLabel].href;
+        var buttonLabelTranslated = translations.t(buttonLabel);
+        var gaLabel = buttonLabel + ': ' + indicatorId;
+        $(el).append($('<a />').text(buttonLabelTranslated)
+        .attr(opensdg.autotrack(buttonLabel, 'Downloads', buttonLabel, gaLabel))
+        .attr({
+          'href': opensdg.remoteDataBaseUrl + '/' + href,
+          'download': href.split('/').pop(),
+          'title': buttonLabelTranslated,
+          'class': 'btn btn-primary btn-download',
+          'tabindex': 0
+        }));
+      }
+    }
   }
 
   this.tableHasData = function(table) {

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -743,6 +743,23 @@ var indicatorView = function (model, options) {
       'class': 'btn btn-primary btn-download',
       'tabindex': 0
     }));
+    {% if site.data[page.language].indicator_downloads %}
+      {% for download_type in site.data[page.language].indicator_downloads %}
+        {% if site.data[page.language].indicator_downloads[download_type][page.indicator.number] %}
+          {% assign button_label = indicator_download | t %}
+          var gaLabel = '{{ button_label }}: ' + indicatorId;
+          var downloadHref = opensdg.remoteDataBaseUrl + '/{{ site.data[page.language].indicator_downloads[download_type][page.indicator.number] }}';
+          $(el).append($('<a />').text('{{ button_label }}')
+          .attr(opensdg.autotrack('indicator_download', 'Downloads', '{{ button_label }}', gaLabel))
+          .attr({
+            'href': downloadHref,
+            'title': '{{ button_label }}',
+            'class': 'btn btn-primary btn-download',
+            'tabindex': 0
+          }));
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   }
 
   this.tableHasData = function(table) {

--- a/_includes/components/indicator/indicator-main.html
+++ b/_includes/components/indicator/indicator-main.html
@@ -19,6 +19,7 @@
   data-graphlimits="{{ page.indicator.graph_limits | jsonify | xml_escape }}"
   data-stackeddisaggregation="{{ page.indicator.graph_stacked_disaggregation }}"
   data-graphannotations="{{ page.indicator.graph_annotations | jsonify | xml_escape }}"
+  data-indicatordownloads="{{ site.data[page.language].indicator_downloads[page.indicator.number] | jsonify | xml_escape }}"
 >
   {% if show_data %}
   <span role="status" class="sr-only" id="indicator-data-view-status"></span>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -69,7 +69,8 @@ $(function() {
               startValues: domData.startvalues,
               graphLimits: domData.graphlimits,
               stackedDisaggregation: domData.stackeddisaggregation,
-              graphAnnotations: domData.graphannotations
+              graphAnnotations: domData.graphannotations,
+              indicatorDownloads: domData.indicatordownloads,
             }),
             view  = new indicatorView(model, {
               rootElement: '#indicatorData',


### PR DESCRIPTION
Fixes #194 

This is intended to allow for download buttons for indicator-specific SDMX files, although it is general-purpose and any indicator-specific file downloads. Testing is possible, though a little tricky because it depends on PRs in sdg-build and jekyll-open-sdg-plugins. I still need to add documentation to this PR, but here are the steps to test:

1. Add something like this to the data repository config (this would be the config to add a download button for CSV files):
        
        indicator_downloads:
          - button_label: indicator.download_source
            source_pattern: data/indicator_*.csv
            indicator_id_pattern: indicator_(.*)
            output_folder: data-csv

2. Change the data repository requirements.txt to point to my fork of sdg-build:

        git+git://github.com/brockfanning/sdg-build-1@indicator-downloads

3. Change the site repository Gemfile to point to my fork of jekyll-open-sdg-plugins:

        gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'indicator-downloads'

4. Change the site repository config to point to this branch:

        remote_theme: brockfanning/open-sdg@indicator-downloads

Some details on those `indicator_downloads` config options for the data repo:
* button_label: This is intended to be a translation key for the label of the download button
* source_pattern: This is a wildcard-style description of where the source files are in the data repository
* indicator_id_pattern: This is a regular expression for how to convert the source filenames into indicator ids. The `(.*)` is where the indicator id is.
* output_folder: This is the name of a folder to create and place the files in. It doesn't really make a difference what you put here. (And maybe I should automate it.)

The config - especially the regular expression - is a bit technical for my tastes. But I'm not sure how to make it simpler.

The other PRs this depends on are:
* https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/39
* https://github.com/open-sdg/sdg-build/pull/167