### PR TITLE
Tweak page-content styles for goal pages

### DIFF
--- a/_sass/base/_tables.scss
+++ b/_sass/base/_tables.scss
@@ -5,11 +5,6 @@
 }
 
 #page-content {
-
-  border-top: 1px solid $indicatorContent-horizontalRule-color;
-  border-bottom: 1px solid $indicatorContent-horizontalRule-color;
-  padding-top: 10px;
-
   table {
     margin-top: 5px;
     margin-bottom: 5px;

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -1,7 +1,7 @@
 .layout-goal, .layout-goal-by-target, .layout-goal-by-target-vertical {
   #page-content {
     margin-top: -20px;
-    margin-bottom: 30px;
+    margin-bottom: 23px;
   }
 }
 

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -1,7 +1,7 @@
 .layout-goal, .layout-goal-by-target, .layout-goal-by-target-vertical {
   #page-content {
     margin-top: -20px;
-    margin-bottom: 23px;
+    margin-bottom: 10px;
   }
 }
 

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -1,3 +1,10 @@
+.layout-goal, .layout-goal-by-target, .layout-goal-by-target-vertical {
+  #page-content {
+    margin-top: -20px;
+    margin-bottom: 30px;
+  }
+}
+
 body.contrast-high {
   .goal-indicators {
     div {

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -562,6 +562,14 @@ body.contrast-high {
   }
 }
 
+.layout-indicator {
+  #page-content {
+    border-top: 1px solid $indicatorContent-horizontalRule-color;
+    border-bottom: 1px solid $indicatorContent-horizontalRule-color;
+    padding-top: 10px;
+  }
+}
+
 @media only screen and (max-width: 500px) {
   body.layout-indicator{
     .container{


### PR DESCRIPTION
Addresses the suggestion from here: https://github.com/open-sdg/open-sdg/pull/1005#issuecomment-748045038

The screenshot below is with 30px margin beneath, and -20px margin above (it needs a negative margin in order to pull it closer to the goal banner).

![screenshot-127 0 0 1_4000-2020 12 18-12_23_13](https://user-images.githubusercontent.com/1319083/102642528-d487c980-412b-11eb-923d-11839b27799f.png)

Feature branch: http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/goal-content/1/