### PR TITLE
Backwards-compatible array-style for search_index_boost

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -144,8 +144,19 @@ var indicatorSearch = function() {
   // Helper function to get a boost score, if any.
   function getSearchFieldOptions(field) {
     var opts = {}
-    if (opensdg.searchIndexBoost[field]) {
-      opts['boost'] = parseInt(opensdg.searchIndexBoost[field])
+    // @deprecated start
+    if (opensdg.searchIndexBoost && !Array.isArray(opensdg.searchIndexBoost)) {
+      if (opensdg.searchIndexBoost[field]) {
+        opts['boost'] = parseInt(opensdg.searchIndexBoost[field])
+      }
+      return opts;
+    }
+    // @deprecated end
+    var fieldBoost = opensdg.searchIndexBoost.find(function(boost) {
+      return boost.field === field;
+    });
+    if (fieldBoost) {
+      opts['boost'] = parseInt(fieldBoost.boost)
     }
     return opts
   }

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -32,8 +32,23 @@
 opensdg.searchItems = {{ site.data.search_items[page.language] | jsonify }};
 {% if site.search_index_boost %}
 opensdg.searchIndexBoost = {{ site.search_index_boost | jsonify }};
+// @deprecated start
+if (!Array.isArray(opensdg.searchIndexBoost)) {
+  var searchIndexBoost = [];
+  Object.keys(opensdg.searchIndexBoost).forEach(function(key) {
+    searchIndexBoost.push({
+      field: key,
+      boost: opensdg.searchIndexBoost[key],
+    });
+  });
+  opensdg.searchIndexBoost = searchIndexBoost;
+}
+// @deprecated end
 {% else %}
-opensdg.searchIndexBoost = {};
+opensdg.searchIndexBoost = [{
+  field: 'title',
+  boost: 10,
+}];
 {% endif %}
 {% if site.search_index_extra_fields %}
 opensdg.searchIndexExtraFields = {{ site.search_index_extra_fields | jsonify }};

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -533,7 +533,8 @@ _Optional_: This setting can be used to give a "boost" to one or more fields in 
 
 ```
 search_index_boost:
-  title: 10
+  - field: title
+    boost: 10
 ```
 
 The following example shows additional fields that can be boosted:
@@ -541,11 +542,14 @@ The following example shows additional fields that can be boosted:
 ```
 search_index_boost:
   # The title of the indicator, goal, or page.
-  title: 10
+  - field: title
+    boost: 10
   # The content of the indicator, goal, or page.
-  content: 1
+  - field: content
+    boost: 1
   # The id number of the indicator or goal.
-  id: 5
+  - field: id
+    boost: 5
 ```
 
 Additionally, any fields set in the `search_index_extra_fields` setting may also be boosted. For example:
@@ -553,7 +557,8 @@ Additionally, any fields set in the `search_index_extra_fields` setting may also
 ```
 search_index_boost:
   # Assumes that "national_agency" was set in "search_index_extra_fields".
-  national_agency: 5
+  - field: national_agency
+    boost: 5
 ```
 
 ### search_index_extra_fields

--- a/tests/site/_config.yml
+++ b/tests/site/_config.yml
@@ -130,6 +130,9 @@ series_toggle: true
 # Search.feature
 search_index_extra_fields:
   - un_custodian_agency
+search_index_boost:
+  - field: title
+    boost: 10
 
 # News.feature
 date_formats:


### PR DESCRIPTION
This is one more tweak to support the site-config-builder functionality. It is intended to be fully backwards-compatible. So the old syntax will still work:

```
search_index_boost:
    title: 10
```

But the documented/recommended syntax will be produced by the site builder, and also works:

```
search_index_boost:
    - field: title
      boost: 10
```