### PR TITLE
For tab panel focus, only show an outline

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -107,6 +107,7 @@ input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus,
 input[type="checkbox"]:focus, body.contrast-high input[type="checkbox"]:focus {
   box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
 }
+.tabPanel:focus,
 input[type="text"]:focus,
 body.contrast-high input[type="text"]:focus {
   background-color: $backgroundColor !important;


### PR DESCRIPTION
Fixes the latest comment in #925 