### PR TITLE
Do not change SVG images in high-contrast mode

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -107,6 +107,7 @@ var accessibilitySwitcher = function() {
 
 
   function imageFix(contrast) {
+    {% unless site.goal_image_extension == 'svg' %}
     if (contrast == 'high')  {
       _.each($('img:not([src*=high-contrast])'), function(goalImage){
         if ($(goalImage).attr('src').slice(0, 35) != "https://platform-cdn.sharethis.com/") {
@@ -118,6 +119,7 @@ var accessibilitySwitcher = function() {
         $(goalImage).attr('src', $(goalImage).attr('src').replace('high-contrast/', ''));
       })
     }
+    {% endunless %}
   };
 
 };

--- a/_includes/components/indicator/header.html
+++ b/_includes/components/indicator/header.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2 goal-icon goal-tiles">
         <a href="{{ page.goal.url }}" title="{{ page.t.indicator.view_indicator_list }}">
-          <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}"/>
+          <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
         </a>
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10 indicator-details">

--- a/_includes/components/reportingstatus/reporting-status-by-goal.html
+++ b/_includes/components/reportingstatus/reporting-status-by-goal.html
@@ -6,7 +6,7 @@
 <div class="goal reporting-status-item">
     <div class="frame goal-tiles">
         <a href="{{ goal.url }}">
-        <img src="{{ goal.icon }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }}"/>
+        <img src="{{ goal.icon }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }} goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
         </a>
     </div>
     <div class="details">

--- a/_layouts/frontpage-alt.html
+++ b/_layouts/frontpage-alt.html
@@ -36,7 +36,7 @@ release) this can replace frontpage.html.
                 {% for goal in page.goals %}
                 <div class="col-xs-4 col-sm-2 col-md-1 goal-tile">
                     <a href="{{ goal.url }}">
-                        <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
+                        <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
                     </a>
                 </div>
                 {% endfor %}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -21,7 +21,7 @@
         {% cycle 'add row' : '<div class="row no-gutters">', '', '', '', '', '' %}
             <div class="col-xs-4 col-md-2">
                 <a href="{{ goal.url }}">
-                  <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
+                  <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
               </a>
             </div>
         {% cycle 'end row' : '', '', '', '', '', '</div>' %}
@@ -32,7 +32,7 @@
     {% endcomment %}
     {% if page.goals.size == 17 %}
         <div class="col-xs-4 col-md-2">
-            <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+            <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
         </div>
     {% endif %}
     </div>

--- a/_layouts/goal-by-target-vertical.html
+++ b/_layouts/goal-by-target-vertical.html
@@ -9,7 +9,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2 goal-tiles">
-        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}"/>
+        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>

--- a/_layouts/goal-by-target.html
+++ b/_layouts/goal-by-target.html
@@ -9,7 +9,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2 goal-tiles">
-        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" />
+        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -9,7 +9,7 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-4 col-md-3 col-lg-2 goal-tiles">
-        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}"/>
+        <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
       </div>
       <div class="col-xs-8 col-md-9 col-lg-10">
         <h1>

--- a/_layouts/goals.html
+++ b/_layouts/goals.html
@@ -9,7 +9,7 @@
             {% for goal in page.goals %}
             <div class="col-xs-4 col-md-2 goal-tile">
                 <a href="{{ goal.url }}">
-                    <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" />
+                    <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
                 </a>
             </div>
             {% endfor %}
@@ -19,7 +19,7 @@
             {% endcomment %}
             {% if page.goals.size == 17 %}
             <div class="col-xs-4 col-md-2 goal-tile">
-                <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" />
+                <img src="{{ site.goal_image_base }}/{{ page.language }}/18.png" id="goal-18" alt="The Global Goals for Sustainable Development" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Because SVG images can use CSS styling, there is no need to change them for high-contrast. So this PR skips the image-changing behavior for SVG icons.

Also, this PR adds some useful HTML classes to all goal icons throughout the site. They aren't used anywhere, and won't affect anything, but may be useful in the future, or to any countries that would like to add special styling to goal images.

EDIT: [Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/svg-icon-high-contrast/)
