### PR TITLE
Site configuration builder form

### DIFF
--- a/_layouts/site-config-builder.html
+++ b/_layouts/site-config-builder.html
@@ -24,7 +24,7 @@
         margin-bottom: 30px;
         padding-bottom: 30px;
       }
-      div[data-schemapath="root"] > .je-panel > .container > div > .columns > div[data-schematype] > .form-group > .je-label {
+      div[data-schemapath="root"] > .je-panel > .container > div > .columns > div[data-schematype] > .form-group > .form-label {
         font-size: 1.2rem;
         font-weight: 500;
       }

--- a/_layouts/site-config-builder.html
+++ b/_layouts/site-config-builder.html
@@ -8,22 +8,25 @@
     <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-exp.min.css">
     <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-icons.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.css" integrity="sha512-lB03MbtC3LxImQ+BKnZIyvVHTQ8SSmQ15AhVh5U/+CCp4wKtZMvgLGXbZIjIBBbnKsmk3/6n2vcF8a9CtVVSfA==" crossorigin="anonymous" />
 
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/ace.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.js" integrity="sha512-ksSfTk6JIdsze75yZ8c+yDVLu09SNefa9IicxEE+HZvWo9kLPY1vrRlmucEMHQReWmEdKqusQWaDMpkTb3M2ug==" crossorigin="anonymous"></script>
 
     <style>
       .container {
         max-width:960px;
         margin: 0 auto
       }
-      .columns > div[data-schematype] {
+      div[data-schemapath="root"] > .je-panel > .container > div > .columns {
         margin-bottom: 30px;
         padding-bottom: 30px;
       }
-      .column > .je-panel > div > div[data-schemapath] > select {
-        display: none !important;
+      div[data-schemapath="root"] > .je-panel > .container > div > .columns > div[data-schematype] > .form-group > .je-label {
+        font-size: 1.2rem;
+        font-weight: 500;
       }
     </style>
   </head>

--- a/_layouts/site-config-builder.html
+++ b/_layouts/site-config-builder.html
@@ -10,11 +10,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.css" integrity="sha512-lB03MbtC3LxImQ+BKnZIyvVHTQ8SSmQ15AhVh5U/+CCp4wKtZMvgLGXbZIjIBBbnKsmk3/6n2vcF8a9CtVVSfA==" crossorigin="anonymous" />
 
-    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/ace.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.js" integrity="sha512-ksSfTk6JIdsze75yZ8c+yDVLu09SNefa9IicxEE+HZvWo9kLPY1vrRlmucEMHQReWmEdKqusQWaDMpkTb3M2ug==" crossorigin="anonymous"></script>
-
     <style>
       .container {
         max-width:960px;
@@ -28,18 +23,34 @@
         font-size: 1.2rem;
         font-weight: 500;
       }
+      #button_holder {
+        margin-bottom: 30px;
+        margin-top: 15px;
+      }
     </style>
   </head>
   <body>
-    <div class='container'>
-      <div class='columns'>
-        <h1 class='col-md-12'>Open SDG site configuration</h1>
+    <div class="container">
+      <div class="columns">
+        <h1 class="col-md-12">Open SDG site configuration</h1>
       </div>
-      <div class='columns'>
-        <div class='column col-md-12' id='editor_holder'></div>
+      <div class="columns">
+        <div class="column col-md-12" id="button_holder">
+          <button id="import">Import</button>
+          <button id="export">Export</button>
+        </div>
+      </div>
+      <div class="columns">
+        <div class="column col-md-12" id="editor_holder"></div>
       </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/ace.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.js" integrity="sha512-ksSfTk6JIdsze75yZ8c+yDVLu09SNefa9IicxEE+HZvWo9kLPY1vrRlmucEMHQReWmEdKqusQWaDMpkTb3M2ug==" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@3.14.0/dist/js-yaml.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
     <script>
       window.ace.config.set("basePath", "https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/");
 
@@ -53,11 +64,35 @@
         disable_edit_json: true,
         disable_properties: true,
         remove_button_labels: true,
+        remove_empty_properties: true,
 
         // The schema for the editor
         schema: {
-          $ref: "assets/js/site-config-schema.json"
+          $ref: "{{ site.baseurl }}/assets/js/site-config-schema.json"
         },
+      });
+
+      editor.on('ready', function() {
+        document.getElementById('import').addEventListener('click', function() {
+          alert('Import not yet implemented');
+        });
+
+        new ClipboardJS('#export', {
+          text: function() {
+            var config = editor.getValue();
+            if (typeof config.additional_settings !== 'undefined') {
+              var additional = jsyaml.safeLoad(config.additional_settings);
+              delete config.additional_settings;
+              if (additional) {
+                for (var key of Object.keys(additional)) {
+                  config[key] = additional[key];
+                }
+              }
+            }
+            alert('Site configuration copied to clipboard.');
+            return jsyaml.safeDump(config);
+          }
+        });
       });
     </script>
   </body>

--- a/_layouts/site-config-builder.html
+++ b/_layouts/site-config-builder.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Open SDG site configuration</title>
+
+    <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-exp.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-icons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/ace.min.js"></script>
+
+    <style>
+      .container {
+        max-width:960px;
+        margin: 0 auto
+      }
+      .columns > div[data-schematype] {
+        margin-bottom: 30px;
+        padding-bottom: 30px;
+      }
+      .column > .je-panel > div > div[data-schemapath] > select {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div class='container'>
+      <div class='columns'>
+        <h1 class='col-md-12'>Open SDG site configuration</h1>
+      </div>
+      <div class='columns'>
+        <div class='column col-md-12' id='editor_holder'></div>
+      </div>
+    </div>
+
+    <script>
+      window.ace.config.set("basePath", "https://cdn.jsdelivr.net/npm/ace-builds@latest/src-noconflict/");
+
+      var editor = new JSONEditor(document.getElementById('editor_holder'), {
+        theme: 'spectre',
+        iconlib: 'spectre',
+        ajax: true,
+        disable_array_delete_all_rows: true,
+        disable_array_delete_last_row: true,
+        disable_array_reorder: true,
+        disable_edit_json: true,
+        disable_properties: true,
+        remove_button_labels: true,
+
+        // The schema for the editor
+        schema: {
+          $ref: "assets/js/site-config-schema.json"
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/assets/js/site-config-schema.json
+++ b/assets/js/site-config-schema.json
@@ -546,6 +546,7 @@
             "title": "Graph color number",
             "type": "integer",
             "description": "This setting can be used to limit the length of the list of colors selected via graph_color_set.",
+            "default": 6,
             "links": [
                 {
                     "rel": "More information",

--- a/assets/js/site-config-schema.json
+++ b/assets/js/site-config-schema.json
@@ -389,7 +389,8 @@
                     "title": {
                         "type": "string",
                         "title": "Title",
-                        "description": "The card's title."
+                        "description": "The card's title.",
+                        "default": "My card title"
                     },
                     "content": {
                         "type": "string",

--- a/assets/js/site-config-schema.json
+++ b/assets/js/site-config-schema.json
@@ -31,127 +31,27 @@
                 }
             ]
         },
-        "remote_data_prefix": {
-            "type": "string",
-            "title": "Data repository URL",
-            "description": "Specify the URL of your published data repository.",
-            "default": "https://my-github-org.github.io/my-data-repository",
-            "examples": [
-                "https://my-github-org.github.io/my-data-repository"
-            ],
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#remote_data_prefix"
+        "analytics": {
+            "options": {"collapsed": true},
+            "type": "object",
+            "title": "Analytics",
+            "description": "If these settings are used, usage statistics will be sent to Google Analytics.",
+            "properties": {
+                "ga_prod": {
+                    "type": "string",
+                    "title": "Google Analytics tracking ID",
+                    "description": "The tracking ID (UA code) for your property on Google Analytics."
                 }
-            ]
-        },
-        "languages": {
-            "options": {
-                "collapsed": true
-            },
-            "format": "table",
-            "type": "array",
-            "title": "Languages",
-            "description": "This setting controls the languages to be used on the site.",
-            "default": ["en"],
-            "items": {
-                "type": "string",
-                "title": "Language"
             },
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#languages"
-                }
-            ]
-        },
-        "environment": {
-            "type": "string",
-            "title": "Environment",
-            "description": "Which environment (staging or production) this configuration is for.",
-            "default": "staging",
-            "format": "choices",
-            "enum": ["staging", "production"],
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#environment"
-                }
-            ]
-        },
-        "goal_image_base": {
-            "type": "string",
-            "title": "Goal image base URL",
-            "description": "This setting controls the base URL for downloading the imagery for the goals.",
-            "default": "https://open-sdg.github.io/sdg-translations/assets/img/goals",
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#goal_image_base"
-                }
-            ]
-        },
-        "menu": {
-            "options": {
-                "collapsed": true
-            },
-            "format": "table",
-            "type": "array",
-            "title": "Main menu",
-            "description": "The links to display in the main menu.",
-            "default": [
-                {
-                    "path": "/reporting-status",
-                    "translation_key": "menu.reporting_status"
-                },
-                {
-                    "path": "/about",
-                    "translation_key": "menu.about"
-                }
-            ],
-            "items": {
-                "$ref": "#/definitions/menu_item"
-            },
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#menu"
-                }
-            ]
-        },
-        "footer_menu": {
-            "options": {
-                "collapsed": true
-            },
-            "format": "table",
-            "type": "array",
-            "title": "Footer menu",
-            "description": "The links to display in the footer menu.",
-            "default": [
-                {
-                    "path": "mailto:my-email-address@example.com",
-                    "translation_key": "menu.contact_us"
-                },
-                {
-                    "path": "https://twitter.com/MyTwitterAccount",
-                    "translation_key": "general.twitter"
-                }
-            ],
-            "items": {
-                "$ref": "#/definitions/menu_item"
-            },
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#footer_menu"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#analytics"
                 }
             ]
         },
         "country": {
-            "options": {
-                "collapsed": true
-            },
+            "options": {"collapsed": true},
             "type": "object",
             "title": "Country information",
             "description": "Information about your country (or region, locality, etc.)",
@@ -182,10 +82,197 @@
                 }
             ]
         },
-        "email_contacts": {
-            "options": {
-                "collapsed": true
+        "create_goals": {
+            "options": {"collapsed": true},
+            "type": "object",
+            "title": "Create goals",
+            "description": "This setting can be used to automatically create the goal pages.",
+            "default": {
+                "layout": "goal-by-target-vertical"
             },
+            "properties": {
+                "layout": {
+                    "type": "string",
+                    "title": "Layout",
+                    "description": "The layout to use for the goal pages.",
+                    "format": "choices",
+                    "enum": ["goal", "goal-by-target", "goal-by-target-vertical"]
+                }
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_goals"
+                }
+            ]
+        },
+        "create_indicators": {
+            "options": {"collapsed": true},
+            "type": "object",
+            "title": "Create indicators",
+            "description": "This setting can be used to automatically create the indicator pages.",
+            "default": {
+                "layout": "indicator"
+            },
+            "properties": {
+                "layout": {
+                    "type": "string",
+                    "title": "Layout",
+                    "description": "The layout to use for the indicator pages.",
+                    "format": "choices",
+                    "enum": ["indicator"]
+                }
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_indicators"
+                }
+            ]
+        },
+        "create_pages": {
+            "options": {"collapsed": true},
+            "format": "table",
+            "type": "array",
+            "title": "Create pages",
+            "description": "This setting can be used to automatically create the pages.",
+            "default": [
+                {
+                    "folder": "/",
+                    "layout": "frontpage-alt"
+                },
+                {
+                    "folder": "/goals",
+                    "layout": "goals"
+                },
+                {
+                    "folder": "/reporting-status",
+                    "layout": "reportingstatus"
+                },
+                {
+                    "filename": "indicators.json",
+                    "folder": "/",
+                    "layout": "indicators.json"
+                },
+                {
+                    "folder": "/search",
+                    "layout": "search"
+                }
+            ],
+            "items": {
+                "type": "object",
+                "title": "Page",
+                "default": {
+                    "filename": "index.html"
+                },
+                "required": [
+                    "layout",
+                    "folder",
+                    "filename"
+                ],
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "title": "Filename",
+                        "description": "The filename for the page - usually 'index.html'."
+                    },
+                    "folder": {
+                        "type": "string",
+                        "title": "Folder",
+                        "description": "The folder path for the page."
+                    },
+                    "layout": {
+                        "type": "string",
+                        "title": "Layout",
+                        "description": "The layout to use for the page."
+                    }
+                }
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_pages"
+                }
+            ]
+        },
+        "custom_css": {
+            "options": {"collapsed": true},
+            "format": "table",
+            "type": "array",
+            "title": "Custom CSS files",
+            "description": "Deprecated: instead of using this, it is recommended to put custom CSS in a _sass/custom.scss file.",
+            "items": {
+                "type": "string",
+                "title": "Custom CSS file"
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_css"
+                }
+            ]
+        },
+        "custom_js": {
+            "options": {"collapsed": true},
+            "format": "table",
+            "type": "array",
+            "title": "Custom JavaScript files",
+            "description": "This setting can be used to load additional JavaScript files on each page.",
+            "items": {
+                "type": "string",
+                "title": "Custom JavaScript file"
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_js"
+                }
+            ]
+        },
+        "data_edit_url": {
+            "type": "string",
+            "title": "Data edit URL",
+            "description": "This setting controls the URL of the 'Edit Data' buttons that appear on the staging site's indicator pages.",
+            "default": "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv",
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#data_edit_url"
+                }
+            ]
+        },
+        "disclaimer": {
+            "options": {"collapsed": true},
+            "type": "object",
+            "title": "Disclaimer",
+            "description": "This setting controls the content of the disclaimer that appears at the top of each page.",
+            "examples": [
+                {
+                    "phase": "BETA",
+                    "message": "This is my disclaimer message"
+                }
+            ],
+            "properties": {
+                "phase": {
+                    "type": "string",
+                    "title": "Phase",
+                    "description": "The development phase of your platform (alpha, beta, etc.)"
+                },
+                "message": {
+                    "type": "string",
+                    "title": "Message",
+                    "description": "A short disclaimer message."
+                }
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#disclaimer"
+                }
+            ]
+        },
+        "email_contacts": {
+            "options": {"collapsed": true},
             "type": "object",
             "title": "Email addresses",
             "description": "Email addresses to publish on your platform.",
@@ -235,107 +322,48 @@
                 }
             ]
         },
-        "data_edit_url": {
+        "environment": {
             "type": "string",
-            "title": "Data edit URL",
-            "description": "This setting controls the URL of the 'Edit Data' buttons that appear on the staging site's indicator pages.",
-            "default": "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv",
+            "title": "Environment",
+            "description": "Which environment (staging or production) this configuration is for.",
+            "default": "staging",
+            "format": "choices",
+            "enum": ["staging", "production"],
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#data_edit_url"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#environment"
                 }
             ]
         },
-        "metadata_edit_url": {
-            "type": "string",
-            "title": "Metadata edit URL",
-            "description": "This setting controls the URL of the 'Edit Metadata' buttons that appear on the staging site's indicator pages.",
-            "default": "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md",
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#metadata_edit_url"
-                }
-            ]
-        },
-        "plugins": {
-            "options": {
-                "collapsed": true
-            },
+        "footer_menu": {
+            "options": {"collapsed": true},
             "format": "table",
             "type": "array",
-            "title": "Plugins",
-            "description": "This setting controls the Jekyll plugins to be used on the site.",
-            "default": ["jekyll-remote-theme", "jekyll-open-sdg-plugins"],
-            "items": {
-                "type": "string",
-                "title": "Plugin"
-            },
-            "links": [
+            "title": "Footer menu",
+            "description": "The links to display in the footer menu.",
+            "default": [
                 {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#plugins"
-                }
-            ]
-        },
-        "analytics": {
-            "options": {
-                "collapsed": true
-            },
-            "type": "object",
-            "title": "Google Analytics",
-            "description": "If these settings are used, usage statistics will be sent to Google Analytics.",
-            "properties": {
-                "ga_prod": {
-                    "type": "string",
-                    "title": "Google Analytics tracking ID",
-                    "description": "The tracking ID (UA code) for your property on Google Analytics."
-                }
-            },
-            "links": [
+                    "path": "mailto:my-email-address@example.com",
+                    "translation_key": "menu.contact_us"
+                },
                 {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#analytics"
-                }
-            ]
-        },
-        "disclaimer": {
-            "options": {
-                "collapsed": true
-            },
-            "type": "object",
-            "title": "Disclaimer",
-            "description": "This setting controls the content of the disclaimer that appears at the top of each page.",
-            "examples": [
-                {
-                    "phase": "BETA",
-                    "message": "This is my disclaimer message"
+                    "path": "https://twitter.com/MyTwitterAccount",
+                    "translation_key": "general.twitter"
                 }
             ],
-            "properties": {
-                "phase": {
-                    "type": "string",
-                    "title": "Phase",
-                    "description": "The development phase of your platform (alpha, beta, etc.)"
-                },
-                "message": {
-                    "type": "string",
-                    "title": "Message",
-                    "description": "A short disclaimer message."
-                }
+            "items": {
+                "$ref": "#/definitions/menu_item"
             },
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#disclaimer"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#footer_menu"
                 }
             ]
         },
         "frontpage_cards": {
-            "options": {
-                "collapsed": true
-            },
+            "options": {"collapsed": true},
             "type": "array",
             "title": "Frontpage cards",
             "description": "This setting is only used in the frontpage-alt layout. It can display any number of 'cards' in 3-column rows, beneath the grid of goal tiles.",
@@ -403,9 +431,7 @@
             ]
         },
         "frontpage_goals_grid": {
-            "options": {
-                "collapsed": true
-            },
+            "options": {"collapsed": true},
             "type": "object",
             "title": "Frontpage goals grid",
             "description": "This setting is only used in the frontpage-alt layout. It can display a title and description above the grid of goal tiles.",
@@ -446,9 +472,7 @@
             ]
         },
         "frontpage_introduction_banner": {
-            "options": {
-                "collapsed": true
-            },
+            "options": {"collapsed": true},
             "type": "object",
             "title": "Frontpage introduction banner",
             "description": "This setting is only used in the frontpage-alt layout. It can display a title and description in a banner at the top of the frontpage.",
@@ -460,10 +484,20 @@
                 }
             ]
         },
+        "goal_image_base": {
+            "type": "string",
+            "title": "Goal image base URL",
+            "description": "This setting controls the base URL for downloading the imagery for the goals.",
+            "default": "https://open-sdg.github.io/sdg-translations/assets/img/goals",
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#goal_image_base"
+                }
+            ]
+        },
         "goals_page": {
-            "options": {
-                "collapsed": true
-            },
+            "options": {"collapsed": true},
             "type": "object",
             "title": "Goals page",
             "description": "This setting is used in the 'goals' layout. It can display a title and description above the grid of goal tiles.",
@@ -490,160 +524,133 @@
                 }
             ]
         },
-        "create_goals": {
-            "options": {
-                "collapsed": true
-            },
-            "type": "object",
-            "title": "Goal pages",
-            "description": "This setting can be used to automatically create the goal pages.",
-            "default": {
-                "layout": "goal-by-target-vertical"
-            },
-            "properties": {
-                "layout": {
-                    "type": "string",
-                    "title": "Layout",
-                    "description": "The layout to use for the goal pages.",
-                    "format": "choices",
-                    "enum": ["goal", "goal-by-target", "goal-by-target-vertical"]
-                }
-            },
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_goals"
-                }
-            ]
-        },
-        "create_indicators": {
-            "options": {
-                "collapsed": true
-            },
-            "type": "object",
-            "title": "Indicator pages",
-            "description": "This setting can be used to automatically create the indicator pages.",
-            "default": {
-                "layout": "indicator"
-            },
-            "properties": {
-                "layout": {
-                    "type": "string",
-                    "title": "Layout",
-                    "description": "The layout to use for the indicator pages.",
-                    "format": "choices",
-                    "enum": ["indicator"]
-                }
-            },
-            "links": [
-                {
-                    "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_indicators"
-                }
-            ]
-        },
-        "create_pages": {
-            "options": {
-                "collapsed": true
-            },
+        "graph_color_list": {
+            "options": {"collapsed": true},
             "format": "table",
             "type": "array",
-            "title": "Create pages",
-            "description": "This setting can be used to automatically create the pages.",
+            "title": "Graph color list",
+            "description": "This setting can be used to define a set of colors to be used in the charts. This is only used when graph_color_set is 'custom'.",
+            "items": {
+                "type": "string",
+                "title": "Color",
+                "description": "Hexadecimal color code"
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#graph_color_list"
+                }
+            ]
+        },
+        "graph_color_number": {
+            "title": "Graph color number",
+            "type": "integer",
+            "description": "This setting can be used to limit the length of the list of colors selected via graph_color_set.",
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#graph_color_number"
+                }
+            ]
+        },
+        "hide_empty_metadata": {
+            "title": "Hide empty metadata",
+            "type": "boolean",
+            "description": "This setting can be used to hide any metadata fields that are empty.",
+            "format": "checkbox",
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#hide_empty_metadata"
+                }
+            ]
+        },
+        "languages": {
+            "options": {"collapsed": true},
+            "format": "table",
+            "type": "array",
+            "title": "Languages",
+            "description": "This setting controls the languages to be used on the site.",
+            "default": ["en"],
+            "items": {
+                "type": "string",
+                "title": "Language"
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#languages"
+                }
+            ]
+        },
+        "menu": {
+            "options": {"collapsed": true},
+            "format": "table",
+            "type": "array",
+            "title": "Main menu",
+            "description": "The links to display in the main menu.",
             "default": [
                 {
-                    "folder": "/",
-                    "layout": "frontpage-alt"
+                    "path": "/reporting-status",
+                    "translation_key": "menu.reporting_status"
                 },
                 {
-                    "folder": "/goals",
-                    "layout": "goals"
-                },
-                {
-                    "folder": "/reporting-status",
-                    "layout": "reportingstatus"
-                },
-                {
-                    "filename": "indicators.json",
-                    "folder": "/",
-                    "layout": "indicators.json"
-                },
-                {
-                    "folder": "/search",
-                    "layout": "search"
+                    "path": "/about",
+                    "translation_key": "menu.about"
                 }
             ],
             "items": {
-                "type": "object",
-                "title": "Page",
-                "default": {
-                    "filename": "index.html"
-                },
-                "required": [
-                    "layout",
-                    "folder",
-                    "filename"
-                ],
-                "properties": {
-                    "filename": {
-                        "type": "string",
-                        "title": "Filename",
-                        "description": "The filename for the page - usually 'index.html'."
-                    },
-                    "folder": {
-                        "type": "string",
-                        "title": "Folder",
-                        "description": "The folder path for the page."
-                    },
-                    "layout": {
-                        "type": "string",
-                        "title": "Layout",
-                        "description": "The layout to use for the page."
-                    }
-                }
+                "$ref": "#/definitions/menu_item"
             },
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_pages"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#menu"
                 }
             ]
         },
-        "custom_js": {
-            "options": {
-                "collapsed": true
-            },
-            "format": "table",
-            "type": "array",
-            "title": "Custom JavaScript files",
-            "description": "This setting can be used to load additional JavaScript files on each page.",
-            "items": {
-                "type": "string",
-                "title": "Custom JavaScript file"
-            },
+        "metadata_edit_url": {
+            "type": "string",
+            "title": "Metadata edit URL",
+            "description": "This setting controls the URL of the 'Edit Metadata' buttons that appear on the staging site's indicator pages.",
+            "default": "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md",
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_js"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#metadata_edit_url"
                 }
             ]
         },
-        "custom_css": {
-            "options": {
-                "collapsed": true
-            },
+        "plugins": {
+            "options": {"collapsed": true},
             "format": "table",
             "type": "array",
-            "title": "Custom CSS files",
-            "description": "Deprecated: instead of using this, it is recommended to put custom CSS in a _sass/custom.scss file.",
+            "title": "Plugins",
+            "description": "This setting controls the Jekyll plugins to be used on the site.",
+            "default": ["jekyll-remote-theme", "jekyll-open-sdg-plugins"],
             "items": {
                 "type": "string",
-                "title": "Custom CSS file"
+                "title": "Plugin"
             },
             "links": [
                 {
                     "rel": "More information",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_css"
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#plugins"
+                }
+            ]
+        },
+        "remote_data_prefix": {
+            "type": "string",
+            "title": "Remote data repository URL",
+            "description": "Specify the URL of your published data repository.",
+            "default": "https://my-github-org.github.io/my-data-repository",
+            "examples": [
+                "https://my-github-org.github.io/my-data-repository"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#remote_data_prefix"
                 }
             ]
         },

--- a/assets/js/site-config-schema.json
+++ b/assets/js/site-config-schema.json
@@ -50,29 +50,14 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Languages",
             "description": "This setting controls the languages to be used on the site.",
             "default": ["en"],
-            "examples": [
-                [
-                    "en"
-                ]
-            ],
-            "additionalItems": true,
             "items": {
-                "title": "Language",
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "title": "Language",
-                        "description": "This is a language code.",
-                        "default": "",
-                        "examples": [
-                            "en"
-                        ]
-                    }
-                ]
+                "type": "string",
+                "title": "Language"
             },
             "links": [
                 {
@@ -86,7 +71,6 @@
             "title": "Environment",
             "description": "Which environment (staging or production) this configuration is for.",
             "default": "staging",
-            "examples": [],
             "format": "choices",
             "enum": ["staging", "production"],
             "links": [
@@ -101,9 +85,6 @@
             "title": "Goal image base URL",
             "description": "This setting controls the base URL for downloading the imagery for the goals.",
             "default": "https://open-sdg.github.io/sdg-translations/assets/img/goals",
-            "examples": [
-                "https://open-sdg.github.io/sdg-translations/assets/img/goals"
-            ],
             "links": [
                 {
                     "rel": "More information",
@@ -115,6 +96,7 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Main menu",
             "description": "The links to display in the main menu.",
@@ -128,60 +110,8 @@
                     "translation_key": "menu.about"
                 }
             ],
-            "examples": [
-                [
-                    {
-                        "path": "/reporting-status",
-                        "translation_key": "menu.reporting_status"
-                    },
-                    {
-                        "path": "/about",
-                        "translation_key": "menu.about"
-                    }
-                ]
-            ],
-            "additionalItems": true,
             "items": {
-                "title": "Main menu item",
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "title": "Menu item",
-                        "description": "This is one menu item in the header.",
-                        "default": {},
-                        "examples": [
-                            {
-                                "path": "/reporting-status",
-                                "translation_key": "menu.reporting_status"
-                            }
-                        ],
-                        "required": [
-                            "path",
-                            "translation_key"
-                        ],
-                        "properties": {
-                            "path": {
-                                "type": "string",
-                                "title": "Path",
-                                "description": "Path or URL that the menu item should link to.",
-                                "default": "",
-                                "examples": [
-                                    "/reporting-status"
-                                ]
-                            },
-                            "translation_key": {
-                                "type": "string",
-                                "title": "Label",
-                                "description": "Label (or translation key) for the link.",
-                                "default": "",
-                                "examples": [
-                                    "menu.reporting_status"
-                                ]
-                            }
-                        },
-                        "additionalProperties": true
-                    }
-                ]
+                "$ref": "#/definitions/menu_item"
             },
             "links": [
                 {
@@ -194,64 +124,22 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Footer menu",
             "description": "The links to display in the footer menu.",
-            "default": [{}],
-            "examples": [
-                [
-                    {
-                        "path": "mailto:my-email-address@example.com",
-                        "translation_key": "menu.contact_us"
-                    },
-                    {
-                        "path": "https://twitter.com/MyTwitterAccount",
-                        "translation_key": "general.twitter"
-                    }
-                ]
+            "default": [
+                {
+                    "path": "mailto:my-email-address@example.com",
+                    "translation_key": "menu.contact_us"
+                },
+                {
+                    "path": "https://twitter.com/MyTwitterAccount",
+                    "translation_key": "general.twitter"
+                }
             ],
-            "additionalItems": true,
             "items": {
-                "title": "Footer menu item",
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "title": "Menu item",
-                        "description": "This is one menu item in the footer.",
-                        "default": {},
-                        "examples": [
-                            {
-                                "path": "mailto:my-email-address@example.com",
-                                "translation_key": "menu.contact_us"
-                            }
-                        ],
-                        "required": [
-                            "path",
-                            "translation_key"
-                        ],
-                        "properties": {
-                            "path": {
-                                "type": "string",
-                                "title": "Path",
-                                "description": "Path or URL that the menu item should link to.",
-                                "default": "",
-                                "examples": [
-                                    "mailto:my-email-address@example.com"
-                                ]
-                            },
-                            "translation_key": {
-                                "type": "string",
-                                "title": "Label",
-                                "description": "Label (or translation key) for the link.",
-                                "default": "",
-                                "examples": [
-                                    "menu.contact_us"
-                                ]
-                            }
-                        },
-                        "additionalProperties": true
-                    }
-                ]
+                "$ref": "#/definitions/menu_item"
             },
             "links": [
                 {
@@ -271,12 +159,6 @@
                 "name": "Australia",
                 "adjective": "Australian"
             },
-            "examples": [
-                {
-                    "name": "Australia",
-                    "adjective": "Australian"
-                }
-            ],
             "required": [
                 "name",
                 "adjective"
@@ -285,21 +167,14 @@
                 "name": {
                     "type": "string",
                     "title": "Name",
-                    "description": "The name of your country/region/locality/etc.",
-                    "examples": [
-                        "Australia"
-                    ]
+                    "description": "The name of your country/region/locality/etc."
                 },
                 "adjective": {
                     "type": "string",
                     "title": "Adjective",
-                    "description": "Adjective form of your country/region/locality/etc.",
-                    "examples": [
-                        "Australian"
-                    ]
+                    "description": "Adjective form of your country/region/locality/etc."
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -314,14 +189,11 @@
             "type": "object",
             "title": "Email addresses",
             "description": "Email addresses to publish on your platform.",
-            "default": {},
-            "examples": [
-                {
-                    "questions": "test@example.com",
-                    "suggestions": "test@example.com",
-                    "functional": "test@example.com"
-                }
-            ],
+            "default": {
+                "questions": "test@example.com",
+                "suggestions": "test@example.com",
+                "functional": "test@example.com"
+            },
             "required": [
                 "questions",
                 "suggestions",
@@ -356,7 +228,6 @@
                     ]
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -369,9 +240,6 @@
             "title": "Data edit URL",
             "description": "This setting controls the URL of the 'Edit Data' buttons that appear on the staging site's indicator pages.",
             "default": "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv",
-            "examples": [
-                "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv"
-            ],
             "links": [
                 {
                     "rel": "More information",
@@ -384,9 +252,6 @@
             "title": "Metadata edit URL",
             "description": "This setting controls the URL of the 'Edit Metadata' buttons that appear on the staging site's indicator pages.",
             "default": "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md",
-            "examples": [
-                "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md"
-            ],
             "links": [
                 {
                     "rel": "More information",
@@ -398,30 +263,14 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Plugins",
             "description": "This setting controls the Jekyll plugins to be used on the site.",
             "default": ["jekyll-remote-theme", "jekyll-open-sdg-plugins"],
-            "examples": [
-                [
-                    "jekyll-remote-theme",
-                    "jekyll-open-sdg-plugins"
-                ]
-            ],
-            "additionalItems": true,
             "items": {
-                "title": "Plugin",
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "title": "Plugin",
-                        "description": "This is a Jekyll plugin.",
-                        "default": "",
-                        "examples": [
-                            "jekyll-remote-theme"
-                        ]
-                    }
-                ]
+                "type": "string",
+                "title": "Plugin"
             },
             "links": [
                 {
@@ -437,23 +286,13 @@
             "type": "object",
             "title": "Google Analytics",
             "description": "If these settings are used, usage statistics will be sent to Google Analytics.",
-            "examples": [
-                {
-                    "ga_prod": "UA1234567"
-                }
-            ],
             "properties": {
                 "ga_prod": {
                     "type": "string",
                     "title": "Google Analytics tracking ID",
-                    "description": "The tracking ID (UA code) for your property on Google Analytics.",
-                    "default": "",
-                    "examples": [
-                        "UA1234567"
-                    ]
+                    "description": "The tracking ID (UA code) for your property on Google Analytics."
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -478,23 +317,14 @@
                 "phase": {
                     "type": "string",
                     "title": "Phase",
-                    "description": "The development phase of your platform (alpha, beta, etc.)",
-                    "default": "",
-                    "examples": [
-                        "BETA"
-                    ]
+                    "description": "The development phase of your platform (alpha, beta, etc.)"
                 },
                 "message": {
                     "type": "string",
                     "title": "Message",
-                    "description": "A short disclaimer message.",
-                    "default": "",
-                    "examples": [
-                        "This is my disclaimer message."
-                    ]
+                    "description": "A short disclaimer message."
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -521,92 +351,49 @@
                     }
                 ]
             ],
-            "additionalItems": true,
             "items": {
-                "title": "Card",
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "title": "Frontpage card",
-                        "description": "This is a frontpage card.",
-                        "default": {},
+                "type": "object",
+                "title": "Frontpage card",
+                "required": [
+                    "title"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "title": "Title",
+                        "description": "The card's title."
+                    },
+                    "content": {
+                        "type": "string",
+                        "title": "Content",
+                        "description": "The card's content.",
+                        "format": "markdown"
+                    },
+                    "include": {
+                        "type": "string",
+                        "title": "Include file",
+                        "description": "A Jekyll include file to place inside the card."
+                    },
+                    "button_label": {
+                        "type": "string",
+                        "title": "Button label",
+                        "description": "A label for a button to display at the bottom of the card.",
+                        "default": "",
                         "examples": [
-                            {
-                                "title": "My card title",
-                                "content": "My card content"
-                            }
-                        ],
-                        "required": [
-                            "title"
-                        ],
-                        "properties": {
-                            "rule_color": {
-                                "type": "string",
-                                "title": "Rule color",
-                                "description": "The color of the horizontal line appearing above the card.",
-                                "default": "",
-                                "examples": [
-                                    "red"
-                                ]
-                            },
-                            "title": {
-                                "type": "string",
-                                "title": "Title",
-                                "description": "The card's title.",
-                                "default": "",
-                                "examples": [
-                                    "My card title"
-                                ]
-                            },
-                            "content": {
-                                "type": "string",
-                                "title": "Content",
-                                "description": "The card's content.",
-                                "default": "",
-                                "examples": [
-                                    "My card content"
-                                ],
-                                "format": "markdown",
-                                "options": {
-                                    "ace": {
-                                        "theme": "ace/theme/dawn",
-                                        "tabSize": 2,
-                                        "useSoftTabs": true,
-                                        "wrap": true
-                                    }
-                                }
-                            },
-                            "include": {
-                                "type": "string",
-                                "title": "Include file",
-                                "description": "A Jekyll include file to place inside the card.",
-                                "default": "",
-                                "examples": [
-                                    "components/download-all-data.html"
-                                ]
-                            },
-                            "button_label": {
-                                "type": "string",
-                                "title": "Button label",
-                                "description": "A label for a button to display at the bottom of the card.",
-                                "default": "",
-                                "examples": [
-                                    "My button label"
-                                ]
-                            },
-                            "button_link": {
-                                "type": "string",
-                                "title": "Button link",
-                                "description": "A path or URL for the card's button to link to.",
-                                "default": "",
-                                "examples": [
-                                    "https://example.com",
-                                    "path/to/my-page"
-                                ]
-                            }
-                        }
+                            "My button label"
+                        ]
+                    },
+                    "button_link": {
+                        "type": "string",
+                        "title": "Button link",
+                        "description": "A path or URL for the card's button to link to."
+                    },
+                    "rule_color": {
+                        "type": "string",
+                        "title": "Rule color",
+                        "description": "The color of the horizontal line appearing above the card."
                     }
-                ]
+                }
             },
             "links": [
                 {
@@ -622,25 +409,7 @@
             "type": "object",
             "title": "Frontpage goals grid",
             "description": "This setting is only used in the frontpage-alt layout. It can display a title and description above the grid of goal tiles.",
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "title": "Title",
-                    "description": "The title to display above the goals grid.",
-                    "examples": [
-                        "My title"
-                    ]
-                },
-                "description": {
-                    "type": "string",
-                    "title": "Description",
-                    "description": "The description to display above the goals grid.",
-                    "examples": [
-                        "My description"
-                    ]
-                }
-            },
-            "additionalProperties": true,
+            "$ref": "#/definitions/title_and_description",
             "links": [
                 {
                     "rel": "More information",
@@ -683,25 +452,7 @@
             "type": "object",
             "title": "Frontpage introduction banner",
             "description": "This setting is only used in the frontpage-alt layout. It can display a title and description in a banner at the top of the frontpage.",
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "title": "Title",
-                    "description": "The title to display at the top of the frontpage.",
-                    "examples": [
-                        "My title"
-                    ]
-                },
-                "description": {
-                    "type": "string",
-                    "title": "Description",
-                    "description": "The description to display at the top of the frontpage.",
-                    "examples": [
-                        "My description"
-                    ]
-                }
-            },
-            "additionalProperties": true,
+            "$ref": "#/definitions/title_and_description",
             "links": [
                 {
                     "rel": "More information",
@@ -716,25 +467,7 @@
             "type": "object",
             "title": "Goals page",
             "description": "This setting is used in the 'goals' layout. It can display a title and description above the grid of goal tiles.",
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "title": "Title",
-                    "description": "The title to display above the goals grid.",
-                    "examples": [
-                        "My title"
-                    ]
-                },
-                "description": {
-                    "type": "string",
-                    "title": "Description",
-                    "description": "The description to display above the goals grid.",
-                    "examples": [
-                        "My description"
-                    ]
-                }
-            },
-            "additionalProperties": true,
+            "$ref": "#/definitions/title_and_description",
             "links": [
                 {
                     "rel": "More information",
@@ -764,25 +497,18 @@
             "type": "object",
             "title": "Goal pages",
             "description": "This setting can be used to automatically create the goal pages.",
-            "examples": [
-                {
-                    "layout": "goal-by-target-vertical"
-                }
-            ],
+            "default": {
+                "layout": "goal-by-target-vertical"
+            },
             "properties": {
                 "layout": {
                     "type": "string",
                     "title": "Layout",
                     "description": "The layout to use for the goal pages.",
-                    "default": "goal-by-target-vertical",
-                    "examples": [
-                        "goal-by-target-vertical"
-                    ],
                     "format": "choices",
                     "enum": ["goal", "goal-by-target", "goal-by-target-vertical"]
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -797,23 +523,18 @@
             "type": "object",
             "title": "Indicator pages",
             "description": "This setting can be used to automatically create the indicator pages.",
-            "examples": [
-                {
-                    "layout": "indicator"
-                }
-            ],
+            "default": {
+                "layout": "indicator"
+            },
             "properties": {
                 "layout": {
                     "type": "string",
                     "title": "Layout",
                     "description": "The layout to use for the indicator pages.",
-                    "default": "indicator",
-                    "examples": [
-                        "indicator"
-                    ]
+                    "format": "choices",
+                    "enum": ["indicator"]
                 }
             },
-            "additionalProperties": true,
             "links": [
                 {
                     "rel": "More information",
@@ -825,6 +546,7 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Create pages",
             "description": "This setting can be used to automatically create the pages.",
@@ -851,90 +573,34 @@
                     "layout": "search"
                 }
             ],
-            "examples": [
-                [
-                    {
-                        "filename": "index.html",
-                        "folder": "/",
-                        "layout": "frontpage-alt"
-                    },
-                    {
-                        "filename": "index.html",
-                        "folder": "/goals",
-                        "layout": "goals"
-                    },
-                    {
-                        "filename": "index.html",
-                        "folder": "/reporting-status",
-                        "layout": "reportingstatus"
-                    },
-                    {
-                        "filename": "indicators.json",
-                        "folder": "/",
-                        "layout": "indicators.json"
-                    },
-                    {
-                        "filename": "index.html",
-                        "folder": "/search",
-                        "layout": "search"
-                    }
-                ]
-            ],
-            "additionalItems": true,
             "items": {
+                "type": "object",
                 "title": "Page",
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "title": "Page",
-                        "description": "This is one page.",
-                        "default": {},
-                        "examples": [
-                            {
-                                "filename": "",
-                                "folder": "/my-folder",
-                                "layout": "my-layout"
-                            }
-                        ],
-                        "required": [
-                            "layout",
-                            "folder",
-                            "filename"
-                        ],
-                        "properties": {
-                            "filename": {
-                                "type": "string",
-                                "title": "Filename",
-                                "description": "The filename for the page - usually 'index.html'.",
-                                "default": "index.html",
-                                "examples": [
-                                    "index.html",
-                                    "indicators.json"
-                                ]
-                            },
-                            "folder": {
-                                "type": "string",
-                                "title": "Folder",
-                                "description": "The folder path for the page.",
-                                "default": "/",
-                                "examples": [
-                                    "/",
-                                    "/my-folder"
-                                ]
-                            },
-                            "layout": {
-                                "type": "string",
-                                "title": "Layout",
-                                "description": "The layout to use for the page.",
-                                "default": "",
-                                "examples": [
-                                    "my-layout"
-                                ]
-                            }
-                        },
-                        "additionalProperties": true
+                "default": {
+                    "filename": "index.html"
+                },
+                "required": [
+                    "layout",
+                    "folder",
+                    "filename"
+                ],
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "title": "Filename",
+                        "description": "The filename for the page - usually 'index.html'."
+                    },
+                    "folder": {
+                        "type": "string",
+                        "title": "Folder",
+                        "description": "The folder path for the page."
+                    },
+                    "layout": {
+                        "type": "string",
+                        "title": "Layout",
+                        "description": "The layout to use for the page."
                     }
-                ]
+                }
             },
             "links": [
                 {
@@ -947,29 +613,13 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Custom JavaScript files",
             "description": "This setting can be used to load additional JavaScript files on each page.",
-            "default": [""],
-            "examples": [
-                [
-                    "assets/js/custom.js"
-                ]
-            ],
-            "additionalItems": true,
             "items": {
-                "title": "Custom JavaScript file",
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "title": "Custom JavaScript file",
-                        "description": "This is a reference to a custom JavaScript file.",
-                        "default": "",
-                        "examples": [
-                            "assets/js/custom.js"
-                        ]
-                    }
-                ]
+                "type": "string",
+                "title": "Custom JavaScript file"
             },
             "links": [
                 {
@@ -982,29 +632,13 @@
             "options": {
                 "collapsed": true
             },
+            "format": "table",
             "type": "array",
             "title": "Custom CSS files",
             "description": "Deprecated: instead of using this, it is recommended to put custom CSS in a _sass/custom.scss file.",
-            "default": [""],
-            "examples": [
-                [
-                    "assets/css/custom.css"
-                ]
-            ],
-            "additionalItems": true,
             "items": {
-                "title": "Custom CSS file",
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "title": "Custom CSS file",
-                        "description": "This is a reference to a custom CSS file.",
-                        "default": "",
-                        "examples": [
-                            "assets/css/custom.css"
-                        ]
-                    }
-                ]
+                "type": "string",
+                "title": "Custom CSS file"
             },
             "links": [
                 {
@@ -1028,5 +662,45 @@
             }
         }
     },
-    "additionalProperties": true
+    "additionalProperties": true,
+    "definitions": {
+        "menu_item": {
+            "type": "object",
+            "title": "Menu item",
+            "required": [
+                "path",
+                "translation_key"
+            ],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "description": "Path or URL that the menu item should link to."
+                },
+                "translation_key": {
+                    "type": "string",
+                    "title": "Label",
+                    "description": "Label (or translation key) for the link."
+                }
+            }
+        },
+        "title_and_description": {
+            "type": "object",
+            "required": [
+                "title",
+                "description"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "title": "Title"
+                },
+                "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "format": "markdown"
+                }
+            }
+        }
+    }
 }

--- a/assets/js/site-config-schema.json
+++ b/assets/js/site-config-schema.json
@@ -1,0 +1,1032 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "title": "Open SDG site configuration",
+    "description": "This form will produce the site configuration for your Open SDG implementation.",
+    "required": [
+        "remote_theme",
+        "country",
+        "email_contacts",
+        "environment",
+        "goal_image_base",
+        "languages",
+        "data_edit_url",
+        "metadata_edit_url",
+        "plugins",
+        "remote_data_prefix"
+    ],
+    "properties": {
+        "remote_theme": {
+            "type": "string",
+            "title": "Open SDG version",
+            "description": "Specify a version of Open SDG to use by referencing a Github.com repository, optionally with a branch or tag. Specifying a tag is strongly recommended.",
+            "default": "open-sdg/open-sdg@1.1.0",
+            "examples": [
+                "open-sdg/open-sdg@master"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#remote_theme"
+                }
+            ]
+        },
+        "remote_data_prefix": {
+            "type": "string",
+            "title": "Data repository URL",
+            "description": "Specify the URL of your published data repository.",
+            "default": "https://my-github-org.github.io/my-data-repository",
+            "examples": [
+                "https://my-github-org.github.io/my-data-repository"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#remote_data_prefix"
+                }
+            ]
+        },
+        "languages": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Languages",
+            "description": "This setting controls the languages to be used on the site.",
+            "default": ["en"],
+            "examples": [
+                [
+                    "en"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Language",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Language",
+                        "description": "This is a language code.",
+                        "default": "",
+                        "examples": [
+                            "en"
+                        ]
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#languages"
+                }
+            ]
+        },
+        "environment": {
+            "type": "string",
+            "title": "Environment",
+            "description": "Which environment (staging or production) this configuration is for.",
+            "default": "staging",
+            "examples": [],
+            "format": "choices",
+            "enum": ["staging", "production"],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#environment"
+                }
+            ]
+        },
+        "goal_image_base": {
+            "type": "string",
+            "title": "Goal image base URL",
+            "description": "This setting controls the base URL for downloading the imagery for the goals.",
+            "default": "https://open-sdg.github.io/sdg-translations/assets/img/goals",
+            "examples": [
+                "https://open-sdg.github.io/sdg-translations/assets/img/goals"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#goal_image_base"
+                }
+            ]
+        },
+        "menu": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Main menu",
+            "description": "The links to display in the main menu.",
+            "default": [
+                {
+                    "path": "/reporting-status",
+                    "translation_key": "menu.reporting_status"
+                },
+                {
+                    "path": "/about",
+                    "translation_key": "menu.about"
+                }
+            ],
+            "examples": [
+                [
+                    {
+                        "path": "/reporting-status",
+                        "translation_key": "menu.reporting_status"
+                    },
+                    {
+                        "path": "/about",
+                        "translation_key": "menu.about"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Main menu item",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "Menu item",
+                        "description": "This is one menu item in the header.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "path": "/reporting-status",
+                                "translation_key": "menu.reporting_status"
+                            }
+                        ],
+                        "required": [
+                            "path",
+                            "translation_key"
+                        ],
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "title": "Path",
+                                "description": "Path or URL that the menu item should link to.",
+                                "default": "",
+                                "examples": [
+                                    "/reporting-status"
+                                ]
+                            },
+                            "translation_key": {
+                                "type": "string",
+                                "title": "Label",
+                                "description": "Label (or translation key) for the link.",
+                                "default": "",
+                                "examples": [
+                                    "menu.reporting_status"
+                                ]
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#menu"
+                }
+            ]
+        },
+        "footer_menu": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Footer menu",
+            "description": "The links to display in the footer menu.",
+            "default": [{}],
+            "examples": [
+                [
+                    {
+                        "path": "mailto:my-email-address@example.com",
+                        "translation_key": "menu.contact_us"
+                    },
+                    {
+                        "path": "https://twitter.com/MyTwitterAccount",
+                        "translation_key": "general.twitter"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Footer menu item",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "Menu item",
+                        "description": "This is one menu item in the footer.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "path": "mailto:my-email-address@example.com",
+                                "translation_key": "menu.contact_us"
+                            }
+                        ],
+                        "required": [
+                            "path",
+                            "translation_key"
+                        ],
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "title": "Path",
+                                "description": "Path or URL that the menu item should link to.",
+                                "default": "",
+                                "examples": [
+                                    "mailto:my-email-address@example.com"
+                                ]
+                            },
+                            "translation_key": {
+                                "type": "string",
+                                "title": "Label",
+                                "description": "Label (or translation key) for the link.",
+                                "default": "",
+                                "examples": [
+                                    "menu.contact_us"
+                                ]
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#footer_menu"
+                }
+            ]
+        },
+        "country": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Country information",
+            "description": "Information about your country (or region, locality, etc.)",
+            "default": {
+                "name": "Australia",
+                "adjective": "Australian"
+            },
+            "examples": [
+                {
+                    "name": "Australia",
+                    "adjective": "Australian"
+                }
+            ],
+            "required": [
+                "name",
+                "adjective"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of your country/region/locality/etc.",
+                    "examples": [
+                        "Australia"
+                    ]
+                },
+                "adjective": {
+                    "type": "string",
+                    "title": "Adjective",
+                    "description": "Adjective form of your country/region/locality/etc.",
+                    "examples": [
+                        "Australian"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#country"
+                }
+            ]
+        },
+        "email_contacts": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Email addresses",
+            "description": "Email addresses to publish on your platform.",
+            "default": {},
+            "examples": [
+                {
+                    "questions": "test@example.com",
+                    "suggestions": "test@example.com",
+                    "functional": "test@example.com"
+                }
+            ],
+            "required": [
+                "questions",
+                "suggestions",
+                "functional"
+            ],
+            "properties": {
+                "questions": {
+                    "type": "string",
+                    "title": "Questions",
+                    "description": "Inbox for questions about your platform.",
+                    "default": "",
+                    "examples": [
+                        "test@example.com"
+                    ]
+                },
+                "suggestions": {
+                    "type": "string",
+                    "title": "Suggestions",
+                    "description": "Inbox for suggestions for your platform.",
+                    "default": "",
+                    "examples": [
+                        "est@example.com"
+                    ]
+                },
+                "functional": {
+                    "type": "string",
+                    "title": "Functional",
+                    "description": "Inbox for bug reports for your platform.",
+                    "default": "",
+                    "examples": [
+                        "test@example.com"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#email_contacts"
+                }
+            ]
+        },
+        "data_edit_url": {
+            "type": "string",
+            "title": "Data edit URL",
+            "description": "This setting controls the URL of the 'Edit Data' buttons that appear on the staging site's indicator pages.",
+            "default": "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv",
+            "examples": [
+                "http://prose.io/#my-org/my-repo/edit/develop/data/indicator_[id].csv"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#data_edit_url"
+                }
+            ]
+        },
+        "metadata_edit_url": {
+            "type": "string",
+            "title": "Metadata edit URL",
+            "description": "This setting controls the URL of the 'Edit Metadata' buttons that appear on the staging site's indicator pages.",
+            "default": "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md",
+            "examples": [
+                "http://prose.io/#my-org/my-repo/edit/develop/meta/[id].md"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#metadata_edit_url"
+                }
+            ]
+        },
+        "plugins": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Plugins",
+            "description": "This setting controls the Jekyll plugins to be used on the site.",
+            "default": ["jekyll-remote-theme", "jekyll-open-sdg-plugins"],
+            "examples": [
+                [
+                    "jekyll-remote-theme",
+                    "jekyll-open-sdg-plugins"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Plugin",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Plugin",
+                        "description": "This is a Jekyll plugin.",
+                        "default": "",
+                        "examples": [
+                            "jekyll-remote-theme"
+                        ]
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#plugins"
+                }
+            ]
+        },
+        "analytics": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Google Analytics",
+            "description": "If these settings are used, usage statistics will be sent to Google Analytics.",
+            "examples": [
+                {
+                    "ga_prod": "UA1234567"
+                }
+            ],
+            "properties": {
+                "ga_prod": {
+                    "type": "string",
+                    "title": "Google Analytics tracking ID",
+                    "description": "The tracking ID (UA code) for your property on Google Analytics.",
+                    "default": "",
+                    "examples": [
+                        "UA1234567"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#analytics"
+                }
+            ]
+        },
+        "disclaimer": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Disclaimer",
+            "description": "This setting controls the content of the disclaimer that appears at the top of each page.",
+            "examples": [
+                {
+                    "phase": "BETA",
+                    "message": "This is my disclaimer message"
+                }
+            ],
+            "properties": {
+                "phase": {
+                    "type": "string",
+                    "title": "Phase",
+                    "description": "The development phase of your platform (alpha, beta, etc.)",
+                    "default": "",
+                    "examples": [
+                        "BETA"
+                    ]
+                },
+                "message": {
+                    "type": "string",
+                    "title": "Message",
+                    "description": "A short disclaimer message.",
+                    "default": "",
+                    "examples": [
+                        "This is my disclaimer message."
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#disclaimer"
+                }
+            ]
+        },
+        "frontpage_cards": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Frontpage cards",
+            "description": "This setting is only used in the frontpage-alt layout. It can display any number of 'cards' in 3-column rows, beneath the grid of goal tiles.",
+            "examples": [
+                [
+                    {
+                        "rule_color": "red",
+                        "title": "My card title",
+                        "content": "My card content",
+                        "include": "components/download-all-data.html",
+                        "button_label": "My button text",
+                        "button_link": "https://example.com"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Card",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "Frontpage card",
+                        "description": "This is a frontpage card.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "title": "My card title",
+                                "content": "My card content"
+                            }
+                        ],
+                        "required": [
+                            "title"
+                        ],
+                        "properties": {
+                            "rule_color": {
+                                "type": "string",
+                                "title": "Rule color",
+                                "description": "The color of the horizontal line appearing above the card.",
+                                "default": "",
+                                "examples": [
+                                    "red"
+                                ]
+                            },
+                            "title": {
+                                "type": "string",
+                                "title": "Title",
+                                "description": "The card's title.",
+                                "default": "",
+                                "examples": [
+                                    "My card title"
+                                ]
+                            },
+                            "content": {
+                                "type": "string",
+                                "title": "Content",
+                                "description": "The card's content.",
+                                "default": "",
+                                "examples": [
+                                    "My card content"
+                                ],
+                                "format": "markdown",
+                                "options": {
+                                    "ace": {
+                                        "theme": "ace/theme/dawn",
+                                        "tabSize": 2,
+                                        "useSoftTabs": true,
+                                        "wrap": true
+                                    }
+                                }
+                            },
+                            "include": {
+                                "type": "string",
+                                "title": "Include file",
+                                "description": "A Jekyll include file to place inside the card.",
+                                "default": "",
+                                "examples": [
+                                    "components/download-all-data.html"
+                                ]
+                            },
+                            "button_label": {
+                                "type": "string",
+                                "title": "Button label",
+                                "description": "A label for a button to display at the bottom of the card.",
+                                "default": "",
+                                "examples": [
+                                    "My button label"
+                                ]
+                            },
+                            "button_link": {
+                                "type": "string",
+                                "title": "Button link",
+                                "description": "A path or URL for the card's button to link to.",
+                                "default": "",
+                                "examples": [
+                                    "https://example.com",
+                                    "path/to/my-page"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#frontpage_cards"
+                }
+            ]
+        },
+        "frontpage_goals_grid": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Frontpage goals grid",
+            "description": "This setting is only used in the frontpage-alt layout. It can display a title and description above the grid of goal tiles.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "title": "Title",
+                    "description": "The title to display above the goals grid.",
+                    "examples": [
+                        "My title"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description to display above the goals grid.",
+                    "examples": [
+                        "My description"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#frontpage_goals_grid"
+                }
+            ]
+        },
+        "frontpage_heading": {
+            "type": "string",
+            "title": "Frontpage heading",
+            "description": "This setting can control the heading that appears on the front page. This setting is only used in the frontpage layout.",
+            "examples": [
+                "Australian data for Sustainable Development Goal indicators"
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#frontpage_heading"
+                }
+            ]
+        },
+        "frontpage_instructions": {
+            "type": "string",
+            "title": "Frontpage instructions",
+            "description": "This setting can control the instructions that appear on the front page. This setting is only used in the frontpage layout.",
+            "examples": [
+                "Click on each goal for Australian statistics for Sustainable Development Goal global indicators."
+            ],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#frontpage_instructions"
+                }
+            ]
+        },
+        "frontpage_introduction_banner": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Frontpage introduction banner",
+            "description": "This setting is only used in the frontpage-alt layout. It can display a title and description in a banner at the top of the frontpage.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "title": "Title",
+                    "description": "The title to display at the top of the frontpage.",
+                    "examples": [
+                        "My title"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description to display at the top of the frontpage.",
+                    "examples": [
+                        "My description"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#frontpage_introduction_banner"
+                }
+            ]
+        },
+        "goals_page": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Goals page",
+            "description": "This setting is used in the 'goals' layout. It can display a title and description above the grid of goal tiles.",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "title": "Title",
+                    "description": "The title to display above the goals grid.",
+                    "examples": [
+                        "My title"
+                    ]
+                },
+                "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The description to display above the goals grid.",
+                    "examples": [
+                        "My description"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#goals_page"
+                }
+            ]
+        },
+        "graph_color_set": {
+            "type": "string",
+            "title": "Graph color set",
+            "description": "This setting can be used to customize the color set used in the charts.",
+            "default": "default",
+            "examples": [],
+            "format": "choices",
+            "enum": ["default", "sdg", "goal", "custom"],
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#graph_color_set"
+                }
+            ]
+        },
+        "create_goals": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Goal pages",
+            "description": "This setting can be used to automatically create the goal pages.",
+            "examples": [
+                {
+                    "layout": "goal-by-target-vertical"
+                }
+            ],
+            "properties": {
+                "layout": {
+                    "type": "string",
+                    "title": "Layout",
+                    "description": "The layout to use for the goal pages.",
+                    "default": "goal-by-target-vertical",
+                    "examples": [
+                        "goal-by-target-vertical"
+                    ],
+                    "format": "choices",
+                    "enum": ["goal", "goal-by-target", "goal-by-target-vertical"]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_goals"
+                }
+            ]
+        },
+        "create_indicators": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "object",
+            "title": "Indicator pages",
+            "description": "This setting can be used to automatically create the indicator pages.",
+            "examples": [
+                {
+                    "layout": "indicator"
+                }
+            ],
+            "properties": {
+                "layout": {
+                    "type": "string",
+                    "title": "Layout",
+                    "description": "The layout to use for the indicator pages.",
+                    "default": "indicator",
+                    "examples": [
+                        "indicator"
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_indicators"
+                }
+            ]
+        },
+        "create_pages": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Create pages",
+            "description": "This setting can be used to automatically create the pages.",
+            "default": [
+                {
+                    "folder": "/",
+                    "layout": "frontpage-alt"
+                },
+                {
+                    "folder": "/goals",
+                    "layout": "goals"
+                },
+                {
+                    "folder": "/reporting-status",
+                    "layout": "reportingstatus"
+                },
+                {
+                    "filename": "indicators.json",
+                    "folder": "/",
+                    "layout": "indicators.json"
+                },
+                {
+                    "folder": "/search",
+                    "layout": "search"
+                }
+            ],
+            "examples": [
+                [
+                    {
+                        "filename": "index.html",
+                        "folder": "/",
+                        "layout": "frontpage-alt"
+                    },
+                    {
+                        "filename": "index.html",
+                        "folder": "/goals",
+                        "layout": "goals"
+                    },
+                    {
+                        "filename": "index.html",
+                        "folder": "/reporting-status",
+                        "layout": "reportingstatus"
+                    },
+                    {
+                        "filename": "indicators.json",
+                        "folder": "/",
+                        "layout": "indicators.json"
+                    },
+                    {
+                        "filename": "index.html",
+                        "folder": "/search",
+                        "layout": "search"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Page",
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "Page",
+                        "description": "This is one page.",
+                        "default": {},
+                        "examples": [
+                            {
+                                "filename": "",
+                                "folder": "/my-folder",
+                                "layout": "my-layout"
+                            }
+                        ],
+                        "required": [
+                            "layout",
+                            "folder",
+                            "filename"
+                        ],
+                        "properties": {
+                            "filename": {
+                                "type": "string",
+                                "title": "Filename",
+                                "description": "The filename for the page - usually 'index.html'.",
+                                "default": "index.html",
+                                "examples": [
+                                    "index.html",
+                                    "indicators.json"
+                                ]
+                            },
+                            "folder": {
+                                "type": "string",
+                                "title": "Folder",
+                                "description": "The folder path for the page.",
+                                "default": "/",
+                                "examples": [
+                                    "/",
+                                    "/my-folder"
+                                ]
+                            },
+                            "layout": {
+                                "type": "string",
+                                "title": "Layout",
+                                "description": "The layout to use for the page.",
+                                "default": "",
+                                "examples": [
+                                    "my-layout"
+                                ]
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#create_pages"
+                }
+            ]
+        },
+        "custom_js": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Custom JavaScript files",
+            "description": "This setting can be used to load additional JavaScript files on each page.",
+            "default": [""],
+            "examples": [
+                [
+                    "assets/js/custom.js"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Custom JavaScript file",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Custom JavaScript file",
+                        "description": "This is a reference to a custom JavaScript file.",
+                        "default": "",
+                        "examples": [
+                            "assets/js/custom.js"
+                        ]
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_js"
+                }
+            ]
+        },
+        "custom_css": {
+            "options": {
+                "collapsed": true
+            },
+            "type": "array",
+            "title": "Custom CSS files",
+            "description": "Deprecated: instead of using this, it is recommended to put custom CSS in a _sass/custom.scss file.",
+            "default": [""],
+            "examples": [
+                [
+                    "assets/css/custom.css"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "title": "Custom CSS file",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Custom CSS file",
+                        "description": "This is a reference to a custom CSS file.",
+                        "default": "",
+                        "examples": [
+                            "assets/css/custom.css"
+                        ]
+                    }
+                ]
+            },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#custom_css"
+                }
+            ]
+        },
+        "additional_settings": {
+            "title": "Additional settings",
+            "description": "This is for any additional custom or Jekyll configuration you would like to include.",
+            "type": "string",
+            "format": "yaml",
+            "options": {
+                "ace": {
+                    "theme": "ace/theme/dawn",
+                    "tabSize": 2,
+                    "useSoftTabs": true,
+                    "wrap": true
+                }
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/tests/site/_pages/site-config-builder.md
+++ b/tests/site/_pages/site-config-builder.md
@@ -1,0 +1,4 @@
+---
+layout: site-config-builder
+permalink: /config
+---


### PR DESCRIPTION
This is a proof-of-concept of an idea for having a form that builds (and validates) the site configuration. The target audience here are those users not yet comfortable with YAML syntax. This proof-of-concept takes the user input in a form, and then copies the YAML to their clipboard, so they can paste it into their `_config.yml` file.

The bulk of this functionality is accomplished by describing our site configuration in JSON Schema format. The json file in this PR illustrates that. It does not yet have all of our site configuration - just enough to try this out. With our config in JSON Schema form, a library called "json-editor" automatically creates the form, and also handles the validation.

To test locally, you can do `make serve` and go to the /config page.

Or if you're not working locally, create a new page like so:

```
---
layout: site-config-builder
permalink: /config
---
```

Then visit the /config page. Here's a screenshot of the whole page with all the fields expanded:

![screenshot-127 0 0 1_4000-2020 08 16-21_02_21](https://user-images.githubusercontent.com/1319083/90348431-f0efea00-e003-11ea-9b33-0f4626ddfd64.png)
