### PR TITLE
Search button outside of label

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,8 +1,7 @@
 <div id="search" class="menu-target">
   <form action="{{ page.baseurl }}search">
     <input type="text" name="q" id="indicator_search" title="{{ page.t.search.search }}" />
-    <label for="indicator_search">
-      <button aria-label="{{ page.t.search.search }}" id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button><span>{{ page.t.search.search }}:</span>
-    </label>
+    <label class="sr-only" for="indicator_search">{{ page.t.search.search }}:</label>
+    <button aria-label="{{ page.t.search.search }}" id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button>
   </form>
 </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,7 +1,7 @@
 <div id="search" class="menu-target">
   <form action="{{ page.baseurl }}search">
     <input type="text" name="q" id="indicator_search" title="{{ page.t.search.search }}" />
-    <label class="sr-only" for="indicator_search">{{ page.t.search.search }}:</label>
+    <label class="sr-only" for="indicator_search">{{ page.t.search.search }}</label>
     <button aria-label="{{ page.t.search.search }}" id="search-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button>
   </form>
 </div>

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -168,17 +168,6 @@ body.contrast-high {
       margin-bottom: 0;
     }
 
-    label {
-      position: absolute;
-      top: 5px;
-      right: 0px;
-      font-size: 1.40em;
-
-      span {
-        display: none;
-      }
-    }
-
     input {
       padding: 5px;
       padding-left: 5px;
@@ -189,11 +178,17 @@ body.contrast-high {
       margin-top: 5px;
       font-size: $searchBar-input-fontSize;
     }
+
+    button {
+      height: 34px;
+      color: $color-dark;
+      position: absolute;
+      right: 0px;
+      bottom: 0px;
+      font-size: 1.40em;
+      line-height: 15px;
+    }
   }
-}
-#search-btn {
-  line-height: 15px;
-  height: 34px;
 }
 
 .table {
@@ -300,27 +295,15 @@ body.contrast-high {
       width: 100%;
       padding: 20px;
 
-      label {
-        top: 23px;
-        left: 25px;
-        color: $color-dark;
-      }
-
-      button {
-        display: inline-flex;
-        position: absolute;
-        right: 20px;
-        top: -3px
-      }
-
       input {
         width: 100%;
         color: $text-color;
         margin-top: 0;
+      }
 
-        &:focus {
-          width: 100%;
-        }
+      button {
+        right: 20px;
+        bottom: 20px;
       }
     }
   }
@@ -369,7 +352,7 @@ body.contrast-high {
       }
     }
     #search {
-      input, label {
+      input, button {
         color: $color-dark-highContrast;
       }
     }


### PR DESCRIPTION
Fixes #847 

As part of this some changes to the CSS were necessary, and so I took the opportunity to remove a bit of CSS that did not seem needed. So manual cross-browser testing will be necessary to ensure that the search bar looks the same as before.

This implements the markup changes suggested in #847. There should be no visual or functional change.