### PR TITLE
Tab focus design fixes

### DIFF
--- a/_includes/components/indicator/data-tabs.html
+++ b/_includes/components/indicator/data-tabs.html
@@ -1,7 +1,7 @@
 <div style="display: none;">
   <span id="table-alternative">{{ page.t.indicator.data_tabular_alternative }}</span>
 </div>
-<ul class="nav nav-tabs data-view" role="tablist">
+<ul class="nav nav-tabs non-stacking-tabs data-view" role="tablist">
   <li role="presentation" class="nav-item active">
     <a class="nav-link" data-toggle="tab" id="tab-chartview" href="#chartview" aria-controls="chartview" role="tab" {% include autotrack.html preset="tab_data_chart" category="Tab change" action="Change data view" label="Change to Chart tab" %} aria-describedby="table-alternative">{{ page.t.indicator.chart }}</a>
   </li>

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -107,6 +107,7 @@ input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus,
 input[type="checkbox"]:focus, body.contrast-high input[type="checkbox"]:focus {
   box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
 }
+.nav-tabs .nav-item .nav-link:focus,
 .tabPanel:focus,
 input[type="text"]:focus,
 body.contrast-high input[type="text"]:focus {

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -107,16 +107,10 @@ input[type="radio"]:focus, body.contrast-high input[type="radio"]:focus,
 input[type="checkbox"]:focus, body.contrast-high input[type="checkbox"]:focus {
   box-shadow: 0px 0px 0px 4px $focusOutlineColor !important;
 }
-.nav-tabs .nav-item .nav-link:focus,
 .tabPanel:focus,
 input[type="text"]:focus,
 body.contrast-high input[type="text"]:focus {
   background-color: $backgroundColor !important;
   box-shadow: none !important;
   outline: 3px solid $focusOutlineColor !important;
-}
-body.contrast-high {
-  .nav-tabs .nav-item .nav-link:focus {
-    background-color: $color-highlight-highContrast !important;
-  }
 }

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -115,3 +115,8 @@ body.contrast-high input[type="text"]:focus {
   box-shadow: none !important;
   outline: 3px solid $focusOutlineColor !important;
 }
+body.contrast-high {
+  .nav-tabs .nav-item .nav-link:focus {
+    background-color: $color-highlight-highContrast !important;
+  }
+}

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -57,18 +57,22 @@ body.contrast-high {
 }
 
 @media only screen and (max-width: 768px) {
-  #main-content .nav-tabs .nav-item {
-    width: 100%;
-    a {
-      margin-right: 0;
-    }
-    &.active {
-      margin-bottom: 1px;
-      border-bottom: 1px solid black;
-    }
-    &:not(.active) {
-      border-bottom: 1px solid black;
-      margin-bottom: 0;
+  #main-content .nav-tabs {
+    &:not(.non-stacking-tabs) {
+      .nav-item {
+        width: 100%;
+        a {
+          margin-right: 0;
+        }
+        &.active {
+          margin-bottom: 1px;
+          border-bottom: 1px solid black;
+        }
+        &:not(.active) {
+          border-bottom: 1px solid black;
+          margin-bottom: 0;
+        }
+      }
     }
   }
 }

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -5,6 +5,7 @@
       padding: 10px 15px;
       margin-right: 2px;
       background-color: $tabs-backgroundColor-inactive;
+      border-radius: 4px 4px 0 0;
       a {
         display: inline-block;
         padding: 0;
@@ -17,7 +18,6 @@
         background-color: $tabs-backgroundColor-active;
         border: 1px solid $tabs-borderColor;
         border-bottom: 0;
-        border-radius: 4px 4px 0 0;
         a {
           border: none;
           text-decoration: none;

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -14,6 +14,7 @@
         text-decoration: underline;
         color: $color-dark;
       }
+      border: 1px solid transparent;
       &.active {
         background-color: $tabs-backgroundColor-active;
         border: 1px solid $tabs-borderColor;

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -23,6 +23,10 @@
           text-decoration: none;
         }
       }
+      &:not(.active) {
+        border: 1px solid $tabs-backgroundColor-inactive;
+        padding-bottom: 8px;
+      }
     }
   }
   .tab-content {

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -14,7 +14,6 @@
         text-decoration: underline;
         color: $color-dark;
       }
-      border: 1px solid transparent;
       &.active {
         background-color: $tabs-backgroundColor-active;
         border: 1px solid $tabs-borderColor;

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -1,12 +1,53 @@
+#main-content {
+  .nav-tabs {
+    border-bottom: 1px solid $tabs-borderColor;
+    .nav-item {
+      padding: 10px 15px;
+      margin-right: 2px;
+      background-color: $tabs-backgroundColor-inactive;
+      a {
+        display: inline-block;
+        padding: 0;
+        border: none;
+        margin-right: 0;
+        text-decoration: underline;
+        color: $color-dark;
+      }
+      &.active {
+        background-color: $tabs-backgroundColor-active;
+        border: 1px solid $tabs-borderColor;
+        border-bottom: 0;
+        border-radius: 4px 4px 0 0;
+        a {
+          border: none;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+  .tab-content {
+    border: 1px solid $tabs-borderColor;
+    padding: 15px;
+    border-top:  0;
+
+    .tab-pane {
+      padding-top: 1.5rem;
+    }
+  }
+}
+
 body.contrast-high {
   .nav-tabs {
     border-color: $color-highlight-highContrast;
   }
 
-  #main-content .nav-tabs .nav-item.active a {
+  #main-content .nav-tabs .nav-item.active {
     background: $color-highlight-highContrast;
-    color: $color-dark-highContrast;
-    border-color: $color-highlight-highContrast; }
+    border-color: $color-highlight-highContrast;
+    a {
+      color: $color-dark-highContrast;
+    }
+  }
 
   a.nav-link:focus {
     background: $color-light-highContrast;

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -37,23 +37,29 @@
 }
 
 body.contrast-high {
-  .nav-tabs {
-    border-color: $color-highlight-highContrast;
-  }
-
-  #main-content .nav-tabs .nav-item.active {
-    background: $color-highlight-highContrast;
-    border-color: $color-highlight-highContrast;
-    a {
-      color: $color-dark-highContrast;
+  #main-content {
+    .nav-tabs {
+      border-color: $color-highlight-highContrast;
+      .nav-item {
+        a:focus {
+          box-shadow: none !important;
+          background-color: $color-highlight-highContrast !important;
+        }
+        &.active {
+          background: $color-highlight-highContrast;
+          border-color: $color-highlight-highContrast;
+          a {
+            color: $color-dark-highContrast;
+            background: $color-highlight-highContrast;
+            &:focus {
+              background-color: $color-highlight-highContrast !important;
+              box-shadow: 0 -2px $color-highlight-highContrast,0 4px $focusColor !important;
+            }
+          }
+        }
+      }
     }
   }
-
-  a.nav-link:focus {
-    background: $color-light-highContrast;
-    color: $color-dark-highContrast;
-  }
-
 }
 
 @media only screen and (max-width: 768px) {

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -26,6 +26,7 @@
       &:not(.active) {
         border: 1px solid $tabs-backgroundColor-inactive;
         padding-bottom: 8px;
+        cursor: pointer;
       }
     }
   }

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -389,41 +389,8 @@
     display: table;
     clear: both;
   }
-  .nav-tabs {
-    border-bottom: 1px solid $indicator-tabs-borderColor;
-    .nav-item {
-      background: none;
-      border: none;
-      a {
-        border: none;
-        color: $color-dark;
-      }
-      &.active {
-        a {
-          border: 1px solid $indicator-tabs-borderColor;
-          border-bottom: 0;
-        }
-      }
-      &:not(.active){
-        a{
-          background-color: $indicator-tabs-backgroundColor-inactive;
-          &:hover{
-            text-decoration: underline;
-          }
-        }
-      }
-    }
-  }
   .tab-content {
-    border: 1px solid $indicator-tabs-borderColor;
-    padding: 15px;
-    border-top:  0;
-
     .tab-pane {
-      padding-top: 1.5rem;
-      // th {
-      //   width: 35%;
-      // }
       #datatable {
         overflow-x: auto;
       }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -156,6 +156,7 @@ $indicator-datasetWarning-backgroundColor: #FFCC0B !default;
 $indicator-legendSwatch-fillColor: #666 !default;
 $indicator-legendSwatch-backgroundColor-hover: #eee !default;
 
+// @deprecated start
 $indicator-tabs-borderColor: $tabs-borderColor !default;
-$indicator-tabs-backgroundColor-active: $tabs-backgroundColor-active !default;
 $indicator-tabs-backgroundColor-inactive: $tabs-backgroundColor-inactive !default;
+// @deprecated end

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -89,6 +89,10 @@ $breadcrumbs-backgroundColor-highContrast: $color-dark-highContrast !default;
 
 $loader-color: #FF6700 !default;
 
+$tabs-borderColor: #888 !default;
+$tabs-backgroundColor-active: $backgroundColor !default;
+$tabs-backgroundColor-inactive: #eeeeee !default;
+
 // Component-level color variables.
 // [component] - [element] - [color|backgroundColor|etc] - [...modifiers]
 $goal-banner-backgroundColors: $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor $backgroundColor !default;
@@ -152,5 +156,6 @@ $indicator-datasetWarning-backgroundColor: #FFCC0B !default;
 $indicator-legendSwatch-fillColor: #666 !default;
 $indicator-legendSwatch-backgroundColor-hover: #eee !default;
 
-$indicator-tabs-borderColor: #888 !default;
-$indicator-tabs-backgroundColor-inactive: #eeeeee !default;
+$indicator-tabs-borderColor: $tabs-borderColor !default;
+$indicator-tabs-backgroundColor-active: $tabs-backgroundColor-active !default;
+$indicator-tabs-backgroundColor-inactive: $tabs-backgroundColor-inactive !default;


### PR DESCRIPTION
@phillipgardiner Can I get your feedback on this? I can't remember if we've discussed this. My thinking is that, since tab focus is activated constantly by all users (just by using the tabs) that it might be a good idea to have it be a bit more subtle - with a yellow outline instead of a full yellow background (which it is inheriting by virtue of being a link). Here's a before/after for this PR:

Before:

![screenshot-127 0 0 1_4000-2020 12 01-06_39_02](https://user-images.githubusercontent.com/1319083/100735904-fb11da80-339f-11eb-93d3-ef8f5db5261e.png)

After:

![screenshot-127 0 0 1_4000-2020 12 01-06_31_52](https://user-images.githubusercontent.com/1319083/100735632-8ccd1800-339f-11eb-9e0d-8739d1bef67c.png)
