### PR TITLE
Accessibility fixes for sorting tables

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -724,9 +724,9 @@ var indicatorView = function (model, options) {
       var table_head = '<thead><tr>';
 
       var getHeading = function(heading, index) {
-        var span = '<span class="sort" />';
-        var span_heading = '<span tabindex="0" role="button" aria-describedby="column-sort-info">' + translations.t(heading) + '</span>';
-        return (!index || heading.toLowerCase() == 'units') ? span_heading + span : span + span_heading;
+        var arrows = '<span class="sort"><i class="fa fa-sort-down"></i><i class="fa fa-sort-up"></i></span>';
+        var button = '<span tabindex="0" role="button" aria-describedby="column-sort-info">' + translations.t(heading) + '</span>';
+        return (!index || heading.toLowerCase() == 'units') ? button + arrows : arrows + button;
       };
 
       table.headings.forEach(function (heading, index) {

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -725,7 +725,7 @@ var indicatorView = function (model, options) {
 
       var getHeading = function(heading, index) {
         var span = '<span class="sort" />';
-        var span_heading = '<span>' + translations.t(heading) + '</span>';
+        var span_heading = '<span tabindex="0" role="button" aria-describedby="column-sort-info">' + translations.t(heading) + '</span>';
         return (!index || heading.toLowerCase() == 'units') ? span_heading + span : span + span_heading;
       };
 
@@ -757,6 +757,8 @@ var indicatorView = function (model, options) {
       initialiseDataTable(el);
 
       $(el).removeClass('table-has-no-data');
+
+      $(el).find('th').removeAttr('tabindex');
     } else {
       $(el).append($('<h3 />').text(translations.indicator.data_not_available));
       $(el).addClass('table-has-no-data');

--- a/_includes/components/indicator/data-panes.html
+++ b/_includes/components/indicator/data-panes.html
@@ -3,6 +3,9 @@
     {% include components/charts/chart.html graph_type=page.indicator.graph_type %}
   </div>
   <div role="tabpanel" class="tab-pane" id="tableview">
+    <div style="display: none;">
+      <span id="column-sort-info">Click to sort by this column</span>
+    </div>
     {% include components/indicator/table.html %}
   </div>
   <div role="tabpanel" class="tab-pane" id="mapview" class="map">

--- a/_sass/base/_tables.scss
+++ b/_sass/base/_tables.scss
@@ -35,50 +35,19 @@ table {
       .sort {
         background-image: none !important;
       }
-      &[aria-sort="descending"], &[aria-sort="ascending"] {
-        position: relative;
-        &:first-child:after, &:last-child:before {
-          content: " ";
-          border-left: 0.4em solid transparent;
-          border-right: 0.4em solid transparent;
-          position: relative;
+      .fa-sort-down, .fa-sort-up {
+        display: none;
+        margin-left: 5px;
+        margin-right: 5px;
+      }
+      &[aria-sort="descending"] {
+        .fa-sort-down {
+          display: inline-block;
         }
       }
-      &[aria-sort="descending"]:first-child:after,
-      &[aria-sort="descending"]:last-child:before {
-        border-top: 0.4em solid black;
-        top: 15px;
-      }
-      &[aria-sort="ascending"]:first-child:after,
-      &[aria-sort="ascending"]:last-child:before {
-        border-bottom: 0.4em solid black;
-        bottom: 15px;
-      }
-      &[aria-sort]:first-child:after {
-        left: auto;
-        right: 1em;
-      }
-      &[aria-sort]:last-child:before {
-        left: 1em;
-        right: auto;
-      }
-    }
-  }
-}
-
-body.contrast-high {
-  table {
-    thead {
-      th {
-        &[aria-sort="descending"] {
-          &:first-child:after, &:last-child:before {
-            border-top-color: $color-light-highContrast;
-          }
-        }
-        &[aria-sort="ascending"] {
-          &:first-child:after, &:last-child:before {
-            border-bottom-color: $color-light-highContrast;
-          }
+      &[aria-sort="ascending"] {
+        .fa-sort-up {
+          display: inline-block;
         }
       }
     }

--- a/_sass/base/_tables.scss
+++ b/_sass/base/_tables.scss
@@ -28,3 +28,59 @@
     border-bottom: 1pt solid $color-dark;
   }
 }
+
+table {
+  thead {
+    th {
+      .sort {
+        background-image: none !important;
+      }
+      &[aria-sort="descending"], &[aria-sort="ascending"] {
+        position: relative;
+        &:first-child:after, &:last-child:before {
+          content: " ";
+          border-left: 0.4em solid transparent;
+          border-right: 0.4em solid transparent;
+          position: relative;
+        }
+      }
+      &[aria-sort="descending"]:first-child:after,
+      &[aria-sort="descending"]:last-child:before {
+        border-top: 0.4em solid black;
+        top: 15px;
+      }
+      &[aria-sort="ascending"]:first-child:after,
+      &[aria-sort="ascending"]:last-child:before {
+        border-bottom: 0.4em solid black;
+        bottom: 15px;
+      }
+      &[aria-sort]:first-child:after {
+        left: auto;
+        right: 1em;
+      }
+      &[aria-sort]:last-child:before {
+        left: 1em;
+        right: auto;
+      }
+    }
+  }
+}
+
+body.contrast-high {
+  table {
+    thead {
+      th {
+        &[aria-sort="descending"] {
+          &:first-child:after, &:last-child:before {
+            border-top-color: $color-light-highContrast;
+          }
+        }
+        &[aria-sort="ascending"] {
+          &:first-child:after, &:last-child:before {
+            border-bottom-color: $color-light-highContrast;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #869 and #854 

I'm not 100% clear on the benefits here, but here are the changes in this PR:
1. The up/down arrows are now done with Fontawesome icons instead of with background images. This is intended to fix the DAC complaint in #854.
2. Instead of tabbing to the `<th>` elements for to a sort, the users now tab to a `<span role="button">` element inside the `<th>`. The button is `aria-describedby` a hidden div. (Which will eventually have to be translated.) This is intended to fix the DAC complaint in #869.