### PR TITLE
Use aria-hidden when hiding sidebar

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -43,7 +43,7 @@ var indicatorView = function (model, options) {
           hideSidebar = $(this).data('no-disagg'),
           mobile = window.matchMedia("screen and (max-width: 990px)");
       if (hideSidebar) {
-        $sidebar.addClass('indicator-sidebar-hidden').attr('aria-hidden', 'true');
+        $sidebar.addClass('indicator-sidebar-hidden');
         $main.addClass('indicator-main-full');
         // On mobile, this can be confusing, so we need to scroll to the tabs.
         if (mobile.matches) {
@@ -53,7 +53,7 @@ var indicatorView = function (model, options) {
         }
       }
       else {
-        $sidebar.removeClass('indicator-sidebar-hidden').removeAttr('aria-hidden');
+        $sidebar.removeClass('indicator-sidebar-hidden');
         $main.removeClass('indicator-main-full');
       }
     });

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -43,7 +43,7 @@ var indicatorView = function (model, options) {
           hideSidebar = $(this).data('no-disagg'),
           mobile = window.matchMedia("screen and (max-width: 990px)");
       if (hideSidebar) {
-        $sidebar.addClass('indicator-sidebar-hidden');
+        $sidebar.addClass('indicator-sidebar-hidden').attr('aria-hidden', 'true');
         $main.addClass('indicator-main-full');
         // On mobile, this can be confusing, so we need to scroll to the tabs.
         if (mobile.matches) {
@@ -53,7 +53,7 @@ var indicatorView = function (model, options) {
         }
       }
       else {
-        $sidebar.removeClass('indicator-sidebar-hidden');
+        $sidebar.removeClass('indicator-sidebar-hidden').removeAttr('aria-hidden');
         $main.removeClass('indicator-main-full');
       }
     });

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -20,18 +20,11 @@
 
   // For shrinking the sidebar.
   .indicator-sidebar-hidden {
-    padding: 0;
-    width: 0;
-    height: 0;
-    overflow: hidden;
+    display: none;
   }
   // For expanding the main section.
   .indicator-main-full {
     width: 100%;
-  }
-  // To make the shrinking/expanding animated.
-  #indicator-sidebar, #indicator-main {
-    transition: width 0.3s ease;
   }
 
   #toolbar {


### PR DESCRIPTION
Fixes #931 

This doesn't use `display: none` because I believe that would mess up our animation. Instead this uses `aria-hidden` which should give the same result.