### PR TITLE
Round the map data

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -215,7 +215,7 @@
     // Get the data from a feature's properties, according to the current year.
     getData: function(props) {
       if (props.values && props.values.length && props.values[this.currentDisaggregation][this.currentYear]) {
-        return props.values[this.currentDisaggregation][this.currentYear];
+        return opensdg.dataRounding(props.values[this.currentDisaggregation][this.currentYear]);
       }
       return false;
     },

--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -55,8 +55,8 @@
       }).join('');
       var div = L.DomUtil.create('div', 'selection-legend');
       div.innerHTML = L.Util.template(controlTpl, {
-        lowValue: this.plugin.valueRange[0],
-        highValue: this.plugin.valueRange[1],
+        lowValue: opensdg.dataRounding(this.plugin.valueRange[0]),
+        highValue: opensdg.dataRounding(this.plugin.valueRange[1]),
         legendSwatches: swatches,
       });
       return div;


### PR DESCRIPTION
Fixes #899 

By itself this doesn't change anything, since the [default dataRounding function](https://github.com/open-sdg/open-sdg/blob/master/_includes/javascript-variables.html#L16-L19) does no rounding. But if this rounding function has been customized, this PR applies it to the map data.

Since the UK has a [dataRounding function](https://github.com/ONSdigital/sdg-indicators/blob/develop/assets/js/custom.js), this can be tested on a UK feature branch if any map data has decimals to check.

[Edit: Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/map-data-rounding)