### PR TITLE
Support non-numeric years in maps

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -368,7 +368,7 @@
         plugin.map.addControl(L.Control.yearSlider({
           years: plugin.years,
           yearChangeCallback: function(e) {
-            plugin.currentYear = new Date(e.time).getFullYear();
+            plugin.currentYear = plugin.years[e.target._currentTimeIndex];
             plugin.updateColors();
             plugin.updateTooltips();
             plugin.selectionLegend.update();

--- a/_includes/assets/js/plugins/leaflet.yearSlider.js
+++ b/_includes/assets/js/plugins/leaflet.yearSlider.js
@@ -31,7 +31,14 @@
 
     // Hijack the displayed date format.
     _getDisplayDateFormat: function(date){
-      return date.getFullYear();
+      var time = date.toISOString().slice(0, 10);
+      var match = this.options.years.find(function(y) { return y.time == time; });
+      if (match) {
+        return match.display;
+      }
+      else {
+        return date.getFullYear();
+      }
     },
 
     // Override the _createButton method to prevent the date from being a link.
@@ -106,6 +113,7 @@
 
   // Helper function to compose the full widget.
   L.Control.yearSlider = function(options) {
+    var years = getYears(options.years);
     // Extend the defaults.
     options = L.Util.extend(defaultOptions, options);
     // Hardcode the timeDimension to year intervals.
@@ -113,8 +121,8 @@
       // We pad our years to at least January 2nd, so that timezone issues don't
       // cause any problems. This converts the array of years into a comma-
       // delimited string of YYYY-MM-DD dates.
-      times: options.years.join('-01-02,') + '-01-02',
-      currentTime: new Date(options.years[0] + '-01-02').getTime(),
+      times: years.map(function(y) { return y.time }).join(','),
+      currentTime: new Date(years[0].time).getTime(),
     });
     // Create the player.
     options.player = new L.TimeDimension.Player(options.playerOptions, options.timeDimension);
@@ -122,7 +130,43 @@
     if (typeof options.yearChangeCallback === 'function') {
       options.timeDimension.on('timeload', options.yearChangeCallback);
     };
+    // Pass in our years for later use.
+    options.years = years;
     // Return the control.
     return new L.Control.YearSlider(options);
   };
+
+  function isYear(year) {
+    var parsedInt = parseInt(year, 10);
+    return /^\d+$/.test(year) && parsedInt > 1900 && parsedInt < 3000;
+  }
+
+  function getYears(years) {
+    // Support an array of years or an array of strings starting with years.
+    var day = 2;
+    return years.map(function(year) {
+      var mapped = {
+        display: year,
+        time: year,
+      };
+      // Usually this is a year.
+      if (isYear(year)) {
+        mapped.time = year + '-01-02';
+        // Start over that day variable.
+        day = 2;
+      }
+      // Otherwise we get the year from the beginning of the string.
+      else {
+        for (var delimiter of ['-', '.', ' ', '/']) {
+          var parts = year.split(delimiter);
+          if (parts.length > 1 && isYear(parts[0])) {
+            mapped.time = parts[0] + '-01-0' + day;
+            day += 1;
+            break;
+          }
+        }
+      }
+      return mapped;
+    });
+  }
 }());


### PR DESCRIPTION
Fixes #108 

Currently a "Year" in data can be non-numeric, like "2017-2019" for example. This works fine for charts and tables, but it breaks the maps. This attempts to provide better support for maps. The years must still *start* with a year, but can include anything else. For example this code should allow for the following year values:
* 2017-2018
* 2017.4
* 2017 Q4
* 2017/4

Note: For testing this will involve creating a data branch too - will need to change a data file for an indicator that has a map e.g. 3.a.1 so that values in year column have something other than the year (don't need to change all though - just headline)

[Feature Branch - indicator 3-a-1](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/non-numeric-years/3-a-1/)