### PR TITLE
Bug fix - variable name in config builder

### DIFF
--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -72,7 +72,7 @@
           if (schema.properties.{{ dropdown.jsonschema }}) {
             schema.properties.{{ dropdown.jsonschema }}.format = 'choices';
             schema.properties.{{ dropdown.jsonschema }}.enum = {{ dropdown.values | jsonify }};
-            {% if choices.labels %}
+            {% if dropdown.labels %}
               schema.properties.{{ dropdown.jsonschema }}.options = schema.properties.{{ dropdown.jsonschema }}.options || {};
               schema.properties.{{ dropdown.jsonschema }}.options.enum_titles = {{ dropdown.labels | jsonify }};
             {% endif %}


### PR DESCRIPTION
@LucyGwilliamAdmin @jwestw This is a straightforward bugfix -- "choices" is not a variable there, it was meant to be "dropdown".

I don't think this is worth a feature branch.