### PR TITLE
New 'accessible' option for chart colors

### DIFF
--- a/_includes/assets/js/chartColors.js
+++ b/_includes/assets/js/chartColors.js
@@ -24,7 +24,8 @@ opensdg.chartColors = function(indicatorId) {
   this.colorSets = {'default':['7e984f', '8d73ca', 'aaa533', 'c65b8a', '4aac8d', 'c95f44'],
                   'sdg':['e5243b', 'dda63a', '4c9f38', 'c5192d', 'ff3a21', '26bde2', 'fcc30b', 'a21942', 'fd6925', 'dd1367','fd9d24','bf8b2e','3f7e44','0a97d9','56c02b','00689d','19486a'],
                   'goal': this.goalColors[this.goalNumber-1],
-                  'custom': customColorList};
+                  'custom': customColorList,
+                  'accessible': ['55a6e5', '8d4d57', 'cd7a00', '993300', '339966', '9966cc']};
   if(Object.keys(this.colorSets).indexOf(colorSet) == -1 || (colorSet=='custom' && customColorList == null)){
     return this.colorSets['default'];
   }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 <h1>Change Log</h1>
 
+## Unreleased
+
+* New 'accessible' color-set option for optimal contrast #1103
+
 ## 1.2.0
 
 * Tweak page-content styles for goal pages #1034

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -416,15 +416,18 @@ As always, for multilingual support, these settings can refer to translation key
 
 ### graph_color_set
 
-_Optional_: This setting can be used to customize the color set used in the charts. There are four possible entries:
-Use `graph_color_set: 'default'` for using the 6 default colors,
-`graph_color_set: 'sdg'` to use the 17 SDG colors in all charts,
-`graph_color_set: 'goal'` to use shades of the color of the current indicator's goal,
-`graph_color_set: 'custom'` to use a set of customized colors. In this case, write the hexadecimal color codes of the colors you want to use to the list in `graph_color_list` (see below).
+_Optional_: This setting can be used to customize the color set used in the charts. There are five possible entries:
+
+* `graph_color_set: 'accessible'` a 6-color set that is specifically chosen for optimal accessibility (recommended)
+* `graph_color_set: 'default'` a deprecated 6-color set that is still the default (for reasons of backwards compatibility)
+* `graph_color_set: 'sdg'` to use the 17 SDG colors in all charts
+* `graph_color_set: 'goal'` to use shades of the color of the current indicator's goal
+* `graph_color_set: 'custom'` to use a set of customized colors. In this case, write the hexadecimal color codes of the colors you want to use to the list in `graph_color_list` (see below).
 
 > **NOTE**: Whatever color scheme you choose here, please ensure that all colors satisfy
 > the accessibility (minimum contrast) standards in your region. These colors will need to
-> be visible on white and black backgrounds.
+> be visible on white and black backgrounds. The `accessible` color scheme is designed to
+> meet this requirement, and so it is recommended.
 
 ### graph_color_list
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/accessible-chart-colors/)
Fixed issues | #1099
Related version | 1.3.0-dev
Bugfix, feature or docs? | Feature
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |✔️
Added CHANGELOG entry? |✔️

## Testing instructions

Site configuration:

```
graph_color_set: accessible
```
