### PR TITLE
Indicator footer as a definition list

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -790,9 +790,12 @@ var indicatorView = function (model, options) {
       'id': divid,
       'class': 'table-footer-text'
     });
+    var footList = $('<dl>');
+    footdiv.append(footList);
 
     _.each(footerFields, function(val, key) {
-      footdiv.append($('<p />').text(key + ': ' + val));
+      footList.append($('<dt />').text(key + ': '));
+      footList.append($('<dd />').text(val));
     });
 
     $(el).append(footdiv);

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -507,6 +507,12 @@
         font-size: 0.85em;
         margin: 0 0 5px;
       }
+      dl {
+        font-size: 0.85em;
+        dd {
+          margin: 0 0 5px;
+        }
+      }
       padding-left: 20px;
     }
   }
@@ -524,6 +530,19 @@
     font-size: 12px;
     line-height: 1.2;
     padding-left: 20px;
+  }
+}
+
+.table-footer-text {
+  dl {
+    dt {
+      float: left;
+      margin-right: 5px;
+      font-weight: normal;
+    }
+    dd {
+      margin-bottom: 10px;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #855 

The footers below indicator charts/tables (with geographical area, unit of measurement, footnote, etc.) should now be a `<dl>` element with a series of `<dt>` and `<dd>` elements, rather than a series of `<p>` elements like before.