### PR TITLE
Custom javascript for better tab accessibility

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -769,7 +769,12 @@ var indicatorView = function (model, options) {
 
       $(el).removeClass('table-has-no-data');
 
-      $(el).find('th').removeAttr('tabindex');
+      $(el).find('th')
+        .removeAttr('tabindex')
+        .click(function() {
+          var sortDirection = $(this).attr('aria-sort');
+          $(this).find('span[role="button"]').attr('aria-sort', sortDirection);
+        });
     } else {
       $(el).append($('<h3 />').text(translations.indicator.data_not_available));
       $(el).addClass('table-has-no-data');

--- a/_includes/assets/js/tabs.js
+++ b/_includes/assets/js/tabs.js
@@ -1,38 +1,38 @@
 {% if site.accessible_tabs %}
 $(document).ready(function() {
     $('.nav-tabs').each(function() {
-        var $tabsList = $(this);
-        var $tabs = $tabsList.find('li > a');
-        var $panes = $tabsList.parent().find('.tab-pane');
+        var tabsList = $(this);
+        var tabs = tabsList.find('li > a');
+        var panes = tabsList.parent().find('.tab-pane');
 
-        $panes.attr({
+        panes.attr({
             'class': 'tabPanel',
             'role': 'tabpanel',
             'aria-hidden': 'true',
         }).hide();
 
-        $tabsList.attr({
+        tabsList.attr({
             'role': 'tablist',
         });
 
-        $tabs.each(function(idx) {
-            var $tab = $(this);
-            var tabId = 'tab-' + $tab.attr('href').slice(1);
-            var $pane = $tabsList.parent().find($tab.attr('href'));
+        tabs.each(function(idx) {
+            var tab = $(this);
+            var tabId = 'tab-' + tab.attr('href').slice(1);
+            var pane = tabsList.parent().find(tab.attr('href'));
 
-            $tab.attr({
+            tab.attr({
                 'id': tabId,
                 'role': 'tab',
                 'aria-selected': 'false',
                 'tabindex': '-1',
             }).parent().attr('role', 'presentation');
 
-            $pane.attr('aria-labelledby', tabId);
+            pane.attr('aria-labelledby', tabId);
 
-            $tab.click(function(e) {
+            tab.click(function(e) {
                 e.preventDefault();
 
-                $tabsList.find('> li.active')
+                tabsList.find('> li.active')
                     .removeClass('active')
                     .find('> a')
                     .attr({
@@ -40,45 +40,45 @@ $(document).ready(function() {
                         'tabindex': '-1',
                     });
                 
-                $panes.filter(':visible').attr('aria-hidden', 'true').hide();
+                panes.filter(':visible').attr('aria-hidden', 'true').hide();
 
-                $pane.attr('aria-hidden', 'false').show();
+                pane.attr('aria-hidden', 'false').show();
 
-                $tab.attr({
+                tab.attr({
                     'aria-selected': 'true',
                     'tabindex': '0',
                 }).parent().addClass('active');
-                $tab.focus();
+                tab.focus();
             });
         });
 
         // Show the first tabPanel
-        $panes.first().attr('aria-hidden', 'false').show();
+        panes.first().attr('aria-hidden', 'false').show();
 
         // Set state for the first tabsList li
-        $tabsList.find('li:first').addClass('active').find(' > a').attr({
+        tabsList.find('li:first').addClass('active').find(' > a').attr({
             'aria-selected': 'true',
             'tabindex': '0',
         });
 
         // Set keydown events on tabList item for navigating tabs
-        $tabsList.delegate('a', 'keydown', function(e) {
-            var $tab = $(this);
+        tabsList.delegate('a', 'keydown', function(e) {
+            var tab = $(this);
             switch (e.which) {
                 case 37:
-                    if ($tab.parent().prev().length != 0) {
-                        $tab.parent().prev().find('> a').click();
+                    if (tab.parent().prev().length != 0) {
+                        tab.parent().prev().find('> a').click();
                     }
                     else {
-                        $tabsList.find('li:last > a').click();
+                        tabsList.find('li:last > a').click();
                     }
                     break;
                 case 39:
-                    if ($tab.parent().next().length != 0) {
-                        $tab.parent().next().find('> a').click();
+                    if (tab.parent().next().length != 0) {
+                        tab.parent().next().find('> a').click();
                     }
                     else {
-                        $tabsList.find('li:first > a').click();
+                        tabsList.find('li:first > a').click();
                     }
                     break;
             }

--- a/_includes/assets/js/tabs.js
+++ b/_includes/assets/js/tabs.js
@@ -1,0 +1,88 @@
+{% if site.accessible_tabs %}
+$(document).ready(function() {
+    $('.nav-tabs').each(function() {
+        var $tabsList = $(this);
+        var $tabs = $tabsList.find('li > a');
+        var $panes = $tabsList.parent().find('.tab-pane');
+
+        $panes.attr({
+            'class': 'tabPanel',
+            'role': 'tabpanel',
+            'aria-hidden': 'true',
+        }).hide();
+
+        $tabsList.attr({
+            'role': 'tablist',
+        });
+
+        $tabs.each(function(idx) {
+            var $tab = $(this);
+            var tabId = 'tab-' + $tab.attr('href').slice(1);
+            var $pane = $tabsList.parent().find($tab.attr('href'));
+
+            $tab.attr({
+                'id': tabId,
+                'role': 'tab',
+                'aria-selected': 'false',
+                'tabindex': '-1',
+            }).parent().attr('role', 'presentation');
+
+            $pane.attr('aria-labelledby', tabId);
+
+            $tab.click(function(e) {
+                e.preventDefault();
+
+                $tabsList.find('> li.active')
+                    .removeClass('active')
+                    .find('> a')
+                    .attr({
+                        'aria-selected': 'false',
+                        'tabindex': '-1',
+                    });
+                
+                $panes.filter(':visible').attr('aria-hidden', 'true').hide();
+
+                $pane.attr('aria-hidden', 'false').show();
+
+                $tab.attr({
+                    'aria-selected': 'true',
+                    'tabindex': '0',
+                }).parent().addClass('active');
+                $tab.focus();
+            });
+        });
+
+        // Show the first tabPanel
+        $panes.first().attr('aria-hidden', 'false').show();
+
+        // Set state for the first tabsList li
+        $tabsList.find('li:first').addClass('active').find(' > a').attr({
+            'aria-selected': 'true',
+            'tabindex': '0',
+        });
+
+        // Set keydown events on tabList item for navigating tabs
+        $tabsList.delegate('a', 'keydown', function(e) {
+            var $tab = $(this);
+            switch (e.which) {
+                case 37:
+                    if ($tab.parent().prev().length != 0) {
+                        $tab.parent().prev().find('> a').click();
+                    }
+                    else {
+                        $tabsList.find('li:last > a').click();
+                    }
+                    break;
+                case 39:
+                    if ($tab.parent().next().length != 0) {
+                        $tab.parent().next().find('> a').click();
+                    }
+                    else {
+                        $tabsList.find('li:first > a').click();
+                    }
+                    break;
+            }
+        });
+    });
+});
+{% endif %}

--- a/_includes/components/indicator/data-panes.html
+++ b/_includes/components/indicator/data-panes.html
@@ -8,9 +8,11 @@
     </div>
     {% include components/indicator/table.html %}
   </div>
+  {%- if page.indicator.data_show_map -%}
   <div role="tabpanel" class="tab-pane" id="mapview" class="map">
     {% include components/indicator/map.html %}
   </div>
+  {%- endif -%}
   {% if page.indicator.embedded_feature_url or page.indicator.embedded_feature_html %}
   <div role="tabpanel" class="tab-pane" id="embeddedmapview" class="embedded-map">
     {% include components/indicator/embedded-feature.html %}

--- a/_includes/components/indicator/data-tabs.html
+++ b/_includes/components/indicator/data-tabs.html
@@ -5,9 +5,11 @@
   <li role="presentation" class="nav-item">
     <a class="nav-link" data-toggle="tab" href="#tableview" aria-controls="tableview" role="tab" {% include autotrack.html preset="tab_data_table" category="Tab change" action="Change data view" label="Change to Table tab" %}>{{ page.t.indicator.table }}</a>
   </li>
+  {%- if page.indicator.data_show_map -%}
   <li role="presentation" class="nav-item map" style="display:none">
     <a data-no-disagg="true" class="nav-link" data-toggle="tab" href="#mapview" aria-controls="mapview" role="tab" {% include autotrack.html preset="tab_data_map" category="Tab change" action="Change data view" label="Change to Map tab" %}>{{ page.t.indicator.map }}</a>
   </li>
+  {%- endif -%}
   {%- if page.indicator.embedded_feature_url or page.indicator.embedded_feature_html -%}
   <li role="presentation" class="nav-item embedded-map">
     <a data-no-disagg="true" class="nav-link" data-toggle="tab" href="#embeddedmapview" aria-controls="embeddedmapview" role="tab" {% include autotrack.html preset="tab_data_embed" category="Tab change" action="Change data view" label="Change to embedded item tab" %}>{{ page.indicator.embedded_feature_tab_title }}</a>

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -12,6 +12,7 @@
 {%- include assets/js/mapView.js -%}
 {%- include assets/js/indicatorView.js -%}
 {%- include assets/js/indicatorController.js -%}
+{%- include assets/js/tabs.js -%}
 {%- include assets/js/search.js -%}
 {%- include assets/js/menu.js -%}
 {%- include assets/js/lib/classList.js -%}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,14 @@ _Note about "strings": Many of the settings detailed here contain human-readable
 
 > To see many of these options in action, the [site starter repository](https://github.com/open-sdg/open-sdg-site-starter) contains an [example config file](https://github.com/open-sdg/open-sdg-site-starter/blob/develop/_config.yml).
 
+### accessible_tabs
+
+_Optional_: This setting can be set to `true` to enable tab functionality that is compliant with the [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel). This adds improved keyboard navigation of the tabs. If omitted, this defaults to `false`, however setting this to `true` is recommended.
+
+```nohighlight
+accessible_tabs: false
+```
+
 ### analytics
 
 _Optional_: This setting can contain another (indented) setting, `ga_prod`, which should be a [Google Analytics tracking ID](https://support.google.com/analytics/answer/1008080?hl=en#GAID). If these settings are used, usage statistics will be sent to Google Analytics. For more information about this, see the [analytics](analytics.md) page.

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -195,3 +195,5 @@ breadcrumbs:
       path: /
     - label: general.goals
       path: /goals
+
+accessible_tabs: true


### PR DESCRIPTION
Fixes #840 

@jwestw @LucyGwilliamAdmin This is ready for review. Because this is a moderately significant bit of javascript and does change the tab behavior, I've got this as an optional feature, `accessible_tabs`. Eventually I would foresee this is the default behavior, but for now I don't want to cause problems for the countries during upgrades.

So, when testing this in a feature branch, you would need to add `accessible_tabs: true` to the _config.yml file.