### PR TITLE
Allow disabling of news category links

### DIFF
--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,9 +1,14 @@
 ---
 layout: default
 ---
+{% if site.news.category_links == false %}
+  {% assign category_links = false %}
+{% else %}
+  {% assign category_links = true %}
+{% endif %}
 <div id="main-content" class="container newslist">
   <div class="row">
-    <div class="col-md-9 push-md-3">
+    <div class="{% if category_links %}col-md-9 push-md-3{% else %}col-md-12{% endif %}">
       {% if page.title %}
       <h1>{{ page.title | t }}</h1>
       {% endif %}
@@ -20,7 +25,14 @@ layout: default
         <ul class="post-categories">
           {% for category in post.categories %}
           <li class="warning">
-            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category }}">{{ category | t }}</a>
+            {% if category_links %}
+            {% assign category_translated = category | t %}
+            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">
+            {% endif %}
+            {{ category | t }}
+            {% if category_links %}
+            </a>
+            {% endif %}
           </li>
           {% endfor %}
         </ul>
@@ -28,8 +40,10 @@ layout: default
       </article>
       {% endfor %}
     </div>
+    {% if category_links %}
     <div class="col-md-3 pull-md-9">
       {% include components/post-categories.html %}
     </div>
+    {% endif %}
   </div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,9 +5,14 @@ layout: default
   {% include components/post/breadcrumbs.html %}
 </div>
 
+{% if site.news.category_links == false %}
+  {% assign category_links = false %}
+{% else %}
+  {% assign category_links = true %}
+{% endif %}
 <div id="main-content" class="container">
   <div class="row">
-    <div class="col-md-9 push-md-3">
+    <div class="{% if category_links %}col-md-9 push-md-3{% else %}col-md-12{% endif %}">
       <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
         <h1 class="post-title" itemprop="name headline">{{ page.title | t }}</h1>
         <p><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | t_date: "standard" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
@@ -20,16 +25,25 @@ layout: default
         <ul class="post-categories">
           {% for category in page.categories %}
           <li class="warning">
-            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="View all posts in the {{category | t}} category">{{ category | t }}</a>
+            {% if category_links %}
+            {% assign category_translated = category | t %}
+            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">
+            {% endif %}
+            {{ category | t }}
+            {% if category_links %}
+            </a>
+            {% endif %}
           </li>
           {% endfor %}
         </ul>
         {% endif %}
       </article>
     </div>
+    {% if category_links %}
     <div class="col-md-3 pull-md-9">
       {% include components/post-categories.html %}
     </div>
+    {% endif %}
   </div>
 </div>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -468,6 +468,12 @@ menu:
     translation_key: menu.faq
 ```
 
+### news
+
+_Optional_: This setting can be used to control the behavior of the `news` and `post` layouts. The available settings are:
+
+* `category_links`: Whether you would like the `categories` of posts to generate links to dedicated category pages. Default is `true`, but set to `false` to disable category links.
+
 ### non_global_metadata
 
 _Optional_: This setting can be used to control the text of the tab containing non-global metadata. The default text is "National Metadata", but if you are implementing a sub-national platform, you could use "Local Metadata", or similar. Note that using a [translation key](translation.md) is recommended for better multilingual support.


### PR DESCRIPTION
Fixes #911 

This allows category links to be disabled, with this site config:

```
news:
  category_links: false
```