### PR TITLE
Configuration form accessibility fixes

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -754,7 +754,9 @@ var indicatorView = function (model, options) {
 
   this.createIndicatorDownloadButtons = function(indicatorDownloads, indicatorId, el) {
     if (indicatorDownloads) {
-      for (var buttonLabel of Object.keys(indicatorDownloads)) {
+      var buttonLabels = Object.keys(indicatorDownloads);
+      for (var i = 0; i < buttonLabels.length; i++) {
+        var buttonLabel = buttonLabels[i];
         var href = indicatorDownloads[buttonLabel].href;
         var buttonLabelTranslated = translations.t(buttonLabel);
         var gaLabel = buttonLabel + ': ' + indicatorId;

--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -63,7 +63,8 @@
       var colorRangeParts = options.mapOptions.colorRange.split('.'),
           colorRange = window,
           overrideColorRange = true;
-      for (var colorRangePart of colorRangeParts) {
+      for (var i = 0; i < colorRangeParts.length; i++) {
+        var colorRangePart = colorRangeParts[i];
         if (typeof colorRange[colorRangePart] !== 'undefined') {
           colorRange = colorRange[colorRangePart];
         }

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -132,7 +132,9 @@
               }
             }
             if (typeof propertyEditor.editors !== 'undefined') {
-              for (var editorKey of Object.keys(propertyEditor.editors)) {
+              var editorKeys = Object.keys(propertyEditor.editors);
+              for (var i = 0; i < editorKeys.length; i++) {
+                var editorKey = editorKeys[i];
                 propertyEditorAccessibilityFixes(propertyEditor.editors[editorKey]);
               }
             }
@@ -200,7 +202,8 @@
       if (errors.length) {
         var alertText = 'Please correct the errors listed below';
         var fieldNames = []
-        for (var error of errors) {
+        for (i = 0; i < errors.length; i++) {
+          var error = errors[i];
           fieldNames.push(error.path.replace('root.', ''));
         }
         alert(alertText + ' (' + fieldNames.join(', ') + ').');

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -159,6 +159,7 @@
           case 'string':
           case 'integer':
           case 'boolean':
+          case 'number':
             propertyEditor.input.setAttribute('id', propertyEditor.formname);
             propertyEditor.label.setAttribute('for', propertyEditor.formname);
             if (typeof propertyEditor.description !== 'undefined') {

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -81,6 +81,15 @@
       {% endif %}
     {% endif %}
 
+    function normalizeCurrentValue(key, value) {
+      // @deprecated start
+      if (key == 'create_pages' && value.pages) {
+        return value.pages;
+      }
+      // @deprecated end
+      return value;
+    }
+
     // Change the theme to create div instead of H3 elements for headers.
     JSONEditor.defaults.themes.bootstrap3.prototype.getHeader = function(text) {
       var el = document.createElement('div')
@@ -179,7 +188,7 @@
     {%- endif -%}
     {% if current_value %}
       try {
-        var currentValue = {{ current_value | jsonify }};
+        var currentValue = normalizeCurrentValue('{{ config_key }}', {{ current_value | jsonify }});
         var propertyEditor = editor.getEditor('root.{{ config_key }}');
         propertyEditor.setValue(null);
         propertyEditor.setValue(currentValue);

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -215,6 +215,16 @@
         SaveAsFile(yaml, '{{ page.config_filename }}', 'text/plain;charset=utf-8');
       }
     });
+
+    function addNewTabMessage(link) {
+      if (!link.querySelector('.sr-only')) {
+        link.insertAdjacentHTML('beforeend', '<span class="sr-only">(opens in a new tab)</span>');
+      }
+    }
+
+    document.querySelectorAll('a[target="_blank"]').forEach(function(link) {
+      addNewTabMessage(link);
+    });
   </script>
 </div>
 {% include footer.html %}

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -1,6 +1,5 @@
 {% include head.html noindex=true %}
 {% include header.html %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.css" integrity="sha512-lB03MbtC3LxImQ+BKnZIyvVHTQ8SSmQ15AhVh5U/+CCp4wKtZMvgLGXbZIjIBBbnKsmk3/6n2vcF8a9CtVVSfA==" crossorigin="anonymous" />
 <div id="main-content" class="container" role="main">
   <div class="col-md-12"><h1>{{ page.title }}</h1></div>
   <div class="config-widgets col-md-12">
@@ -16,7 +15,6 @@
   <div class="col-md-12" id="editor_holder"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/simplemde/1.11.2/simplemde.min.js" integrity="sha512-ksSfTk6JIdsze75yZ8c+yDVLu09SNefa9IicxEE+HZvWo9kLPY1vrRlmucEMHQReWmEdKqusQWaDMpkTb3M2ug==" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@3.14.0/dist/js-yaml.min.js"></script>
   <script src="http://cdn.jsdelivr.net/g/filesaver.js"></script>
   <script>

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -86,6 +86,29 @@
       if (key == 'create_pages' && value && value.pages) {
         return value.pages;
       }
+      if (key == 'date_formats' && value && !Array.isArray(value)) {
+        var date_formats = [];
+        Object.keys(value).forEach(function(type) {
+          Object.keys(value[type]).forEach(function(language) {
+            date_formats.push({
+              type: type,
+              language: language,
+              format: value[type][language],
+            });
+          })
+        });
+        return date_formats;
+      }
+      if (key == 'languages_public' && value && !Array.isArray(value)) {
+        var languages_public = [];
+        Object.keys(value).forEach(function(language) {
+          languages_public.push({
+            language: language,
+            language_public: value[language],
+          });
+        });
+        return languages_public;
+      }
       // @deprecated end
       return value;
     }

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -81,6 +81,18 @@
       {% endif %}
     {% endif %}
 
+    // Change the theme to create div instead of H3 elements for headers.
+    JSONEditor.defaults.themes.bootstrap3.prototype.getHeader = function(text) {
+      var el = document.createElement('div')
+      if (typeof text === 'string') {
+        el.textContent = text;
+      } else {
+        el.appendChild(text);
+      }
+      el.classList.add('je-header');
+      return el;
+    }
+
     var editor = new JSONEditor(document.getElementById('editor_holder'), {
       theme: 'bootstrap3',
       iconlib: 'fontawesome4',

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -83,7 +83,7 @@
 
     function normalizeCurrentValue(key, value) {
       // @deprecated start
-      if (key == 'create_pages' && value.pages) {
+      if (key == 'create_pages' && value && value.pages) {
         return value.pages;
       }
       // @deprecated end

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -104,6 +104,7 @@
         // Variety of accessibility fixes.
         switch (propertyEditor.schema.type) {
           case 'string':
+          case 'integer':
           case 'boolean':
             propertyEditor.input.setAttribute('id', propertyEditor.formname);
             propertyEditor.label.setAttribute('for', propertyEditor.formname);

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -271,7 +271,7 @@
 
     function addNewTabMessage(link) {
       if (!link.querySelector('.sr-only')) {
-        link.insertAdjacentHTML('beforeend', '<span class="sr-only">(opens in a new tab)</span>');
+        link.insertAdjacentHTML('beforeend', '<span>(opens in a new tab)</span>');
       }
     }
 

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -192,6 +192,11 @@
                 propertyEditorAccessibilityFixes(propertyEditor.editors[editorKey]);
               }
             }
+            if (typeof propertyEditor.rows !== 'undefined') {
+              for (var i = 0; i < propertyEditor.rows.length; i++) {
+                propertyEditorAccessibilityFixes(propertyEditor.rows[i]);
+              }
+            }
             break;
         }
       }
@@ -271,7 +276,7 @@
 
     function addNewTabMessage(link) {
       if (!link.querySelector('.sr-only')) {
-        link.insertAdjacentHTML('beforeend', '<span>(opens in a new tab)</span>');
+        link.insertAdjacentHTML('beforeend', ' <span>(opens in a new tab)</span>');
       }
     }
 

--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -6,12 +6,11 @@
     <div class="col-md-6" id="search_holder">
       <label for="config-search">Filter settings</label>
       <input id="config-search" />
+      <input id="config-search-button" type="button" value="Filter">
     </div>
     <div class="col-md-6" id="button_holder"><button class="btn btn-primary btn-download" id="export">Download configuration</button></div>
   </div>
-  <div class="col-md-12" id="no_results" style="display:none" role="status">
-    There are no settings that match those keywords.
-  </div>
+  <div class="col-md-12" id="results-status" role="status"></div>
   <div class="col-md-12" id="editor_holder"></div>
 
   <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
@@ -21,9 +20,18 @@
 
     // Dynamic filtering functionality.
     var configSearch = document.getElementById('config-search');
+    var configSearchButton = document.getElementById('config-search-button');
+    var resultsStatus = document.getElementById('results-status');
     var itemSelector = 'div[data-schemapath="root"] > .well > div > div > .row';
+    configSearchButton.addEventListener('click', performSearch);
     configSearch.addEventListener('keyup', function(e) {
-      var keywords = this.value.toLowerCase();
+      if (e.key === "Enter") {
+        performSearch();
+      }
+    });
+    function performSearch() {
+      var keywords = configSearch.value.toLowerCase();
+      var numResults = 0;
       if (keywords.length > 2) {
         var noMatches = true;
         $(itemSelector).each(function(item) {
@@ -31,23 +39,24 @@
           if (title.includes(keywords)) {
             noMatches = false;
             $(this).show();
+            numResults += 1;
           }
           else {
             $(this).hide();
           }
         });
         if (noMatches) {
-          $('#no_results').show();
+          $(resultsStatus).text('There are no settings that match those keywords.');
         }
         else {
-          $('#no_results').hide();
+          var settingsText = (numResults > 1) ? 'settings' : 'setting';
+          $(resultsStatus).text(numResults + ' matching ' + settingsText + ' found.');
         }
       }
       else {
-        $(itemSelector).show();
-        $('#no_results').hide();
+        $(resultsStatus).text('');
       }
-    });
+    };
 
     {% if page.config_type == 'site' %}
       {% assign json_schema = site.data.schema-site-config %}

--- a/_sass/layouts/_config_bulder.scss
+++ b/_sass/layouts/_config_bulder.scss
@@ -30,7 +30,7 @@
         margin-top: 15px;
         display: inline-block;
     }
-    div[data-schemapath="root"] > h3 {
+    div[data-schemapath="root"] > .je-header {
         display: none !important;
     }
     .help-block {

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'remove-non-accessible-config-form-features'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: 'master'

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: 'master'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'remove-non-accessible-config-form-features'


### PR DESCRIPTION
This attempts to address the items in #1000. Changes include:

* Remove all "table formatting" (ie, fields in rows) and instead display all fields vertically
* Remove the Markdown editor and show plain text areas instead
* Labels for integer fields (eg "Goal color number")
* Adds a message to links about opening in a new tab (screenreaders only)
* Use a button for the search filter
* Adds screenreader status announcement of search filter results

This also fixes IE support in general, which had been broken by recent changes.

A couple of items from #1000 are not fixed here:
* Item 4 - related to color fields: Since we're only using the standard HTML5 input for color, I would want to get confirmation that we actually need to remove those.
* Items 2 and 9 (I think these are the same right?): This is going to be a more difficult fix, and I thought I would submit this PR with the easier items.