### PR TITLE
Announce changes to the chart/table

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -333,7 +333,7 @@ var indicatorView = function (model, options) {
     view_obj._chartInstance.update(1000, true);
 
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
-
+    view_obj.updateIndicatorDataViewStatus(chartInfo);
     view_obj.updateChartDownloadButton(chartInfo.selectionsTable);
   };
 
@@ -486,6 +486,7 @@ var indicatorView = function (model, options) {
     });
 
     $(this._legendElement).html(view_obj._chartInstance.generateLegend());
+    view_obj.updateIndicatorDataViewStatus(chartInfo);
   };
 
   this.getGridColor = function(contrast) {
@@ -662,6 +663,23 @@ var indicatorView = function (model, options) {
           .data('csvdata', tableCsv);
       }
     }
+  }
+
+  this.updateIndicatorDataViewStatus = function(chartInfo) {
+    var status = 'Chart and table include no data.';
+    if (chartInfo.datasets.length > 0) {
+      var labels = chartInfo.datasets.map(function(dataset) {
+        return dataset.label;
+      });
+      status = 'Chart and table include data disaggregated by ' + labels.join(' and ') + '.';
+      if (chartInfo.selectedUnit) {
+        status += ' Selected unit of measurement is ' + chartInfo.selectedUnit + '.';
+      }
+      if (chartInfo.selectedSeries) {
+        status += ' Selected series is ' + chartInfo.selectedSeries + '.';
+      }
+    }
+    $('#indicator-data-view-status').html(status);
   }
 
   this.createSourceButton = function(indicatorId, el) {

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -666,12 +666,12 @@ var indicatorView = function (model, options) {
   }
 
   this.updateIndicatorDataViewStatus = function(chartInfo) {
-    var status = 'Chart and table include no data.';
+    var status = 'Chart and table shows no data.';
     if (chartInfo.datasets.length > 0) {
       var labels = chartInfo.datasets.map(function(dataset) {
         return dataset.label;
       });
-      status = 'Chart and table include data disaggregated by ' + labels.join(' and ') + '.';
+      status = 'Chart and table shows datasets for ' + labels.join(' and ') + '.';
       if (chartInfo.selectedUnit) {
         status += ' Selected unit of measurement is ' + chartInfo.selectedUnit + '.';
       }

--- a/_includes/components/indicator/indicator-main.html
+++ b/_includes/components/indicator/indicator-main.html
@@ -36,6 +36,7 @@
   data-stackeddisaggregation="{{ page.indicator.graph_stacked_disaggregation }}"
 >
   {% if show_data %}
+  <span role="status" class="sr-only" id="indicator-data-view-status"></span>
   <div id="indicator-sidebar" class="indicator-sidebar col-md-3">
     {% include components/indicator/data-sidebar.html %}
   </div>


### PR DESCRIPTION
Fixes #846 

This adds a screenreader-only element with some text describing the current state of the chart/table. Examples of possible announcements are:
* "Chart and table shows no data."
* "Chart and table shows datasets for Female and Male."
* "Chart and table shows datasets for Female and Male. Selected unit of measurement is percent."
* "Chart and table shows datasets for Female and Male. Selected series is [my series name]."