### PR TITLE
Optimization of validParentsByChild

### DIFF
--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -343,6 +343,9 @@ function selectMinimumStartingFields(rows, selectableFieldNames, selectedUnit) {
  * @param {Array} fieldItemStates
  * @param {Array} rows
  * @return {Object} Arrays of parents keyed to children
+ *
+ * @TODO: This function can be a bottleneck in large datasets with a lot of
+ * disaggregation values. Can this be further optimized?
  */
 function validParentsByChild(edges, fieldItemStates, rows) {
   var parentFields = getParentFieldNames(edges);
@@ -356,18 +359,17 @@ function validParentsByChild(edges, fieldItemStates, rows) {
       return value.value;
     });
     var parentField = parentFields[fieldIndex];
+    var childRows = rows.filter(function(row) {
+      var childNotEmpty = row[childField];
+      var parentNotEmpty = row[parentField];
+      return childNotEmpty && parentNotEmpty;
+    })
     validParentsByChild[childField] = {};
     childValues.forEach(function(childValue) {
-      var rowsWithParentValues = rows.filter(function(row) {
-        var childMatch = row[childField] == childValue;
-        var parentNotEmpty = row[parentField];
-        return childMatch && parentNotEmpty;
+      var rowsWithParentValues = childRows.filter(function(row) {
+        return row[childField] == childValue;
       });
-      var parentValues = rowsWithParentValues.map(function(row) {
-        return row[parentField];
-      });
-      parentValues = parentValues.filter(isElementUniqueInArray);
-      validParentsByChild[childField][childValue] = parentValues;
+      validParentsByChild[childField][childValue] = getUniqueValuesByProperty(parentField, rowsWithParentValues);
     });
   });
   return validParentsByChild;


### PR DESCRIPTION
The `validParentsByChild` function can be a bottleneck in large datasets with a lot of disaggregation values, because of all the loops and filtering. This is a minor optimization of it that should help some. This moves some calculations outside of a loop to reduce the number of times it has to run.

Here is a before/after comparison using UK's 4.2.1:

## Running the code from 1.3.0-dev

![valid-parents-by-child-current](https://user-images.githubusercontent.com/1319083/103157061-5bb4ed00-477d-11eb-8dcd-e4b64c807f07.png)

Total: 959.3ms

## Running the code from this PR

![valid-parents-by-child-optimized](https://user-images.githubusercontent.com/1319083/103157045-2dcfa880-477d-11eb-8462-976421894426.png)

Total: 521.9ms

So this optimization saves a little less than half a second. Not a huge improvement, but at least something. It should be noted that 521.9ms is still a _lot_ for a javascript function, so there is still room for improvement (like seeing if this function can be avoided altogether in some way).

## Testing advice

Testing should focus on making sure that:
1. Indicators with lots of data and disaggregation load a bit faster
2. Indicators with normal amounts of data/disaggregation load the same, if not faster
3. In all cases, the parent/child functionality works as expected ("Available when 'Region' is selected", etc.)

JW edit: [Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/valid-parents-by-child-optimization)