### PR TITLE
Support for goal content

### DIFF
--- a/_includes/components/goal/goal-content.html
+++ b/_includes/components/goal/goal-content.html
@@ -1,0 +1,8 @@
+{% assign goal_page_content_raw = include.content | strip %}
+{% if goal_page_content_raw != '' %}
+<div class="row" id="page-content">
+  <div class="col-xs-12">
+    {{ goal_page_content_raw | t | markdownify }}
+  </div>
+</div>
+{% endif %}

--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -22,7 +22,7 @@
 
 <div id="main-content" class="container" role="main">
 
-  {{ content }}
+  {% include components/goal/goal-content.html content=content %}
 
   <div class="container">
     <h2>{{ page.t.general.targets_and_indicators }}</h2>

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -22,7 +22,7 @@
 
 <div id="main-content" class="container goal-indicators goal-{{ page.goal.number }} goal-by-target" role="main">
 
-  {{ content }}
+  {% include components/goal/goal-content.html content=content %}
 
   <div class="visible-md-block visible-lg-block">
     <div class="col-md-6">

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -22,7 +22,7 @@
 
 <div id="main-content" class="container goal-indicators goal-{{ page.goal.number }}" role="main">
 
-  {{ content }}
+  {% include components/goal/goal-content.html content=content %}
 
   {% assign goal_indicators = page.indicators | where: 'goal_number', page.goal.number %}
   {% for indicator in goal_indicators %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,11 +109,16 @@ create_config_forms:
 
 ### create_goals
 
-_Optional_: This setting can be used to automatically create the goal pages. Without this setting, you will need a file for each goal (per language), in a `_goals` folder. This setting should include another (indented) setting indicating the Jekyll layout to use for the goals.
+_Optional_: This setting can be used to automatically create the goal pages. Without this setting, you will need a file for each goal (per language), in a `_goals` folder. This setting should include another (indented) `layout` setting indicating the Jekyll layout to use for the goals.
+
+Additionally, there can be a `goals` item that includes an array of objects, each with a `number` and `content`. Use this to specify specific content for goal pages.
 
 ```nohighlight
 create_goals:
   layout: goal
+  goals:
+    - number: '1'
+      content: My content for goal 1
 ```
 
 ### create_indicators

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,14 +111,15 @@ create_config_forms:
 
 _Optional_: This setting can be used to automatically create the goal pages. Without this setting, you will need a file for each goal (per language), in a `_goals` folder. This setting should include another (indented) `layout` setting indicating the Jekyll layout to use for the goals.
 
-Additionally, there can be a `goals` item that includes an array of objects, each with a `number` and `content`. Use this to specify specific content for goal pages.
+Additionally, there can be a `goals` item that includes an array of objects, each with a `content` field. Use this to specify specific content for goal pages, which can include Markdown, or can be a translation key.
 
 ```nohighlight
 create_goals:
   layout: goal
   goals:
-    - number: '1'
-      content: My content for goal 1
+    - content: My content for goal 1
+    - content: My content for goal 2 with a [link](https://example.com)
+    - content: custom.my_translation_key_for_goal_3
 ```
 
 ### create_indicators

--- a/tests/data/custom-translations/en/custom.yml
+++ b/tests/data/custom-translations/en/custom.yml
@@ -9,3 +9,4 @@ goals_page_description: My goals page description
 frontpage_introduction_banner_title: My frontpage introduction banner title
 about_title: My about page title
 about_content: This is placeholder content for the About page. The English version has the word "platypus".
+goal_1_content: My content for goal 1

--- a/tests/data/custom-translations/es/custom.yml
+++ b/tests/data/custom-translations/es/custom.yml
@@ -9,3 +9,4 @@ goals_page_description: My Spanish goals page description
 frontpage_introduction_banner_title: My Spanish frontpage introduction banner title
 about_title: About
 about_content: This is placeholder content for the About page.
+goal_1_content: My translated content for goal 1

--- a/tests/data/custom-translations/fr/custom.yml
+++ b/tests/data/custom-translations/fr/custom.yml
@@ -7,3 +7,4 @@ reporting_status_description: My French Canadian reporting status description
 goals_page_title: My French Canadian goals page title
 goals_page_description: My French Canadian goals page description
 frontpage_introduction_banner_title: My French Canadian frontpage introduction banner title
+goal_1_content: My translated content for goal 1

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -32,3 +32,5 @@ Feature: Goal page
     And I click on "the language toggle dropdown"
     And I follow "the first language option"
     Then I should see "My translated content for goal 1"
+    And I am on "/2"
+    Then I should see "My goal 2 content"

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -25,3 +25,10 @@ Feature: Goal page
     Then I should see "Targets and indicators"
     And I should see 5 "goal target" elements
     And I should see 10 "goal indicator" elements
+
+  Scenario: Goals can have custom content
+    Given I am on "/1"
+    Then I should see "My content for goal 1"
+    And I click on "the language toggle dropdown"
+    And I follow "the first language option"
+    Then I should see "My translated content for goal 1"

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: 'master'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'goal-content-configuration'

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -25,6 +25,9 @@ create_config_forms:
   layout: config-builder
 create_goals:
   layout: goal
+  goals:
+    - number: "1"
+      content: custom.goal_1_content
 create_indicators:
   layout: indicator
 create_pages:

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -26,8 +26,8 @@ create_config_forms:
 create_goals:
   layout: goal
   goals:
-    - number: "1"
-      content: custom.goal_1_content
+    - content: custom.goal_1_content
+    - content: My goal 2 content
 create_indicators:
   layout: indicator
 create_pages:


### PR DESCRIPTION
Fixes #631 

## Dependencies

This depends on a PR on jekyll-open-sdg-plugins, so needs this in the Gemfile for the site repository:

```
gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'goal-content-configuration'
```

## Usage

Add to the "create_goals" site configuration, like so:

```
create_goals:
    layout: goal
    goals:
      - content: My goal content for goal 1
      - content: "My goal content for goal 2, with [a link](https://example.com)"
      - content: custom.my_translation_key
```

Feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/goal-content