### PR TITLE
Series helper function bug fix

### DIFF
--- a/_includes/assets/js/model/helpers.js
+++ b/_includes/assets/js/model/helpers.js
@@ -66,6 +66,7 @@
     dataHasGeoCodes: dataHasGeoCodes,
     dataHasSerieses: dataHasSerieses,
     getFirstUnitInData: getFirstUnitInData,
+    getFirstSeriesInData: getFirstSeriesInData,
     getDataByUnit: getDataByUnit,
     getDataBySeries: getDataBySeries,
     getDataBySelectedFields: getDataBySelectedFields,


### PR DESCRIPTION
This helper function is used in indicatorModel.js, but is not actually present in the "helpers" object. So this is a bug - a bit hard to test because of all the conditions to satisfy - but clearly in need of fixing.