### PR TITLE
Reporting status accessibility fixes

### DIFF
--- a/_includes/components/reportingstatus/reporting-status-by-field.html
+++ b/_includes/components/reportingstatus/reporting-status-by-field.html
@@ -9,14 +9,14 @@
     <div class="goal details reporting-status-item">
         <h3 class="status-goal">
             <span class="status-field">{{ fieldreport[extra_field_name] | t }}</span>
-            <span class="total">{{ fieldreport.totals.total }}
-                {% if fieldreport.totals.total == 1 %}
-                    {{ indicator_singular }}
-                {% else %}
-                    {{ indicators_plural }}
-                {% endif %}
-            </span>
         </h3>
+        <span class="total">{{ fieldreport.totals.total }}
+            {% if fieldreport.totals.total == 1 %}
+                {{ indicator_singular }}
+            {% else %}
+                {{ indicators_plural }}
+            {% endif %}
+        </span>
         <div class="summary">
             <div class="statuses">
                 {%- for status in fieldreport.statuses -%}

--- a/_includes/components/reportingstatus/reporting-status-by-goal.html
+++ b/_includes/components/reportingstatus/reporting-status-by-goal.html
@@ -12,8 +12,8 @@
     <div class="details">
         <h3 class="status-goal">
             <a href="{{ goal.url }}">{{ goal.short }}</a>
-            <span class="total">{{ goalreport.totals.total }} {{ indicators_plural }}</span>
         </h3>
+        <span class="total">{{ goalreport.totals.total }} {{ indicators_plural }}</span>
         <div class="summary">
             <div class="statuses">
                 {%- for status in goalreport.statuses -%}

--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -4,8 +4,9 @@
 <div class="goal goal-overall">
     <div class="details">
         <h2 class="status-goal">
-            {{ include.title }} <span class="total"><span>{{ overall.totals.total }}</span> {{ indicators_plural }}</span>
+            {{ include.title }}
         </h2>
+        <span class="total"><span>{{ overall.totals.total }}</span> {{ indicators_plural }}</span>
         <div class="summary">
             <div class="statuses">
             {%- for status in overall.statuses -%}

--- a/_sass/components/_high_contrast.scss
+++ b/_sass/components/_high_contrast.scss
@@ -23,6 +23,7 @@
 
     &.contrast-default {
       display: none;
+      @include preserveOriginalColors;
       background: $color-light-highContrast;
       a {
         color: $color-dark-highContrast;
@@ -31,6 +32,7 @@
 
     &.contrast-high {
       display: block;
+      @include preserveOriginalColors;
       background: $color-dark-highContrast;
       a {
         color: $color-highlight-highContrast;

--- a/_sass/layouts/_header.scss
+++ b/_sass/layouts/_header.scss
@@ -126,6 +126,7 @@ body.contrast-high {
       }
 
       &.contrast-default {
+        @include preserveOriginalColors;
         background: $color-light-highContrast;
         a {
           color: $color-dark-highContrast;
@@ -133,6 +134,7 @@ body.contrast-high {
       }
 
       &.contrast-high {
+        @include preserveOriginalColors;
         background: $color-dark-highContrast;
         a {
           color: $color-highlight-highContrast;

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -29,7 +29,7 @@
     }
     > div {
       display: inline-block;
-
+      margin-bottom: 5px;
       margin-right: 10px;
 
       .status {
@@ -104,16 +104,18 @@
     border-bottom: 1px solid $horizontalRule-color;
     .total {
        line-height: 1.2;
-       vertical-align: middle;
        font-size: 16px;
        width: auto;
        padding-left: 4px;
        padding-right: 4px;
        text-align: center;
        display: inline-block;
-       margin-left: 10px;
+       margin-bottom: 10px;
        border-radius: 4px;
        border: 1px solid $horizontalRule-color;
+       @media screen and (min-width: 520px) {
+         margin-left: 10px;
+       }
     }
   }
   .frame {
@@ -127,8 +129,16 @@
   .details {
     width: calc(100% - 125px);
     float: left;
+    h2 {
+      @media screen and (min-width: 520px) {
+        display: inline-block;
+      }
+    }
     h3 {
       margin-top: 10px;
+      @media screen and (min-width: 520px) {
+        display: inline-block;
+      }
       @media only screen and (max-width: 720px) {
         margin-top: 3px;
       }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -84,6 +84,7 @@
     margin-left: 3px;
   }
   .goal-stats {
+    @include preserveOriginalColors;
     border: 1px solid $color-dark;
     font-size: 0;
     margin-top:10px;
@@ -102,7 +103,7 @@
     padding-bottom: 4px;
     border-bottom: 1px solid $horizontalRule-color;
     .total {
-       line-height: 24px;
+       line-height: 1.2;
        vertical-align: middle;
        font-size: 16px;
        width: auto;
@@ -111,7 +112,6 @@
        text-align: center;
        display: inline-block;
        margin-left: 10px;
-       margin-top: -2px;
        border-radius: 4px;
        border: 1px solid $horizontalRule-color;
     }
@@ -135,7 +135,7 @@
       @media only screen and (max-width: 520px) {
         margin-bottom: 3px;
       }
-      line-height: 24px;
+      line-height: 1.2;
     }
   }
   [data-extra-field] {


### PR DESCRIPTION
Partial fixes for #989 

In this PR:
1. Move spans outside of headings on reporting status page - style changes to match
2. Line-height-related fixes for better support of zooming in
3. Preserve some background colors in Windows high contrast mode in IE/Edge

Some of the things mentioned in #989 are not yet in this PR - I'll post my thoughts over there.

EDIT: [Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/reporting-status-accessibility-fixes/reporting-status/)