### PR TITLE
Focus on search when tabbing past final menu item

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -60,7 +60,7 @@ var accessibilitySwitcher = function() {
     var gaAttributes = opensdg.autotrack('switch_contrast', 'Accessibility', 'Change contrast setting', contrast);
     var contrastTitle = getContrastToggleTitle(contrast);
     $('.contrast-switcher').append($('<li />').attr({
-      'class': 'nav-link contrast contrast-' + contrast
+      'class': 'contrast contrast-' + contrast
     }).html($('<a />').attr(gaAttributes).attr({
       'href': 'javascript:void(0)',
       'title': contrastTitle,

--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -80,6 +80,15 @@ $(function() {
     }
   });
 
+  // Hack to focus on search when using the keyboard
+  // to tab past the final menu item, in mobile.
+  $('#menu .nav-link').last().focusout(function(e) {
+    if (topLevelMenuToggle.classList.contains("active")) {
+      $('#menuToggle button').click();
+      $('#searchToggle button').focus();
+    }
+  });
+
   $(window).on('resize', function(e) {
     var viewportWidth = window.innerWidth,
         previousWidth = $('body').data('vwidth'),


### PR DESCRIPTION
Fixes #922 

This doesn't adjust the tab order, but hopefully fixes the problem in a different way. This adds javascript that will focus on the mobile search button when tabbing past the final menu item.