### PR TITLE
Add role='status' to search results info

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -3,7 +3,7 @@
 
 <script type="text/template" class="results-template">
   <% if(resultsCount) { %>
-    <p><%= resultsCount %> results found</p>
+    <p role="status"><%= resultsCount %> results found</p>
     <% _.each(searchResults, function(result){ %>
       <div class="row search-result">
         <div class="col col-xs-12">
@@ -19,7 +19,7 @@
     <% }); %>
 
   <% } else { %>
-    <p>
+    <p role="status">
       {{ page.t.search.no_results }}
       <% if(didYouMean) { %>
       - {{ page.t.search.did_you_mean }}:


### PR DESCRIPTION
Fixes #861 

This add `role="status"` to the paragraph with info about the number of results found on the search page.