### PR TITLE
Allow click around tab link to trigger tab

### DIFF
--- a/_includes/assets/js/accessibleTabs.js
+++ b/_includes/assets/js/accessibleTabs.js
@@ -1,0 +1,97 @@
+$(document).ready(function() {
+    $('.nav-tabs').each(function() {
+        var tabsList = $(this);
+        var tabs = tabsList.find('li > a');
+        var panes = tabsList.parent().find('.tab-pane');
+
+        panes.attr({
+            'class': 'tabPanel',
+            'role': 'tabpanel',
+            'aria-hidden': 'true',
+            'tabindex': '0',
+        }).hide();
+
+        tabsList.attr({
+            'role': 'tablist',
+        });
+
+        tabs.each(function(idx) {
+            var tab = $(this);
+            var tabId = 'tab-' + tab.attr('href').slice(1);
+            var pane = tabsList.parent().find(tab.attr('href'));
+
+            tab.attr({
+                'id': tabId,
+                'role': 'tab',
+                'aria-selected': 'false',
+                'tabindex': '-1',
+            }).parent().attr('role', 'presentation');
+
+            tab.removeAttr('href');
+
+            pane.attr('aria-labelledby', tabId);
+
+            tab.click(function(e) {
+                e.preventDefault();
+
+                tabsList.find('> li.active')
+                    .removeClass('active')
+                    .find('> a')
+                    .attr({
+                        'aria-selected': 'false',
+                        'tabindex': '-1',
+                    });
+
+                panes.filter(':visible').attr({
+                    'aria-hidden': 'true',
+                }).hide();
+
+                pane.attr({
+                    'aria-hidden': 'false',
+                }).show();
+
+                tab.attr({
+                    'aria-selected': 'true',
+                    'tabindex': '0',
+                }).parent().addClass('active');
+                tab.focus();
+            });
+        });
+
+        // Show the first tabPanel
+        panes.first().attr('aria-hidden', 'false').show();
+
+        // Set state for the first tabsList li
+        tabsList.find('li:first').addClass('active').find(' > a').attr({
+            'aria-selected': 'true',
+            'tabindex': '0',
+        });
+
+        // Set keydown events on tabList item for navigating tabs
+        tabsList.delegate('a', 'keydown', function(e) {
+            var tab = $(this);
+            switch (e.which) {
+                case 37:
+                    if (tab.parent().prev().length != 0) {
+                        tab.parent().prev().find('> a').click();
+                        e.preventDefault();
+                    }
+                    else {
+                        tabsList.find('li:last > a').click();
+                        e.preventDefault();
+                    }
+                    break;
+                case 39:
+                    if (tab.parent().next().length != 0) {
+                        tab.parent().next().find('> a').click();
+                        e.preventDefault();
+                    }
+                    else {
+                        tabsList.find('li:first > a').click();
+                        e.preventDefault();
+                    }
+                    break;
+            }
+        });
+    });
+});

--- a/_includes/assets/js/tabs.js
+++ b/_includes/assets/js/tabs.js
@@ -1,97 +1,11 @@
 $(document).ready(function() {
     $('.nav-tabs').each(function() {
         var tabsList = $(this);
-        var tabs = tabsList.find('li > a');
-        var panes = tabsList.parent().find('.tab-pane');
 
-        panes.attr({
-            'class': 'tabPanel',
-            'role': 'tabpanel',
-            'aria-hidden': 'true',
-            'tabindex': '0',
-        }).hide();
-
-        tabsList.attr({
-            'role': 'tablist',
-        });
-
-        tabs.each(function(idx) {
-            var tab = $(this);
-            var tabId = 'tab-' + tab.attr('href').slice(1);
-            var pane = tabsList.parent().find(tab.attr('href'));
-
-            tab.attr({
-                'id': tabId,
-                'role': 'tab',
-                'aria-selected': 'false',
-                'tabindex': '-1',
-            }).parent().attr('role', 'presentation');
-
-            tab.removeAttr('href');
-
-            pane.attr('aria-labelledby', tabId);
-
-            tab.click(function(e) {
-                e.preventDefault();
-
-                tabsList.find('> li.active')
-                    .removeClass('active')
-                    .find('> a')
-                    .attr({
-                        'aria-selected': 'false',
-                        'tabindex': '-1',
-                    });
-
-                panes.filter(':visible').attr({
-                    'aria-hidden': 'true',
-                }).hide();
-
-                pane.attr({
-                    'aria-hidden': 'false',
-                }).show();
-
-                tab.attr({
-                    'aria-selected': 'true',
-                    'tabindex': '0',
-                }).parent().addClass('active');
-                tab.focus();
-            });
-        });
-
-        // Show the first tabPanel
-        panes.first().attr('aria-hidden', 'false').show();
-
-        // Set state for the first tabsList li
-        tabsList.find('li:first').addClass('active').find(' > a').attr({
-            'aria-selected': 'true',
-            'tabindex': '0',
-        });
-
-        // Set keydown events on tabList item for navigating tabs
-        tabsList.delegate('a', 'keydown', function(e) {
-            var tab = $(this);
-            switch (e.which) {
-                case 37:
-                    if (tab.parent().prev().length != 0) {
-                        tab.parent().prev().find('> a').click();
-                        e.preventDefault();
-                    }
-                    else {
-                        tabsList.find('li:last > a').click();
-                        e.preventDefault();
-                    }
-                    break;
-                case 39:
-                    if (tab.parent().next().length != 0) {
-                        tab.parent().next().find('> a').click();
-                        e.preventDefault();
-                    }
-                    else {
-                        tabsList.find('li:first > a').click();
-                        e.preventDefault();
-                    }
-                    break;
-            }
+        // Allow clicking on the <li> to trigger tab click.
+        tabsList.find('li').click(function(event) {
+            $(event.target).find('> a').click();
+            event.stopPropagation();
         });
     });
 });

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -15,8 +15,9 @@
 {%- include assets/js/mapView.js -%}
 {%- include assets/js/indicatorView.js -%}
 {%- include assets/js/indicatorController.js -%}
-{% if site.accessible_tabs %}
 {%- include assets/js/tabs.js -%}
+{% if site.accessible_tabs %}
+{%- include assets/js/accessibleTabs.js -%}
 {% endif %}
 {%- include assets/js/search.js -%}
 {%- include assets/js/menu.js -%}


### PR DESCRIPTION
We recently changed the styling of tabs so that only the text gets highlighted. Unfortunately this means that the rest of the tab no longer has the click behavior. This tweak is intended to fix that.

We already had a "tabs.js" file but it was only being loaded if "accessible_tabs" was on. So this PR renames that file to accessibleTabs.js and puts the new behavior in tabs.js.