### PR TITLE
Do not use empty titles in head

### DIFF
--- a/_includes/title-tag.html
+++ b/_includes/title-tag.html
@@ -7,7 +7,7 @@
     </title>
 {% elsif page.goal %}
     <title>{{ page.t.general.goal | escape }} {{ page.goal.number }} - {{ page.goal.short | escape }} - {{ site.title | t | escape }}</title>
-{% elsif page.title %}
+{% elsif page.title and page.title != '' %}
     <title>{{ page.title | t | escape }} - {{ site.title | t | escape }}</title>
 {% else %}
     <title>{{ site.title | t | escape }}</title>


### PR DESCRIPTION
When using the config forms, empty values are saved as empty strings (`''`). But these are being placed in the page title, so it ends up like: `- Indicators for the Sustainable Development Goals`. This extra check avoids that, so it will properly be `Indicators for the Sustainable Development Goals`.

If you would like to test this one, you could try giving an empty title to the homepage. Eg:

```
create_pages:
  - folder: /
    layout: frontpage
    title: ''
```

EDIT: [Feature branch](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/skip-empty-titles)