### PR TITLE
Do not use Lunr for indicator id searches

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -21,6 +21,14 @@ var indicatorSearch = function() {
       }
     }
 
+    // Recognize an indicator id as a special case that does not need Lunr.
+    var searchWords = searchTermsToUse.split(' '),
+        indicatorIdParts = searchWords[0].split('.'),
+        isIndicatorSearch = (searchWords.length === 1 && indicatorIdParts.length === 3);
+    if (isIndicatorSearch) {
+      useLunr = false;
+    }
+
     var results = [];
     var alternativeSearchTerms = [];
 

--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -24,7 +24,7 @@ var indicatorSearch = function() {
     // Recognize an indicator id as a special case that does not need Lunr.
     var searchWords = searchTermsToUse.split(' '),
         indicatorIdParts = searchWords[0].split('.'),
-        isIndicatorSearch = (searchWords.length === 1 && indicatorIdParts.length === 3);
+        isIndicatorSearch = (searchWords.length === 1 && indicatorIdParts.length >= 3);
     if (isIndicatorSearch) {
       useLunr = false;
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 <h1>Change Log</h1>
 
+## Unreleased
+
+* Fix support for indicator ID searches in all languages #1110
+
 ## 1.2.0
 
 * Tweak page-content styles for goal pages #1034


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | #979 
Related version | 1.3.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |✔️

## Testing

1. Configure site to use multiple languages
2. Visit site in a non-English language (I've tested in Spanish)
3. Do a search for "1.1.1"
4. Confirm that 1 result is shown

Without this PR, 0 results will be shown.
