### PR TITLE
Full indicator name in the page title and h1

### DIFF
--- a/_includes/components/indicator/header.html
+++ b/_includes/components/indicator/header.html
@@ -8,8 +8,10 @@
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10 indicator-details">
         <div>
-          <h1>{{ page.t.general.indicator }} {{ page.indicator.number }}</h1>
-          <p class="lead-copy">{{ page.indicator.name }}</p>
+          <h1>
+            {{ page.t.general.indicator }} {{ page.indicator.number }}
+            <span class="lead-copy">{{ page.indicator.name }}</span>
+          </h1>
         </div>
       </div>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
         ================================================== -->
 
         {% if page.indicator %}
-        <title>{{ page.t.general.indicator | escape }} {{ page.indicator.number }} - {{ page.t.general.goal | escape }} {{ page.goal.number }}</title>
+        <title>{{ page.t.general.indicator | escape }} {{ page.indicator.number }} - {{ page.indicator.name | escape }}</title>
         {% elsif page.goal %}
         <title>{{ page.t.general.goal | escape }} {{ page.goal.number }} - {{ page.goal.short | escape }}</title>
         {% elsif page.title %}

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -637,4 +637,10 @@ body.contrast-high {
   .goal-icon {
     margin-top: 10px;
   }
+  h1 {
+    .lead-copy {
+      display: block;
+      margin-top: 10px;
+    }
+  }
 }


### PR DESCRIPTION
This is an experimental PR intended as a companion to #901 to make the indicator page title and H1 closer to what displays in the search results, in that PR.

Visually nothing should change, but semantically the indicator name is now included inside the H1.

Also the page title (ie, the contents of the browser tabs) will now be the word "Indicator" followed by the number, then a dash and the name. Example:

`Indicator 1.1.1 - Proportion of population below the international poverty line, by sex, age, employment status and geographical location (urban/rural)`.

We could simplify that a bit more by removing "Indicator" and/or the dash. Example:

`1.1.1 Proportion of population below the international poverty line, by sex, age, employment status and geographical location (urban/rural)`

This would make it exactly like the search results in #901.

An important note is that whatever we choose for the page title will be what appears in search engines (Google, DuckDuckGo, etc.). Right now, the page title is (for example) `Indicator 1.1.1 - Goal 1` and so this is what appears in search engines.