### PR TITLE
Fix tab clicking when accessible_tabs is false

### DIFF
--- a/_includes/assets/js/tabs.js
+++ b/_includes/assets/js/tabs.js
@@ -4,8 +4,9 @@ $(document).ready(function() {
 
         // Allow clicking on the <li> to trigger tab click.
         tabsList.find('li').click(function(event) {
-            $(event.target).find('> a').click();
-            event.stopPropagation();
+            if (event.target.tagName === 'LI') {
+                $(event.target).find('> a').click();
+            }
         });
     });
 });


### PR DESCRIPTION
The recently-merged tab fix (#1012) unfortunately broke tab functionality for sites with accessible_tabs set to false. This should fix that.