### PR TITLE
Make the meta/data edit links optional

### DIFF
--- a/_includes/components/indicator/edit-buttons.html
+++ b/_includes/components/indicator/edit-buttons.html
@@ -13,13 +13,13 @@
 
 
   <a class="btn btn-primary" href="{{ data_edit_url | replace: '[id]', page.indicator.slug }}">{{ page.t.indicator.edit_data }}</a>
-  {% else %}
+  {% elsif data_edit_url != '' %}
   <a class="btn btn-primary" href="http://prose.io/#{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/{{ site.data_dir_for_edits | default: 'data' }}/indicator_{{ page.indicator.slug }}.csv">{{ page.t.indicator.edit_data }}</a>
   {% endif %}
 
   {% if site.metadata_edit_url and site.metadata_edit_url != '' %}
   <a class="btn btn-primary" href="{{ site.metadata_edit_url | replace: '[id]', page.indicator.slug }}">{{ page.t.indicator.edit_metadata }}</a>
-  {% else %}
+  {% elsif site.metadata_edit_url != '' %}
   <a class="btn btn-primary" href="http://prose.io/#{{ site.org_name }}/{{ site.repo_name }}/edit/{{ site.branch }}/meta/{{ page.indicator.slug }}.md">{{ page.t.indicator.edit_metadata }}</a>
   {% endif %}
 


### PR DESCRIPTION
I don't remember the reasons for making these fields required, but with more and more implementations of Open SDG using data sources that are not file-based, it seems like these fields should be optional.

Corresponds to https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/79