### PR TITLE
More obvious focus colors

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,6 +1,6 @@
 <div id="search" class="menu-target">
   <form action="{{ page.baseurl }}search">
-    <input name="q" id="indicator_search" title="{{ page.t.search.search }}" />
+    <input type="text" name="q" id="indicator_search" title="{{ page.t.search.search }}" />
     <label for="indicator_search">
       <button aria-label="{{ page.t.search.search }}" id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button><span>{{ page.t.search.search }}:</span>
     </label>

--- a/_layouts/goals.html
+++ b/_layouts/goals.html
@@ -7,7 +7,7 @@
     <div class="goal-tiles">
         <div class="row no-gutters">
             {% for goal in page.goals %}
-            <div class="col-xs-4 col-md-2">
+            <div class="col-xs-4 col-md-2 goal-tile">
                 <a href="{{ goal.url }}">
                     <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
                 </a>
@@ -18,7 +18,7 @@
             out more symmetrically.
             {% endcomment %}
             {% if page.goals.size == 17 %}
-            <div class="col-xs-4 col-md-2">
+            <div class="col-xs-4 col-md-2 goal-tile">
                 <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
             </div>
             {% endif %}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -108,3 +108,6 @@ body.contrast-high {
     box-shadow: 0 -2px $focusOutlineColor-highContrast,0 4px $focusColor-highContrast !important;
   }
 }
+input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus {
+  box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
+}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -111,3 +111,9 @@ body.contrast-high {
 input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus {
   box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
 }
+input[type="text"]:focus,
+body.contrast-high input[type="text"]:focus {
+  background-color: $backgroundColor !important;
+  box-shadow: none !important;
+  outline: 3px solid $focusOutlineColor !important;
+}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -37,7 +37,6 @@ h3{ font-size: $h3-fontSize; }
 
   img {
     max-width: 100%;
-    margin-top: 10px;
   }
 }
 

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -88,22 +88,22 @@ h3{ font-size: $h3-fontSize; }
 [href]:focus,
 [tabindex]:focus,
 iframe:focus,
-.navbar #search input:focus,
-.navbar #search button:focus {
-  color: $focusColor;
-  outline: .25rem solid $focusOutlineColor;
-  background-color: $focusBackgroundColor;
-  outline-offset: 0;
+input:focus,
+button:focus {
+  color: $focusColor !important;
+  outline: .25rem solid $focusOutlineColor !important;
+  background-color: $focusBackgroundColor !important;
+  outline-offset: 0 !important;
 }
 body.contrast-high {
   [contentEditable="true"]:focus,
   [href]:focus,
   [tabindex]:focus,
   iframe:focus,
-  .navbar #search input:focus,
-  .navbar #search button:focus {
-    color: $focusColor-highContrast;
-    outline: .25rem solid $focusOutlineColor-highContrast;
-    background-color: $focusBackgroundColor-highContrast;
+  input:focus,
+  button:focus {
+    color: $focusColor-highContrast !important;
+    outline: .25rem solid $focusOutlineColor-highContrast !important;
+    background-color: $focusBackgroundColor-highContrast !important;
   }
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -90,9 +90,11 @@ iframe:focus,
 input:focus,
 button:focus {
   color: $focusColor !important;
-  outline: .25rem solid $focusOutlineColor !important;
+  outline: 3px solid transparent !important;
   background-color: $focusBackgroundColor !important;
   outline-offset: 0 !important;
+  box-shadow: 0 -2px $focusOutlineColor,0 4px $focusColor !important;
+  text-decoration: none !important;
 }
 body.contrast-high {
   [contentEditable="true"]:focus,
@@ -102,7 +104,7 @@ body.contrast-high {
   input:focus,
   button:focus {
     color: $focusColor-highContrast !important;
-    outline: .25rem solid $focusOutlineColor-highContrast !important;
     background-color: $focusBackgroundColor-highContrast !important;
+    box-shadow: 0 -2px $focusOutlineColor-highContrast,0 4px $focusColor-highContrast !important;
   }
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -83,3 +83,24 @@ h3{ font-size: $h3-fontSize; }
   clip: rect(0,0,0,0);
   border: 0;
 }
+
+[contentEditable="true"]:focus,
+[href]:focus,
+[tabindex]:focus,
+iframe:focus,
+.navbar #search input:focus,
+.navbar #search button:focus {
+  outline: .25rem solid $focusColor;
+  outline-offset: 0;
+}
+body.contrast-high {
+  [contentEditable="true"]:focus,
+  [href]:focus,
+  [tabindex]:focus,
+  iframe:focus,
+  .navbar #search input:focus,
+  .navbar #search button:focus {
+    outline: .25rem solid $focusColor-highContrast;
+    outline-offset: 0;
+  }
+}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -108,7 +108,8 @@ body.contrast-high {
     box-shadow: 0 -2px $focusOutlineColor-highContrast,0 4px $focusColor-highContrast !important;
   }
 }
-input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus {
+input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus,
+input[type="checkbox"]:focus, body.contrast-high input[type="checkbox"]:focus {
   box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
 }
 input[type="text"]:focus,

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -90,7 +90,9 @@ h3{ font-size: $h3-fontSize; }
 iframe:focus,
 .navbar #search input:focus,
 .navbar #search button:focus {
-  outline: .25rem solid $focusColor;
+  color: $focusColor;
+  outline: .25rem solid $focusOutlineColor;
+  background-color: $focusBackgroundColor;
   outline-offset: 0;
 }
 body.contrast-high {
@@ -100,7 +102,8 @@ body.contrast-high {
   iframe:focus,
   .navbar #search input:focus,
   .navbar #search button:focus {
-    outline: .25rem solid $focusColor-highContrast;
-    outline-offset: 0;
+    color: $focusColor-highContrast;
+    outline: .25rem solid $focusOutlineColor-highContrast;
+    background-color: $focusBackgroundColor-highContrast;
   }
 }

--- a/_sass/components/_download_buttons.scss
+++ b/_sass/components/_download_buttons.scss
@@ -73,7 +73,7 @@ body.contrast-high {
       background: $color-highlight-highContrast !important;
     }
     &:focus {
-      background: $color-highlight-highContrast !important;
+      background: $focusBackgroundColor-highContrast !important;
     }
   }
   #zip-download-info {

--- a/_sass/components/_goal_banner.scss
+++ b/_sass/components/_goal_banner.scss
@@ -11,4 +11,9 @@
   h1, p {
     color: $goal-banner-color;
   }
+  .goal-icon {
+    a:focus {
+      outline: 6px $focusOutlineColor solid !important;
+    }
+  }
 }

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -19,3 +19,22 @@
     }
   }
 }
+
+#main-content {
+  .goal-tiles {
+    .no-gutters img {
+      width: calc(100% - 10px);
+      border: 0;
+      padding: 0;
+      margin: 0;
+
+      &:not(#goal-18){
+        box-shadow: 5px 5px 5px 0px $goalTiles-tile-shadowColor;
+
+        &:hover{
+          box-shadow: 5px 5px 5px 0px $goalTiles-tile-shadowColor-hover;
+        }
+      }
+    }
+  }
+}

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -22,6 +22,9 @@
 
 #main-content {
   .goal-tiles {
+    .goal-tile {
+      padding-bottom: 10px;
+    }
     .no-gutters img {
       width: calc(100% - 10px);
       border: 0;

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -24,6 +24,9 @@
   .goal-tiles {
     .goal-tile {
       padding-bottom: 10px;
+      a:focus {
+        outline: 6px $focusOutlineColor solid !important;
+      }
     }
     .no-gutters img {
       width: calc(100% - 10px);

--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -39,6 +39,16 @@
   }
 }
 
+.contrast-switcher .contrast-high a:focus {
+  background-color: $focusColor !important;
+  color: $focusOutlineColor !important;
+  box-shadow: 0 -2px $focusColor,0 4px $focusOutlineColor !important;
+}
+body.contrast-high .contrast-switcher .contrast-high a:focus {
+  box-shadow: none !important;
+  outline: 2px solid $focusOutlineColor !important;
+}
+
 body.contrast-high {
 
   li {

--- a/_sass/components/_language_toggle.scss
+++ b/_sass/components/_language_toggle.scss
@@ -192,18 +192,31 @@ footer #footerLinks .language-toggle-menu-footer {
       color: $color-highlight-highContrast;
     }
   }
+  .language-toggle-link:focus {
+    &, span {
+      color: $focusColor-highContrast !important;
+    }
+  }
   .language-toggle-dropdown {
     .dropdown-toggle {
-      &, &:hover, &:active, &:focus {
+      &, &:hover, &:active {
         background: $color-dark-highContrast !important;
       }
       &, span, .language-toggle-caret {
         color: $color-light-highContrast !important;
       }
+      &:focus, &:focus span, &:focus i {
+        background: $focusBackgroundColor-highContrast !important;
+        color: $focusColor-highContrast !important;
+      }
     }
     .dropdown-menu {
-      &, a:hover, a:focus {
+      &, a:hover {
         background: $color-dark-highContrast;
+      }
+      a:focus {
+        background: $focusBackgroundColor-highContrast;
+        color: $focusColor-highContrast;
       }
       border-color: $color-light-highContrast;
     }
@@ -213,8 +226,11 @@ footer #footerLinks .language-toggle-menu-footer {
       a:visited {
         color: $color-light-highContrast;
       }
-      a:hover, a:focus {
+      a:hover {
         color: $color-highlight-highContrast;
+      }
+      a:focus {
+        color: $focusColor-highContrast
       }
     }
   }

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -54,11 +54,24 @@ header {
   width: 75%;
   max-width: 350px;
   padding: 15px;
+  height: auto;
+  &:focus {
+    background-color: transparent !important;
+    outline: 7px solid $focusOutlineColor !important;
+  }
   @media screen and (min-width: 769px) {
     padding: 5px 15px 15px 0;
   }
   img {
     width: 100%;
+  }
+}
+body.contrast-high {
+  .navbar-brand {
+    &:focus {
+      background-color: transparent !important;
+      outline: 7px solid $focusOutlineColor !important;
+    }
   }
 }
 

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -52,7 +52,7 @@ header {
 .navbar-brand {
   display: block;
   width: 75%;
-  max-width: 300px;
+  max-width: 350px;
   padding: 15px;
   @media screen and (min-width: 769px) {
     padding: 5px 15px 15px 0;

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -608,3 +608,9 @@ body.contrast-high {
     }
   }
 }
+
+.goal-banner {
+  .goal-icon {
+    margin-top: 10px;
+  }
+}

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -383,20 +383,6 @@
   canvas {
     @include noselect;
   }
-  .no-gutters img {
-    width: calc(100% - 10px);
-    border: 0;
-    padding: 0;
-    margin: 5px 10px 5px 0;
-
-    &:not(#goal-18){
-      box-shadow: 5px 5px 5px 0px $goalTiles-tile-shadowColor;
-
-      &:hover{
-        box-shadow: 5px 5px 5px 0px $goalTiles-tile-shadowColor-hover;
-      }
-    }
-  }
 
   &.goal-indicators {
     @include indicatorcards;

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -549,15 +549,15 @@ body.contrast-high {
     }
   }
 
-  #toolbar {
+  #main-content #toolbar {
     button {
-      background-color: $color-dark-highContrast !important;
+      background-color: $color-dark-highContrast;
       border-color: $color-light-highContrast;
       color: $color-light-highContrast;
     }
   }
 
-  .variable-options {
+  #main-content #fields .variable-selector .variable-options {
     background: $color-dark-highContrast;
     color: $color-light-highContrast;
     div {
@@ -566,7 +566,7 @@ body.contrast-high {
     }
     button {
       background: $color-dark-highContrast;
-      color: $color-light-highContrast !important;
+      color: $color-light-highContrast;
       border-color: $color-light-highContrast;
     }
   }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -97,6 +97,9 @@
     width: 115px;
     float: left;
     min-height: 1px;
+    > a:focus {
+      outline: 6px $focusOutlineColor solid !important;
+    }
   }
   .details {
     width: calc(100% - 125px);

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,8 +1,13 @@
 // Top-level color variables.
 // [color|backgroundColor|etc] - [...modifiers]
 $backgroundColor: white !default;
-$focusColor: #1d70b8 !default;
-$focusColor-highContrast: #fd0 !default;
+
+$focusColor: #0b0c0c !default;
+$focusBackgroundColor: #ffdd00 !default;
+$focusOutlineColor: #ffdd00 !default;
+$focusColor-highContrast: #0b0c0c !default;
+$focusBackgroundColor-highContrast: #ffdd00 !default;
+$focusOutlineColor-highContrast: #ffdd00 !default;
 
 $color-dark: #0b0c0c !default;
 $color-light: white !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -1,6 +1,8 @@
 // Top-level color variables.
 // [color|backgroundColor|etc] - [...modifiers]
 $backgroundColor: white !default;
+$focusColor: #1d70b8 !default;
+$focusColor-highContrast: #fd0 !default;
 
 $color-dark: #0b0c0c !default;
 $color-light: white !default;


### PR DESCRIPTION
Fixes #849 

This could use design input, as I arbitrarily chose the colors here. I'm using our link color for the normal focus color, and our button highlight color for the high-contrast focus color. Here's an example of each:

Normal contrast:

![screenshot-127 0 0 1_4000-2020 09 01-15_43_30](https://user-images.githubusercontent.com/1319083/91898609-fab35780-ec69-11ea-8fae-e4d718ccc6c2.png)

High contrast:

![screenshot-127 0 0 1_4000-2020 09 01-15_43_49](https://user-images.githubusercontent.com/1319083/91898620-fedf7500-ec69-11ea-8ea4-8a7d8fa76bc0.png)

