### PR TITLE
Use https to avoid mixed content error

### DIFF
--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -15,7 +15,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@3.14.0/dist/js-yaml.min.js"></script>
-  <script src="http://cdn.jsdelivr.net/g/filesaver.js"></script>
+  <script src="https://cdn.jsdelivr.net/g/filesaver.js"></script>
   <script>
 
     // Dynamic filtering functionality.


### PR DESCRIPTION
This is a quick change to avoid "mixed content" errors in browsers. Some (all?) browsers do not like it when a page loads some assets using "https" and others using "http", and they will block the "http" assets.

I don't think this is worth a feature branch.