### PR TITLE
Move fieldset/legend to different spot in markup

### DIFF
--- a/_includes/components/indicator/fields-template.html
+++ b/_includes/components/indicator/fields-template.html
@@ -1,22 +1,22 @@
 <script type="text/template" id="item_template">
   <% _.each(fields, function(fieldItem) { %>
-    <fieldset>
-      <legend class="sr-only">{{ page.t.indicator.sub_categories }} - <%=translations.t(fieldItem.field)%></legend>
-      <div class="variable-selector<% if(allowedFields.indexOf(fieldItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=fieldItem.field%>">
-        <button class='accessBtn' tabindex='0' aria-expanded='false'
-          <% if(allowedFields.indexOf(fieldItem.field) == -1) { %>
-          aria-describedby='variable-hint-<%=fieldItem.field.replace(/ /g, '-')%>'
-          <% }%>
-        >
-          <% if(allowedFields.indexOf(fieldItem.field) == -1) { %><h6><% } else { %><h5><% } %>
-            <span aria-hidden="true"><%=translations.t(fieldItem.field)%><i class="fa fa-chevron-down"></i></span>
-            <span class="sr-only">Show sub-categories: <%=translations.t(fieldItem.field)%></span>
-          <% if(allowedFields.indexOf(fieldItem.field) == -1) { %></h6><% } else { %></h5><% } %>
-        </button>
-        <div class="bar">
-          <div class="selected"></div>
-        </div>
-        <div class="variable-options">
+    <div class="variable-selector<% if(allowedFields.indexOf(fieldItem.field) == -1) { %> disallowed child<% }%>" data-field="<%=fieldItem.field%>">
+      <button class='accessBtn' tabindex='0' aria-expanded='false'
+        <% if(allowedFields.indexOf(fieldItem.field) == -1) { %>
+        aria-describedby='variable-hint-<%=fieldItem.field.replace(/ /g, '-')%>'
+        <% }%>
+      >
+        <% if(allowedFields.indexOf(fieldItem.field) == -1) { %><h6><% } else { %><h5><% } %>
+          <span aria-hidden="true"><%=translations.t(fieldItem.field)%><i class="fa fa-chevron-down"></i></span>
+          <span class="sr-only">Show sub-categories: <%=translations.t(fieldItem.field)%></span>
+        <% if(allowedFields.indexOf(fieldItem.field) == -1) { %></h6><% } else { %></h5><% } %>
+      </button>
+      <div class="bar">
+        <div class="selected"></div>
+      </div>
+      <div class="variable-options">
+        <fieldset>
+          <legend class="sr-only">{{ page.t.indicator.sub_categories }} - <%=translations.t(fieldItem.field)%></legend>
           <div>
             <button data-type="select">{{ page.t.indicator.select_all }}</button>
             <button data-type="clear">{{ page.t.indicator.clear_all }}</button>
@@ -26,21 +26,21 @@
               <input type="checkbox" <%=item.checked ? 'checked' : ''%> value="<%=item.value%>" data-field="<%=fieldItem.field%>" /><%=translations.t(item.value)%>
             </label>
           <% }); %>
-        </div>
-
-        <% if(allowedFields.indexOf(fieldItem.field) == -1) { %>
-          <div class="variable-hint" id="variable-hint-<%=fieldItem.field.replace(/ /g, '-')%>">
-            {%- capture var_hint_replacement -%}
-              {% raw %}<%= translations.t(_.findWhere(edges, { To: fieldItem.field }).From) %>{% endraw %}
-            {%- endcapture -%}
-            {{ page.t.indicator.variable_hint | replace_first: '%field', var_hint_replacement }}
-          </div>
-          <div class="no-data-hint" id="no-data-hint-<%=fieldItem.field.replace(/ /g, '-')%>">
-            {{ page.t.indicator.no_data_hint }}
-          </div>
-        <% }%>
-
+        </fieldset>
       </div>
-    </fieldset>
+
+      <% if(allowedFields.indexOf(fieldItem.field) == -1) { %>
+        <div class="variable-hint" id="variable-hint-<%=fieldItem.field.replace(/ /g, '-')%>">
+          {%- capture var_hint_replacement -%}
+            {% raw %}<%= translations.t(_.findWhere(edges, { To: fieldItem.field }).From) %>{% endraw %}
+          {%- endcapture -%}
+          {{ page.t.indicator.variable_hint | replace_first: '%field', var_hint_replacement }}
+        </div>
+        <div class="no-data-hint" id="no-data-hint-<%=fieldItem.field.replace(/ /g, '-')%>">
+          {{ page.t.indicator.no_data_hint }}
+        </div>
+      <% }%>
+
+    </div>
   <% }); %>
 </script>


### PR DESCRIPTION
Fixes #964 

Though this looks like a lot of changes, it is really just moving a couple of elements (`fieldset` and `legend`) from one spot to another. Because the indentation changed, a lot of lines appear changed. Moving markup does carry the risk of messing up some CSS styling and/or javascript. I tested locally and it seemed OK.