### PR TITLE
Keep swatch colors in Edge/IE + high-contrast mode

### DIFF
--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -96,3 +96,10 @@
   box-shadow: 0 -2px $focusOutlineColor,0 4px $focusColor !important;
   text-decoration: none !important;
 }
+
+@mixin preserveOriginalColors {
+  @media (-ms-high-contrast: active), (forced-colors: active) {
+    -ms-high-contrast-adjust: none;
+    forced-color-adjust: none;
+  }
+}

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -72,7 +72,7 @@
       padding: 0;
       width: 300px;
       .legend-swatches {
-        forced-color-adjust: none;
+        @include preserveOriginalColors;
         height: 10px;
         .legend-swatch {
           display: block;

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -81,6 +81,7 @@
         }
       }
       .legend-values {
+        @include preserveOriginalColors;
         position: absolute;
         bottom: -10px;
         width: 100%;
@@ -104,6 +105,7 @@
           }
         }
         .legend-value {
+          color: $text-color;
           padding: 0 4px;
           background: $backgroundColor;
           position: absolute;

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -72,6 +72,7 @@
       padding: 0;
       width: 300px;
       .legend-swatches {
+        forced-color-adjust: none;
         height: 10px;
         .legend-swatch {
           display: block;


### PR DESCRIPTION
This fixes #955 only in the IE and Edge browsers. In other browsers (like Chrome and Firefox) this will have no effect, but if they ever decide to support the property `forced-color-adjust` property, it will resolve it for them too.