### PR TITLE
Make map unfocusable and remove loading image

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -400,6 +400,11 @@
         plugin.map.setZoom(plugin.options.maxZoom);
         plugin.map.setZoom(zoom);
 
+        // Hide the loading image.
+        $('.map-loading-image').hide();
+        // Make the map unfocusable.
+        $('#map').removeAttr('tabindex');
+
         // The list of handlers to apply to each feature on a GeoJson layer.
         function onEachFeature(feature, layer) {
           if (plugin.featureShouldDisplay(feature)) {

--- a/_includes/components/indicator/map.html
+++ b/_includes/components/indicator/map.html
@@ -1,3 +1,3 @@
 <div id="map" aria-describedby="table-alternative">
-  <img src="{{ site.baseurl }}/assets/img/loading.gif" alt="{{ page.t.indicator.loading_map }}" />
+  <img class="map-loading-image" src="{{ site.baseurl }}/assets/img/loading.gif" alt="{{ page.t.indicator.loading_map }}" />
 </div>


### PR DESCRIPTION
Fixes #923 

This just hides the loading image and makes the map unfocusable. Another PR (#925) handles making the tab pane focusable.