### PR TITLE
Refactor of goal-by-target-vertical for accessibility

### DIFF
--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-<div id="main-content" class="container goal-indicators goal-{{ page.goal.number }}">
+<div id="main-content" class="container">
 
   {{ content }}
 
@@ -30,15 +30,12 @@
     {% assign goal_indicators = page.indicators | where: 'goal_number', page.goal.number | group_by: 'target_number' %}
     {% for group in goal_indicators %}
       {% assign target = group.name | sdg_lookup %}
-      <div class="row no-gutters goal-target">
-        <div class="col-md-1">
-          {{ target.number }}
-        </div>
-        <div class="col-md-11">
-          {{ target.name }}
-        </div>
+      <div class="row no-gutters target-and-indicators">
+        <h3 class="target">
+          <span class="target-number">{{ target.number }}</span>
+          <span class="target-name">{{ target.name }}</span>
+        </h3>
         {% for indicator in group.items %}
-        <div class="row no-gutters goal-indicator indicator-cards">
 
           {% assign status_css = indicator.reporting_status | slugify %}
           {% if indicator.reporting_status == 'notapplicable' %}
@@ -62,26 +59,23 @@
           {% endif %}
           {% assign tag_classes = tag_classes | join: " " %}
 
-          <div class="col-md-1 col-md-offset-1">{{ indicator.number }}</div>
-          <div class="col-md-8">
-            <a href="{{ indicator.url }}">{{ indicator.name }}</a>
-          </div>
-          <div class="col-md-2 status-column">
+          <h4 class="indicator">
+            <span class="indicator-number">{{ indicator.number }}</span>
+            <span class="indicator-name"><a href="{{ indicator.url }}">{{ indicator.name }}</a></span>
+            <span class="sr-only">Indicator status</span>
             <span class="status {{ status_css }}">
               {{ status_desc }}
             </span>
-          </div>
-          {% if indicator.tags %}
-          <div class="col-md-offset-2 col-md-10">
-            <ul class="tags">
+            {% if indicator.tags %}
+            <span class="tags">
             {% for tag in indicator.tags %}
               {% assign tag_class = tag | slugify %}
-              <li class="tag-{{ tag_class }} warning">{{ tag | t }}</li>
+              <span class="tag tag-{{ tag_class }} warning">{{ tag | t }}</span>
             {% endfor %}
-            </ul>
-          </div>
-          {% endif %}
-        </div>
+            </span>
+            {% endif %}
+          </h4>
+
         {% endfor %}
       </div>
     {% endfor %}

--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -30,8 +30,8 @@
     {% assign goal_indicators = page.indicators | where: 'goal_number', page.goal.number | group_by: 'target_number' %}
     {% for group in goal_indicators %}
       {% assign target = group.name | sdg_lookup %}
-      <div class="row no-gutters target-and-indicators">
-        <h3 class="target">
+      <div class="row no-gutters goal-target-and-indicators">
+        <h3 class="goal-target">
           <span class="target-number">{{ target.number }}</span>
           <span class="target-name">{{ target.name }}</span>
         </h3>
@@ -59,7 +59,7 @@
           {% endif %}
           {% assign tag_classes = tag_classes | join: " " %}
 
-          <h4 class="indicator">
+          <h4 class="goal-indicator">
             <span class="indicator-number">{{ indicator.number }}</span>
             <span class="indicator-name"><a href="{{ indicator.url }}">{{ indicator.name }}</a></span>
             <span class="sr-only">Indicator status</span>

--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -67,6 +67,7 @@
               {{ status_desc }}
             </span>
             {% if indicator.tags %}
+            <span class="sr-only">Tags</span>
             <span class="tags">
             {% for tag in indicator.tags %}
               {% assign tag_class = tag | slugify %}

--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -32,9 +32,9 @@
       {% assign target = group.name | sdg_lookup %}
       <div class="row no-gutters goal-target-and-indicators">
         <h3 class="goal-target">
-          <span class="target-number">{{ target.number }}</span>
-          <span class="target-name">{{ target.name }}</span>
+          <span class="target-number"><span class="sr-only">{{ page.t.general.target }}</span> {{ target.number }}</span>
         </h3>
+        <span class="target-name">{{ target.name }}</span>
         {% for indicator in group.items %}
 
           {% assign status_css = indicator.reporting_status | slugify %}
@@ -59,8 +59,10 @@
           {% endif %}
           {% assign tag_classes = tag_classes | join: " " %}
 
-          <h4 class="goal-indicator">
-            <span class="indicator-number">{{ indicator.number }}</span>
+          <div class="goal-indicator">
+            <h4>
+              <span class="indicator-number"><span class="sr-only">{{ page.t.general.indicator }}</span> {{ indicator.number }}</span>
+            </h4>
             <span class="indicator-name"><a href="{{ indicator.url }}">{{ indicator.name }}</a></span>
             <span class="sr-only">Indicator status</span>
             <span class="status {{ status_css }}">
@@ -75,8 +77,7 @@
             {% endfor %}
             </span>
             {% endif %}
-          </h4>
-
+          </div>
         {% endfor %}
       </div>
     {% endfor %}

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -18,6 +18,31 @@
   }
 }
 
+@mixin status {
+  color: $color-dark;
+  font-weight: normal;
+  border: none;
+  padding: 4px;
+  font-size: 12px;
+
+  &.complete {
+    color: $status-color-complete;
+    border: $status-border-complete;
+  }
+  &.inprogress{
+    color: $status-color-inprogress;
+    border: $status-border-inprogress;
+  }
+  &.notstarted {
+    color: $status-color-notstarted;
+    border: $status-border-notstarted;
+  }
+  &.notapplicable {
+    color: $status-color-notapplicable;
+    border: $status-border-notapplicable;
+  }
+}
+
 @mixin indicatorcards {
   .indicator-cards {
     a {
@@ -42,32 +67,11 @@
       padding: 5px 0;
 
       &.status {
-        color: $color-dark;
-        font-weight: normal;
-        border: none;
-        padding: 4px;
+        @include status;
         position: absolute;
         top: -1px;
         right: 0;
         display: inline;
-        font-size: 12px;
-
-        &.complete {
-          color: $status-color-complete;
-          border: $status-border-complete;
-        }
-        &.inprogress{
-          color: $status-color-inprogress;
-          border: $status-border-inprogress;
-        }
-        &.notstarted {
-          color: $status-color-notstarted;
-          border: $status-border-notstarted;
-        }
-        &.notapplicable {
-          color: $status-color-notapplicable;
-          border: $status-border-notapplicable;
-        }
       }
 
     }

--- a/_sass/layouts/_goal-by-target-vertical.scss
+++ b/_sass/layouts/_goal-by-target-vertical.scss
@@ -1,21 +1,21 @@
 $goal-by-target-indentation: 50px;
 
 .layout-goal-by-target-vertical {
-  .target, .indicator {
+  .goal-target, .goal-indicator {
     font-size: 16px;
     font-weight: normal;
     clear: both;
     display: inline-block;
   }
-  .target {
+  .goal-target {
     margin-bottom: 20px;
   }
-  #main-content h4.indicator {
+  #main-content h4.goal-indicator {
     margin-top: 0;
     margin-bottom: 15px;
   }
 
-  .target-and-indicators {
+  .goal-target-and-indicators {
     margin-bottom: 20px;
     &::after {
       content: "";
@@ -31,7 +31,7 @@ $goal-by-target-indentation: 50px;
     }
   }
 
-  .indicator {
+  .goal-indicator {
     @media screen and (min-width: 769px) {
       margin-left: $goal-by-target-indentation;
       position: relative;

--- a/_sass/layouts/_goal-by-target-vertical.scss
+++ b/_sass/layouts/_goal-by-target-vertical.scss
@@ -1,38 +1,99 @@
+$goal-by-target-indentation: 50px;
+
 .layout-goal-by-target-vertical {
-  .tags {
-    @include tags;
+  .target, .indicator {
+    font-size: 16px;
+    font-weight: normal;
+    clear: both;
+    display: inline-block;
   }
-  .goal-target, .goal-target > div {
+  .target {
     margin-bottom: 20px;
   }
-
-  .goal-target::after {
-    content : "";
-    height: 1px;
-    width: 84%;
-    border-bottom: 1px solid $goalTarget-horizontalRule-color;
-    margin: 0 auto;
-    padding-bottom: 10px;
+  #main-content h4.indicator {
+    margin-top: 0;
+    margin-bottom: 15px;
   }
 
-  #main-content.goal-indicators .indicator-cards a {
-    padding: 0;
-  }
-
-  #main-content.goal-indicators .indicator-cards .status-column {
-    .status {
-      position: static;
+  .target-and-indicators {
+    margin-bottom: 20px;
+    &::after {
+      content: "";
+      height: 1px;
+      width: calc(100% - #{$goal-by-target-indentation});
+      border-bottom: 1px solid $goalTarget-horizontalRule-color;
+      margin-left: $goal-by-target-indentation;
+      padding-bottom: 10px;
+      @media screen and (min-width: 769px) {
+        padding-bottom: 20px;
+      }
       display: inline-block;
-      margin-top: 10px;
-      margin-bottom: 10px;
     }
-    @media only screen and (min-width: 992px) {
-      text-align: right;
+  }
+
+  .indicator {
+    @media screen and (min-width: 769px) {
+      margin-left: $goal-by-target-indentation;
+      position: relative;
+      width: calc(100% - #{$goal-by-target-indentation});
+      .indicator-name {
+        width: 75%;
+      }
       .status {
         position: absolute;
-        right: 15px;
+        right: 0;
+        top: 0;
         margin-top: 0;
-        margin-bottom: 0;
+      }
+    }
+  }
+
+  .target-number, .target-name, .indicator-number, .indicator-name {
+    display: block;
+  }
+
+  .target-number, .indicator-number {
+    position: absolute;
+  }
+
+  .target-name, .indicator-name {
+    margin-left: 50px;
+    box-decoration-break: clone;
+  }
+
+  .status {
+    display: block;
+    float: left;
+    clear: left;
+    @include status;
+    margin-bottom: 10px;
+    margin-top: 10px;
+  }
+
+  .tags {
+    float: left;
+    clear: left;
+    @include tags;
+    margin-top: 10px;
+    @media screen and (min-width: 769px) {
+      margin-top: 20px;
+    }
+    margin-bottom: 5px;
+    .tag {
+      margin-right: 6px;
+      padding: 4px 6px;
+      border-radius: 10px;
+    }
+  }
+
+  .status, .tags {
+    margin-left: $goal-by-target-indentation;
+  }
+
+  &.contrast-high {
+    .tags {
+      .tag {
+        color: $color-dark-highContrast;
       }
     }
   }

--- a/_sass/layouts/_goal-by-target-vertical.scss
+++ b/_sass/layouts/_goal-by-target-vertical.scss
@@ -7,10 +7,7 @@ $goal-by-target-indentation: 50px;
     clear: both;
     display: inline-block;
   }
-  .goal-target {
-    margin-bottom: 20px;
-  }
-  #main-content h4.goal-indicator {
+  #main-content .goal-indicator h4 {
     margin-top: 0;
     margin-bottom: 15px;
   }
@@ -18,7 +15,7 @@ $goal-by-target-indentation: 50px;
   .goal-target-and-indicators {
     margin-bottom: 20px;
     &::after {
-      content: "";
+      content: "" / "";
       height: 1px;
       width: calc(100% - #{$goal-by-target-indentation});
       border-bottom: 1px solid $goalTarget-horizontalRule-color;
@@ -53,7 +50,17 @@ $goal-by-target-indentation: 50px;
   }
 
   .target-number, .indicator-number {
-    position: absolute;
+    margin-top: 3px;
+  }
+
+  .goal-target, .goal-indicator h4 {
+    clear: left;
+    float: left;
+    margin-top: 0;
+  }
+
+  .goal-indicator {
+    margin-top: 20px;
   }
 
   .target-name, .indicator-name {


### PR DESCRIPTION
This is a rebuild of the `goal-by-target-vertical` layout to address the items in #831 and #832.

Because the markup is completely different here, there may be visual differences, though I've tried to keep them to a minimum. This should be tested for cross-browser issues.

I'm not sure if this approach is exactly what was intended. This approach puts all of the target pieces (number and name) in an `h3` and all of the indicator pieces (number, name, status, and tags) in an `h4`. I also considered, to take the example of the indicators, putting the status/tags outside the heading, and the number/name inside the heading. But here I went with the approach of putting all the pieces inside each heading.

That may be confusing, so here's a pseudo-code version of that.

What I considered:
```
<h3>
    target number
    target name
</h3>
<h4>
    indicator number
    indicator name
</h4>
<p>
    status
    tags
</p>
<h4>
    indicator number
    indicator name
</h4>
<p>
    status
    tags
</p>
etc...
```

What I did instead:
```
<h3>
    target number
    target name
</h3>
<h4>
    indicator number
    indicator name
    status
    tags
</h4>
<h4>
    indicator number
    indicator name
    status
    tags
</h4>
etc...
```