### PR TITLE
Use text-colour for table caption

### DIFF
--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -534,6 +534,10 @@
   }
 }
 
+caption {
+  color: $text-color;
+}
+
 .table-footer-text {
   dl {
     dt {


### PR DESCRIPTION
Final fix for #848 

Feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/black-table-caption/1-2-1/