### PR TITLE
HTML 'lang' attribute should depend on current language

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="{{ page.language }}" class="no-js">
     <head>
         <meta charset="utf-8">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>


### PR DESCRIPTION
Right now our html `lang` attribute is hardcoded as "en". I'm not aware of any reason we would not want it to be dynamic, based on the current language.

[Feature Branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/dynamic-lang-att2)