### PR TITLE
1.2.0 release prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ make-cache
 venv
 /site
 .vscode
+version-*

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,8 @@ test.docs: build.docs
 	gem install html-proofer
 	htmlproofer site --disable_external
 
+test.only:
+	cd site-starter && bundle exec htmlproofer --file-ignore '/documentation/' --disable-external ./_site
+	cd tests && npx cucumber-js
+
 test: test.html test.features test.accessibility test.docs

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -300,17 +300,20 @@ var indicatorView = function (model, options) {
   };
 
   this.initialiseSerieses = function(args) {
-    var template = _.template($('#series_template').html()),
-        serieses = args.serieses || [],
-        selectedSeries = args.selectedSeries || null;
+    var templateElement = $('#series_template');
+    if (templateElement.length > 0) {
+      var template = _.template(templateElement.html()),
+          serieses = args.serieses || [],
+          selectedSeries = args.selectedSeries || null;
 
-    $('#serieses').html(template({
-      serieses: serieses,
-      selectedSeries: selectedSeries
-    }));
+      $('#serieses').html(template({
+        serieses: serieses,
+        selectedSeries: selectedSeries
+      }));
 
-    if(!serieses.length) {
-      $(this._rootElement).addClass('no-serieses');
+      if(!serieses.length) {
+        $(this._rootElement).addClass('no-serieses');
+      }
     }
   };
 

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -79,9 +79,11 @@ var indicatorView = function (model, options) {
     view_obj.initialiseUnits(args);
   });
 
-  this._model.onSeriesesComplete.attach(function(sender, args) {
-    view_obj.initialiseSerieses(args);
-  });
+  if (this._model.onSeriesesComplete) {
+    this._model.onSeriesesComplete.attach(function(sender, args) {
+      view_obj.initialiseSerieses(args);
+    });
+  }
 
   this._model.onFieldsCleared.attach(function(sender, args) {
     $(view_obj._rootElement).find(':checkbox').prop('checked', false);

--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -145,7 +145,7 @@ function fieldItemStatesForView(fieldItemStates, fieldsByUnit, selectedUnit, dat
     states = fieldItemStatesForUnit(fieldItemStates, fieldsByUnit, selectedUnit);
   }
 
-  if (selectedFields.length > 0) {
+  if (selectedFields && selectedFields.length > 0) {
     states.forEach(function(fieldItem) {
       var selectedField = selectedFields.find(function(selectedItem) {
         return selectedItem.field === fieldItem.field;
@@ -171,16 +171,18 @@ function fieldItemStatesForView(fieldItemStates, fieldsByUnit, selectedUnit, dat
 function sortFieldsForView(fieldItemStates, edges) {
   var grandparents = [],
       parents = [];
-  edges.forEach(function(edge) {
-    if (!parents.includes(edge.From)) {
-      parents.push(edge.From);
-    }
-  });
-  edges.forEach(function(edge) {
-    if (parents.includes(edge.To)) {
-      grandparents.push(edge.From);
-    }
-  });
+  if (edges) {
+    edges.forEach(function(edge) {
+      if (!parents.includes(edge.From)) {
+        parents.push(edge.From);
+      }
+    });
+    edges.forEach(function(edge) {
+      if (parents.includes(edge.To)) {
+        grandparents.push(edge.From);
+      }
+    });
+  }
   fieldItemStates.sort(function(a, b) {
     if (grandparents.includes(a.field) && !grandparents.includes(b.field)) {
       return -1;

--- a/_includes/assets/js/model/helpers.js
+++ b/_includes/assets/js/model/helpers.js
@@ -47,6 +47,12 @@
   {% include assets/js/model/tableHelpers.js %}
   {% include assets/js/model/dataHelpers.js %}
 
+  function deprecated(name) {
+    return function() {
+      console.log('The ' + name + ' function has been removed. Please update any overridden files.');
+    }
+  }
+
   return {
     UNIT_COLUMN: UNIT_COLUMN,
     SERIES_COLUMN: SERIES_COLUMN,
@@ -86,5 +92,7 @@
     getCombinationData: getCombinationData,
     getDatasets: getDatasets,
     tableDataFromDatasets: tableDataFromDatasets,
+    // Backwards compatibility.
+    footerFields: deprecated('helpers.footerFields'),
   }
 })();

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -103,3 +103,15 @@
     forced-color-adjust: none;
   }
 }
+
+@mixin screenreaderOnly {
+  // Better to use the sr-only class, but this is
+  // here as a last resort.
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/_sass/components/_language_toggle.scss
+++ b/_sass/components/_language_toggle.scss
@@ -235,3 +235,21 @@ footer #footerLinks .language-toggle-menu-footer {
     }
   }
 }
+
+// @deprecated start
+.language-toggle-menu-header > .language-toggle.language-options {
+  display: none;
+  position: absolute;
+  z-index: 999;
+  left: 12px;
+  color: #222;
+  background: #fff;
+  border-radius: 3px;
+  box-shadow: 0px 0px 2px 0px #a6a6a6;
+  padding: .2em 1em .2em .2em;
+  text-shadow: #f5f5f5 0 1px 0;
+  li {
+    padding: 5px;
+  }
+}
+// @deprecated end

--- a/_sass/layouts/_goal-by-target.scss
+++ b/_sass/layouts/_goal-by-target.scss
@@ -1,3 +1,4 @@
+// @deprecated start
 .layout-goal-by-target {
   .indicator-cards.target {
     @media screen and (max-width: 768px) {
@@ -5,3 +6,4 @@
     }
   }
 }
+// @deprecated end

--- a/_sass/layouts/_goal-by-target.scss
+++ b/_sass/layouts/_goal-by-target.scss
@@ -1,0 +1,7 @@
+.layout-goal-by-target {
+  .indicator-cards.target {
+    @media screen and (max-width: 768px) {
+      padding-top: 20px;
+    }
+  }
+}

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -188,6 +188,10 @@ body.contrast-high {
       font-size: 1.40em;
       line-height: 15px;
     }
+    // Backwards compat.
+    form > label > span {
+      @include screenreaderOnly;
+    }
   }
 }
 

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -188,10 +188,11 @@ body.contrast-high {
       font-size: 1.40em;
       line-height: 15px;
     }
-    // Backwards compat.
+    // @deprecated start
     form > label > span {
       @include screenreaderOnly;
     }
+    // @deprecated end
   }
 }
 

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -31,6 +31,7 @@
 @import "layouts/reporting_status";
 @import "layouts/search";
 @import "layouts/homeintro";
+@import "layouts/goal-by-target";
 @import "layouts/goal-by-target-vertical";
 @import "layouts/frontpage_alt";
 @import "layouts/goals";

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,9 +84,12 @@
 * Alt tag for loading image #758
 * Javascript fixes for IE support #757
 
-The release involved significant changes, in part to resolve serious accessibility issues. Extensive testing has helped us avoid breaking changes, except for one unavoidable change:
+The release involved significant changes, in part to resolve serious accessibility issues. Extensive testing has helped us avoid breaking changes, except in regards to chart/table footer fields:
 
-* _includes/components/charts/chart.html - If you have overridden this file, your chart/table "footer fields" may not display properly.
+* _includes/components/charts/chart.html
+* _includes/components/indicator/table.html
+
+If you have overridden either to these two files, your chart/table "footer fields" may not display properly.
 
 Most files in the _includes and _layouts folders underwent some change in this release. If you are overriding any of those files, your implementation might not benefit from the various enhancements/fixes in the release.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -89,9 +89,11 @@ The release involved significant changes, in part to resolve serious accessibili
 * _includes/components/charts/chart.html
 * _includes/components/indicator/table.html
 
-If you have overridden either to these two files, your chart/table "footer fields" may not display properly.
+If you have overridden either to these two files, your chart/table "footer fields" may not display properly. More information on the necessary updates is on the [1.2.0 upgrade instructions](upgrades/upgrading-1-2-0.md).
 
 Most files in the _includes and _layouts folders underwent some change in this release. If you are overriding any of those files, your implementation might not benefit from the various enhancements/fixes in the release.
+
+For details on upgrading from 1.0.0 or higher to 1.2.0, see the [1.2.0 upgrade instructions](upgrades/upgrading-1-2-0.md).
 
 ## 1.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,7 +34,7 @@
 * Translate page titles and content #891
 * Use aside instead of div for news sidebar #890
 * Search button outside of label #886
-* Revamp of chart/table/map footers #885, #948 (breaking - chart.html)
+* Revamp of chart/table/map footers #885, #948
 * Use text color for disclaimer text #883
 * Add aria-label to contrast toggle #882
 * Accessibility fixes for sorting tables #880
@@ -71,7 +71,6 @@
 * Configurable reporting status title and description #778
 * Vertical goal-by-target layout #776, #838
 * More usage of variables with status colors and borders #773
-* Alternate frontpage layout #772
 * Syntax fix - map tooltips #768
 * Support translations in the reporting status extra fields #767
 * Fix styling of mobile menu items #765

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,95 @@
 <h1>Change Log</h1>
 
+## 1.2.0
+
+* Different canvas fallback for mobile/desktop. #968
+* Remove aria-label from table headers #967
+* Move fieldset/legend to different spot in markup #966
+* Keep swatch colors in Edge/IE + high-contrast mode #957
+* Remove rowspan and colspan from table headers #954
+* Fix the mobile navigation tab order #952
+* Better support for third-party and remote javascript files. #951
+* Map color contrast fixes #946
+* Map search accessibility #945
+* Map fullscreen accessibility #944, #958
+* Map slider accessibility #941
+* More descriptive disaggregation button label/hierarchy for screenreaders #935
+* Use aria-hidden when hiding sidebar #934
+* aria-describedby for no-data-hint #933
+* Remove role from datatable #927
+* Make map unfocusable and remove loading image #926
+* Consider hierarchy when sorting fields #920
+* Add background colour to goal icons #919
+* Allow disabling of news category links #917
+* Remove legend clickability #914
+* Support for Chart.js annotations #912
+* Backwards-compatible array-style for search_index_boost #907
+* Add site title to page title #906
+* Full indicator name in the page title and h1 #905
+* Accessible charts #904, #963
+* Use text-colour for table caption #903
+* Alert role and screenreader-only warning label for too-many-datasets #902
+* Search results link fixes #901
+* Chart/table accessibility #894
+* Translate page titles and content #891
+* Use aside instead of div for news sidebar #890
+* Search button outside of label #886
+* Revamp of chart/table/map footers #885, #948 (breaking - chart.html)
+* Use text color for disclaimer text #883
+* Add aria-label to contrast toggle #882
+* Accessibility fixes for sorting tables #880
+* Accessibility improvements for chart legends #878
+* Remove alert role from disclaimer #877
+* Default mouse cursor on disabled elements #876
+* Announce changes to the chart/table #875, #916
+* Use buttons for the mobile menu/search drop-downs #874
+* aria-described-by for indicator disaggregation variable hint #873
+* H4 instead of H3 for chart title #872
+* More efficient unique function for better support of large datasets #871
+* Use darker text color and default to white text in high-contrast #865
+* More obvious focus colors #864
+* Fieldsets around radios and checkboxes #863
+* Better keyboard accessibility for tabbed content #862, #884, #925, #953, #965
+* Add an anchor for any back-to-top links #836
+* H1 in news and post layouts #835
+* Page titles #834
+* Allow translated href in footer menu links #825
+* More space beneath reporting status goal items #824
+* Only link indicator name in goal-by-target #823
+* Button revamp #822
+* New breadcrumb configuration and separator #821
+* Add vertical hover lines to line charts #816
+* Refactor metadata tabs to support array structure #812
+* Support markdown in the description property of some config settings #811
+* Custom source-file downloads #809
+* Pad the search bar to avoid hiding terms #807
+* Skip map layers that do not have data #806
+* Line height fix for Firefox search icon #797
+* Simplify goals layout and allow configurable intro #793
+* Display a no-data message when chart has no data #786
+* Optional setting for language toggle as links #784
+* Configurable reporting status title and description #778
+* Vertical goal-by-target layout #776, #838
+* More usage of variables with status colors and borders #773
+* Alternate frontpage layout #772
+* Syntax fix - map tooltips #768
+* Support translations in the reporting status extra fields #767
+* Fix styling of mobile menu items #765
+* Hide map selection legend on mobile #764
+* Update tooltips of active selections when the year changes #763
+* Translate mobile search buttons #762
+* Correct selector to avoid infinite loop #761
+* Sort the disaggregations that display in table headers #760
+* Visited color for download buttons #759
+* Alt tag for loading image #758
+* Javascript fixes for IE support #757
+
+The release involved significant changes, in part to resolve serious accessibility issues. Extensive testing has helped us avoid breaking changes, except for one unavoidable change:
+
+* _includes/components/charts/chart.html - If you have overridden this file, your chart/table "footer fields" may not display properly.
+
+Most files in the _includes and _layouts folders underwent some change in this release. If you are overriding any of those files, your implementation might not benefit from the various enhancements/fixes in the release.
+
 ## 1.1.0
 
 * Embed using either Pym parent or iframe (#751)

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -2,6 +2,10 @@
 
 For a more technical list of platform changes, see [the change log](changelog.md).
 
+## 1.2.0
+
+TBD
+
 ## 1.1.0
 
 29 July 2020

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -4,7 +4,25 @@ For a more technical list of platform changes, see [the change log](changelog.md
 
 ## 1.2.0
 
-TBD
+1 December 2020
+
+This release includes the following:
+
+* Improved keyboard navigation across the platform, such as in charts, tabs, and maps
+* Improved screenreader support across the platform, such as with disaggregation controls on indicator pages
+* Improved accessibility through unique page titles and more semantic HTML markup
+* Design and user-experience improvements for buttons, links, breadcrumbs, and "focus" treatment
+* Darker text color for better contrast
+* Better support for Windows high-contrast mode
+* User-experience improvements on mobile
+* Simplified chart legends without clickability
+* Support for annotations/labels on charts (such as adding a line for "2030 target")
+* Support for translation of contents and titles of custom pages
+* Ability for footer menu to use different links per language
+* Vertical "hover lines" on charts
+* A "no data" message for when a chart/table has no data
+* New layout available for goal pages: goal_by_target_vertical
+* Faster performance on large datasets
 
 ## 1.1.0
 

--- a/docs/upgrades/upgrading-1-2-0.md
+++ b/docs/upgrades/upgrading-1-2-0.md
@@ -1,0 +1,49 @@
+<h1>Upgrading to 1.2.0</h1>
+
+This document is intended for developers, to help with the process of upgrading to version 1.2.0 of Open SDG, from 1.0.0 or higher.
+
+## Breaking changes
+
+Although our goal is to avoid introducing breaking changes in minor releases, there were two unavoidable changes made for improved accessibility, which may necessitate some adjustments. In the rare case that your implementation is overriding either of the following files, you may need to adjust your overrides as you upgrade to 1.2.0:
+
+* _includes/components/charts/chart.html
+* _includes/components/indicator/table.html
+
+If you are in this situation, and you choose **not** to adjust your overrides of these files, then the "footer fields" (Unit of measurement, Footnote, etc.) may not appear beneath your indicator charts and tables. In order to restore these footer fields, please add the following line to your overridden versions:
+
+`{% include components/indicator/data-footer.html %}`
+
+That code will render the footer fields. The placement of the code is left to your discretion.
+
+## Upgrade data repository to sdg-build 1.2.0
+
+In your data repository, update your `requirements.txt` file to:
+
+```
+git+git://github.com/open-sdg/sdg-build@1.2.0-beta1
+```
+
+## Update version of Open SDG to 1.2.0
+
+In your site repository's `_config.yml` file, update the version of Open SDG in `remote_theme`, like so:
+
+```
+remote_theme: open-sdg/open-sdg@1.2.0-beta1
+```
+
+## Update version of jekyll-open-sdg-plugins to 1.2.0
+
+In your site repository's `Gemfile`, update the version of jekyll-open-sdg-plugins like so:
+
+```
+gem "jekyll-open-sdg-plugins", "1.2.0.pre.beta4"
+```
+
+## Recommended updates to the `_config.yml` file
+
+In your site repository's `_config.yml` file, the following optional changes are recommended, because they enable important accessibility improvements:
+
+```
+accessible_tabs: true
+accessible_charts: true
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,3 +72,4 @@ pages:
     - Upgrades:
         - Upgrade process: upgrades/upgrade-process.md
         - Upgrading to 1.0.0: upgrades/upgrading-1-0-0.md
+        - Upgrading to 1.2.0: upgrades/upgrading-1-2-0.md

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -8,7 +8,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "hunger"
     And I send key "Enter" in "the search box" element
-    And I wait 7 seconds
+    And I wait 10 seconds
     Then I should see "1 results found"
     And I follow "End hunger, achieve food security and improved nutrition and promote sustainable agriculture"
     Then I should be on "/2/"
@@ -17,7 +17,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "mortality"
     And I send key "Enter" in "the search box" element
-    And I wait 7 seconds
+    And I wait 10 seconds
     Then I should see "1 results found"
     And I follow "Maternal mortality ratio"
     Then I should be on "/3-1-1/"
@@ -26,7 +26,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "platypus"
     And I send key "Enter" in "the search box" element
-    And I wait 7 seconds
+    And I wait 10 seconds
     Then I should see "1 results found"
     And I follow "My about page title"
     Then I should be on "/about/"
@@ -35,14 +35,14 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "FAO"
     And I send key "Enter" in "the search box" element
-    And I wait 7 seconds
+    And I wait 10 seconds
     Then I should see "4 results found"
 
   Scenario: The "did you mean" feature suggests alternative searches
     Given I am on the homepage
     And I fill in "the search box" with "popular"
     And I send key "Enter" in "the search box" element
-    And I wait 7 seconds
+    And I wait 10 seconds
     Then I should see "No results"
     And I should see "did you mean"
     And I follow "popul"

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -8,7 +8,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "hunger"
     And I send key "Enter" in "the search box" element
-    And I wait 10 seconds
+    And I wait 5 seconds
     Then I should see "1 results found"
     And I follow "End hunger, achieve food security and improved nutrition and promote sustainable agriculture"
     Then I should be on "/2/"
@@ -17,7 +17,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "mortality"
     And I send key "Enter" in "the search box" element
-    And I wait 10 seconds
+    And I wait 5 seconds
     Then I should see "1 results found"
     And I follow "Maternal mortality ratio"
     Then I should be on "/3-1-1/"
@@ -26,7 +26,7 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "platypus"
     And I send key "Enter" in "the search box" element
-    And I wait 10 seconds
+    And I wait 5 seconds
     Then I should see "1 results found"
     And I follow "My about page title"
     Then I should be on "/about/"
@@ -35,16 +35,16 @@ Feature: Search
     Given I am on the homepage
     And I fill in "the search box" with "FAO"
     And I send key "Enter" in "the search box" element
-    And I wait 10 seconds
+    And I wait 5 seconds
     Then I should see "4 results found"
 
   Scenario: The "did you mean" feature suggests alternative searches
     Given I am on the homepage
     And I fill in "the search box" with "popular"
     And I send key "Enter" in "the search box" element
-    And I wait 10 seconds
+    And I wait 5 seconds
     Then I should see "No results"
     And I should see "did you mean"
     And I follow "popul"
-    And I wait 7 seconds
+    And I wait 5 seconds
     Then I should see "results found"

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "cucumber": "latest",
         "cucumber-mink": "git://github.com/brockfanning/cucumber-mink.git#circleci-compatibility",
-        "pa11y-ci": "2.3.0"
+        "pa11y-ci": "2.3.0",
+        "simple-git": "^2.21.0"
     }
 }

--- a/tests/release/back-compat.js
+++ b/tests/release/back-compat.js
@@ -25,6 +25,10 @@ async function main() {
 
 async function testFile(filePath) {
     await git.checkout(filePath)
+    if (!fs.existsSync(path.join(majorFolder, filePath))) {
+        console.log('The file did not exist before.')
+        return
+    }
     fs.copyFileSync(path.join(majorFolder, filePath), filePath)
     const diff = await git.diff(filePath)
     if (diff === '') {

--- a/tests/release/back-compat.js
+++ b/tests/release/back-compat.js
@@ -29,6 +29,7 @@ async function testFile(filePath) {
     const diff = await git.diff(filePath)
     if (diff === '') {
         await git.checkout(filePath)
+        console.log('That file has not changed.')
     }
     else {
         await runTests(filePath)

--- a/tests/release/back-compat.js
+++ b/tests/release/back-compat.js
@@ -1,0 +1,58 @@
+const fs = require('fs')
+const path = require('path')
+const { exec, spawn } = require('child_process')
+const git = require('simple-git')()
+
+const majorFolder = 'version-1.0.0'
+
+main()
+
+async function main() {
+    const args = process.argv
+    if (args.length < 3) {
+        console.error('Indicate a file to test. Eg: node tests/release/back-compat.js _layouts/goal.html')
+    }
+    else {
+        clean()
+        await git.clone('https://github.com/open-sdg/open-sdg.git', majorFolder, {
+            '--depth': 1,
+            '--branch': '1.0.0',
+        })
+        await testFile(args[2])
+    }
+}
+
+function clean() {
+    fs.rmdirSync(majorFolder, { recursive: true });
+}
+
+async function testFile(filePath) {
+    await git.checkout(filePath)
+    fs.copyFileSync(path.join(majorFolder, filePath), filePath)
+    const diff = await git.diff(filePath)
+    if (diff === '') {
+        await git.checkout(filePath)
+    }
+    else {
+        await runTests(filePath)
+    }
+}
+
+async function runTests(filePath) {
+    const serve = spawn('make', ['serve.detached'])
+    serve.on('exit', function (code) {
+        console.log('Testing changes to ' + filePath + '...')
+        exec('make test.only', (err, stdout, stderr) => {
+            if (err) {
+                console.log(stdout)
+                console.log(err)
+                console.error('Failed while testing: ' + filePath + '. See above for errors.')
+            }
+            else {
+                git.checkout(filePath)
+                console.log('...no failures. Press CTRL-c to stop test.')
+
+            }
+        })
+    });
+}

--- a/tests/release/back-compat.js
+++ b/tests/release/back-compat.js
@@ -13,17 +13,14 @@ async function main() {
         console.error('Indicate a file to test. Eg: node tests/release/back-compat.js _layouts/goal.html')
     }
     else {
-        clean()
-        await git.clone('https://github.com/open-sdg/open-sdg.git', majorFolder, {
-            '--depth': 1,
-            '--branch': '1.0.0',
-        })
+        if (!fs.existsSync(majorFolder)) {
+            await git.clone('https://github.com/open-sdg/open-sdg.git', majorFolder, {
+                '--depth': 1,
+                '--branch': '1.0.0',
+            })
+        }
         await testFile(args[2])
     }
-}
-
-function clean() {
-    fs.rmdirSync(majorFolder, { recursive: true });
 }
 
 async function testFile(filePath) {
@@ -46,7 +43,7 @@ async function runTests(filePath) {
             if (err) {
                 console.log(stdout)
                 console.log(err)
-                console.error('Failed while testing: ' + filePath + '. See above for errors.')
+                console.error('Failed while testing: ' + filePath + '. See above for errors. Press CTRL-c to stop test.')
             }
             else {
                 git.checkout(filePath)


### PR DESCRIPTION
EDIT: Since I'm adding fixes and changelog updates to this PR, this can be a general 1.2.0 preparation PR.

This is a helper script to test the behavior of the codebase when a single file is reverted to the 1.0.0 version. It's intended to reveal potential breaking changes in the case that an implementation has overridden that file. Using this will be a very manual process, because many times the tests will fail for some reason that does not mean there is a breaking change. The usage would be something like this:

```
node tests/release/back-compat.js _layouts/goal.html
```

The above would look for breaking changes in the goal.html layout. We would need to run this script for every single file that has changed, so it will still be a time-consuming process, just a bit easier.