### PR TITLE
Tweak the link/visited colors in high contrast mode

### DIFF
--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -14,7 +14,7 @@ $color-light: white !default;
 
 $color-dark-highContrast: black !default;
 $color-light-highContrast: white !default;
-$color-highlight-highContrast: yellow !default;
+$color-highlight-highContrast: #FFDD00 !default;
 $color-success-highContrast: green !default;
 $color-danger-highContrast: red !default;
 $color-medium-highContrast: #767676 !default;
@@ -34,7 +34,7 @@ $link-color: #1d70b8 !default;
 $link-color-dark: #0275d8 !default;
 $link-color-hover: #003078 !default;
 $link-color-visited: #4c2c92 !default;
-$link-color-visited-highContrast: #F47738 !default;
+$link-color-visited-highContrast: #AD6800 !default;
 
 $horizontalRule-color: #ccc !default;
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/chart-color-accessibility-revamp)
Fixed issues | #1100
Related version | 1.3.0-dev
Bugfix, feature or docs? | feature
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |❌
