### PR TITLE
Translate 'Results found'

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -3,7 +3,7 @@
 
 <script type="text/template" class="results-template">
   <% if(resultsCount) { %>
-    <p><%= resultsCount %> results found</p>
+    <p>{{ page.t.search.results_found }}: <%= resultsCount %></p>
     <% _.each(searchResults, function(result){ %>
       <div class="row search-result">
         <div class="col col-xs-12">

--- a/tests/data/custom-translations/es/search.yml
+++ b/tests/data/custom-translations/es/search.yml
@@ -1,0 +1,1 @@
+results_found: Results found (translated)

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -61,4 +61,4 @@ Feature: Search
     And I fill in "the search box" with "proporciónes"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "Results found: 10"
+    Then I should see "Results found (translated): 10"

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -9,7 +9,7 @@ Feature: Search
     And I fill in "the search box" with "hunger"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "1 results found"
+    Then I should see "Results found: 1"
     And I follow "End hunger, achieve food security and improved nutrition and promote sustainable agriculture"
     Then I should be on "/2/"
 
@@ -18,7 +18,7 @@ Feature: Search
     And I fill in "the search box" with "mortality"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "1 results found"
+    Then I should see "Results found: 1"
     And I follow "Maternal mortality ratio"
     Then I should be on "/3-1-1/"
 
@@ -27,7 +27,7 @@ Feature: Search
     And I fill in "the search box" with "platypus"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "1 results found"
+    Then I should see "Results found: 1"
     And I follow "My about page title"
     Then I should be on "/about/"
 
@@ -36,7 +36,7 @@ Feature: Search
     And I fill in "the search box" with "FAO"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "4 results found"
+    Then I should see "Results found: 4"
 
   Scenario: The "did you mean" feature suggests alternative searches
     Given I am on the homepage
@@ -47,18 +47,18 @@ Feature: Search
     And I should see "did you mean"
     And I follow "popul"
     And I wait 5 seconds
-    Then I should see "results found"
+    Then I should see "Results found:"
 
   Scenario: Searching for words also matches their stems
     Given I am on the homepage
     And I fill in "the search box" with "proportions"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "10 results found"
+    Then I should see "Results found: 10"
 
   Scenario: Searching for words also matches their stems in other languages
     Given I am on "/es"
     And I fill in "the search box" with "proporciónes"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "10 results found"
+    Then I should see "Results found: 10"


### PR DESCRIPTION
Fixes #236 

## Testing

Testing this in a non-English language is quite tricky and would involve a lot of extra steps. I would recommend only testing that this works in English. If it works in English, it will work in other languages (once they are translated).

To test, do any search and look for a "Results found: X" message.  If it does not appear, then it's not working right.