### PR TITLE
Only link indicator name in goal-by-target

### DIFF
--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -70,23 +70,23 @@
       {% assign tag_classes = tag_classes | join: " " %}
 
       <div class="col-md-12 {{ tag_classes }} goal-indicator">
-        <a href="{{ indicator.url }}">
-          <span>
-            {{ indicator.number }}
-            <span class="status {{ status_css }}">
-              {{ status_desc }}
-            </span>
+        <span>
+          {{ indicator.number }}
+          <span class="status {{ status_css }}">
+            {{ status_desc }}
           </span>
+        </span>
+        <a href="{{ indicator.url }}">
           {{ indicator.name }}
-          {% if indicator.tags %}
-            <ul class="tags">
-            {% for tag in indicator.tags %}
-              {% assign tag_class = tag | slugify %}
-              <li class="tag-{{ tag_class }} warning">{{ tag | t }}</li>
-            {% endfor %}
-            </ul>
-          {% endif %}
         </a>
+        {% if indicator.tags %}
+          <ul class="tags">
+          {% for tag in indicator.tags %}
+            {% assign tag_class = tag | slugify %}
+            <li class="tag-{{ tag_class }} warning">{{ tag | t }}</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
       </div>
     {% endfor %}
     </div>

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -8,7 +8,7 @@
 
 @mixin tags {
   padding: 0;
-  margin: 6px 10px 0 0;
+  margin: 15px 10px 0 0;
   list-style-type: none;
   li {
     margin-right: 6px;

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -390,9 +390,11 @@
   &.goal-indicators {
     @include indicatorcards;
     &.goal-by-target {
+      .goal-indicator {
+        margin-bottom: 2.5rem;
+      }
       .indicator-cards a {
         padding: 0;
-        margin-bottom: 2.5rem;
 
         .tags li{
           color: $color-dark;


### PR DESCRIPTION
Fixes #795 

This updates the goal-by-target layout to only have a link on the indicator name, instead of the whole thing (including the number, tags, etc.)

I did not update the original "goal" layout (the one where the indicators are displayed in a grid, without targets) because that would take more effort. For consistency we may want to do that at some point, although I don't believe many (any?) implementations are still using that layout.