### PR TITLE
Fix layout issues with odd-numbered indicator sources

### DIFF
--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -595,3 +595,9 @@ body.contrast-high {
     }
   }
 }
+
+#sources {
+  .row > div:nth-child(odd) {
+    clear: left;
+  }
+}

--- a/tests/data/meta/1-1-1.md
+++ b/tests/data/meta/1-1-1.md
@@ -9,7 +9,13 @@ national_indicator_description: Lorem ipsum dolor sit amet, consectetur adipisci
   elit.
 sdg_goal: '1'
 source_active_1: true
-source_organisation_1: My organisation
+source_organisation_1: My first organisation with a long title, which in the past has caused the 3rd source to end up displaying on the right, with empty space on the left. This long text is provided to test that this has been fixed.
+source_active_2: true
+source_organisation_2: My second organisation with a short title.
+source_active_3: true
+source_organisation_3: Does this third show on the left or right?
+source_active_4: true
+source_organisation_4: This fourth one really makes the problem obvious, if the third one was on the right.
 target_name: global_targets.1-1-title
 target_id: '1.1'
 un_custodian_agency: World Bank

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -28,7 +28,7 @@ Feature: Indicator
     And I click on "the National metadata tab"
     Then I should see "Indicator description"
     And I click on "the Sources metadata tab"
-    And I should see "My organisation"
+    And I should see "My first organisation with a long title"
 
   Scenario: The metadata tab titles and blurbs can both be configured
     Then I should see "My national metadata title"

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -54,7 +54,7 @@ Feature: Indicator
     Then I should see "This is the page content in English."
 
   Scenario: Indicators can show certain metadata fields beneath the table, chart, and map
-    Then I should see "My organisation"
+    Then I should see "My first organisation with a long title"
     And I should see a "chart footer" element
     And I should see 5 "chart footer item" elements
     And I click on "the Table tab"


### PR DESCRIPTION
This is a fix for one of the issues mentioned in #504 -- namely the problem where the placement of the odd-numbered sources is inconsistent depending on the height of the even-numbered sources. This change forces odd-numbered sources to always align to the left.

There is another issue mentioned in #504 -- namely the incongruity of the horizontal lines when different-height fields are next to each other -- which needs a design discussion, so is not addressed here.

Testing note - if using a feature branch, the UK's indicator 5-5-1 is a good one to test.