### PR TITLE
Allow alteration of DataTable configuration and fix tables for "binary" indicators

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -323,6 +323,12 @@ var indicatorView = function (model, options) {
     });
   };
 
+  this.alterTableConfig = function(config, info) {
+    opensdg.tableConfigAlterations.forEach(function(callback) {
+      callback(config, info);
+    });
+  };
+
   this.updateChartTitle = function(chartTitle) {
     if (typeof chartTitle !== 'undefined') {
       $('.chart-title').text(chartTitle);
@@ -597,7 +603,7 @@ var indicatorView = function (model, options) {
     }
   };
 
-  var initialiseDataTable = function(el) {
+  var initialiseDataTable = function(el, info) {
     var datatables_options = options.datatables_options || {
       paging: false,
       bInfo: false,
@@ -609,6 +615,7 @@ var indicatorView = function (model, options) {
 
     datatables_options.aaSorting = [];
 
+    view_obj.alterTableConfig(datatables_options, info);
     table.DataTable(datatables_options);
     table.removeAttr('role');
     table.find('thead th').removeAttr('rowspan').removeAttr('colspan').removeAttr('aria-label');
@@ -829,8 +836,12 @@ var indicatorView = function (model, options) {
 
       $(el).append(currentTable);
 
-      // initialise data table
-      initialiseDataTable(el);
+      // initialise data table and provide some info for alterations.
+      var alterationInfo = {
+        table: table,
+        indicatorId: indicatorId,
+      };
+      initialiseDataTable(el, alterationInfo);
 
       $(el).removeClass('table-has-no-data');
       $('#selectionTableFooter').show();

--- a/_includes/components/charts/binary.html
+++ b/_includes/components/charts/binary.html
@@ -53,10 +53,14 @@ opensdg.chartConfigAlter(function(config) {
 });
 
 opensdg.tableConfigAlter(function(config, info) {
+  var targetColumns = [];
+  for (var i = 1; i < info.table.headings.length; i++) {
+    targetColumns.push(i);
+  }
   var overrides = {
     columnDefs: [
       {
-        targets: -1,
+        targets: targetColumns,
         createdCell: function(td, cellData, rowData, row, col) {
           $(td).text(opensdg.convertBinaryValue(cellData));
         },

--- a/_includes/components/charts/binary.html
+++ b/_includes/components/charts/binary.html
@@ -4,6 +4,20 @@ The "binary" graphs builds on top of "bar", with a few configuration overrides.
 {% include components/charts/canvas.html %}
 {% include components/charts/graph_annotations.html %}
 <script>
+
+opensdg.convertBinaryValue = function(value) {
+  if (typeof value === 'string') {
+    value = parseInt(value, 10);
+  }
+  if (value === 1) {
+    return 'Yes';
+  }
+  else if (value === -1) {
+    return 'No';
+  }
+  return '';
+}
+
 opensdg.chartConfigAlter(function(config) {
   var overrides = {
     // Force the "bar" type instead of the "binary" type which Chart.js
@@ -15,12 +29,7 @@ opensdg.chartConfigAlter(function(config) {
         callbacks: {
           label: function(tooltipItem, data) {
             var label = data.datasets[tooltipItem.datasetIndex].label || '';
-            if (tooltipItem.yLabel == 1) {
-              label += ': Yes';
-            }
-            else {
-              label += ': No';
-            }
+            label += ': ' + opensdg.convertBinaryValue(tooltipItem.yLabel);
             return label;
           }
         }
@@ -32,15 +41,7 @@ opensdg.chartConfigAlter(function(config) {
             // middle and either go up (for 1) or down (for -1).
             min: -1,
             max: 1,
-            callback: function(value, index, values) {
-                if (value == 1) {
-                  return 'Yes';
-                }
-                if (value == -1) {
-                  return 'No';
-                }
-                return '';
-            }
+            callback: opensdg.convertBinaryValue,
           },
         }]
       },
@@ -50,4 +51,20 @@ opensdg.chartConfigAlter(function(config) {
   // Add these overrides onto the normal config.
   $.extend(true, config, overrides);
 });
+
+opensdg.tableConfigAlter(function(config, info) {
+  var overrides = {
+    columnDefs: [
+      {
+        targets: -1,
+        createdCell: function(td, cellData, rowData, row, col) {
+          $(td).text(opensdg.convertBinaryValue(cellData));
+        },
+      }
+    ]
+  };
+
+  $.extend(true, config, overrides);
+});
+
 </script>

--- a/_includes/javascript-variables.html
+++ b/_includes/javascript-variables.html
@@ -11,6 +11,12 @@ var opensdg = {
     this.chartConfigAlterations.push(callback);
   },
 
+  tableConfigAlterations: [],
+  // A hook which can be used to modify the configuration for Datatables.
+  tableConfigAlter: function(callback) {
+    this.tableConfigAlterations.push(callback);
+  },
+
   // A hook which can be replaced to alter whether/how the values that are
   // displayed on indicator tables/graphs get rounded.
   dataRounding: function(value) {


### PR DESCRIPTION
Fixes #1013 

We already allow alteration of Chart.js configuration through the `opensdg.chartConfigAlter` function. Along the same lines, this allows alteration of the DataTables configuration through `opensdg.tableConfigAlter`. A possible use-case might be changing the display of some data value to a more human-friendly version.

To demonstrate this also fixes issue #1013 by converting "1" into "Yes" and "-1" into "No" in the "binary" graph type.

Note: This requires a data branch - will need to change graph_type to binary and make sure data complies to requirements set out here: https://open-sdg.readthedocs.io/en/latest/charts/#binary