### PR TITLE
Search results link fixes

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -9,10 +9,8 @@
         <div class="col col-xs-12">
           <a href="<%= result.url %>">
             <h3 class="title"><%= result.title %></h3>
-            <span class="url">
-              <%= result.type %> &raquo; <%= result.url %>
-            </span>
           </a>
+          <div class="url"><%= result.type %> &raquo; <%= result.url %></div>
           <div class="content"><%= result.content %></div>
         </div>
       </div>

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -87,3 +87,12 @@
     }
   }
 }
+
+@mixin focus {
+  color: $focusColor !important;
+  outline: 3px solid transparent !important;
+  background-color: $focusBackgroundColor !important;
+  outline-offset: 0 !important;
+  box-shadow: 0 -2px $focusOutlineColor,0 4px $focusColor !important;
+  text-decoration: none !important;
+}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -89,12 +89,7 @@ h3{ font-size: $h3-fontSize; }
 iframe:focus,
 input:focus,
 button:focus {
-  color: $focusColor !important;
-  outline: 3px solid transparent !important;
-  background-color: $focusBackgroundColor !important;
-  outline-offset: 0 !important;
-  box-shadow: 0 -2px $focusOutlineColor,0 4px $focusColor !important;
-  text-decoration: none !important;
+  @include focus;
 }
 body.contrast-high {
   [contentEditable="true"]:focus,

--- a/_sass/layouts/_search.scss
+++ b/_sass/layouts/_search.scss
@@ -41,6 +41,9 @@
       color: $search-resultURL-color;
       font-size: 16px;
     }
+    .content {
+      margin-top: 2px;
+    }
   }
 }
 

--- a/_sass/layouts/_search.scss
+++ b/_sass/layouts/_search.scss
@@ -22,15 +22,15 @@
         margin-bottom: 5px;
         font-size: 18px;
       }
-      .url {
-        color: $search-resultURL-color;
-        font-size: 16px;
-      }
       &:hover {
         .title {
           text-decoration: underline;
         }
       }
+    }
+    .url {
+      color: $search-resultURL-color;
+      font-size: 16px;
     }
   }
 }
@@ -44,10 +44,8 @@ body.contrast-high {
     }
 
     .search-result {
-      a {
-        .url {
-          color: $color-highlight-highContrast !important;
-        }
+      .url {
+        color: $color-highlight-highContrast !important;
       }
       .content {
         color: $color-light-highContrast !important;

--- a/_sass/layouts/_search.scss
+++ b/_sass/layouts/_search.scss
@@ -26,6 +26,9 @@
       &:focus {
         .title {
           @include focus;
+          span.match {
+            background-color: transparent;
+          }
         }
       }
       &:hover {

--- a/_sass/layouts/_search.scss
+++ b/_sass/layouts/_search.scss
@@ -21,6 +21,12 @@
       .title {
         margin-bottom: 5px;
         font-size: 18px;
+        display: inline-block;
+      }
+      &:focus {
+        .title {
+          @include focus;
+        }
       }
       &:hover {
         .title {


### PR DESCRIPTION
Fixes #845 

* Removes the category/path from the search result link
* Adds the indicator/goal number in front of the title in the link
* Fixes the problem with the focus treatment of search results

This relies on a PR for jekyll-open-sdg-plugins: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/51

So testing this would require this in the `Gemfile`:

`gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'numbers-in-search-results'`

Here is a screenshot:

![numbers-in-search-results](https://user-images.githubusercontent.com/1319083/93380004-a513a900-f82c-11ea-9df7-ae76a41e20e6.png)
