### PR TITLE
Map color contrast fixes

### DIFF
--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -32,6 +32,12 @@
         display: block;
         cursor: pointer;
       }
+      &.leaflet-control-attribution {
+        background: $backgroundColor;
+        a {
+          color: $link-color;
+        }
+      }
     }
     .disaggregation-select-container {
       background: $backgroundColor;


### PR DESCRIPTION
Fixes the parts of #900 related to color contrast - I think. Actually #900 might need clarification of the specific color contrast issues. So far this only affects the "attribution" section, in the lower-right corner of the map.