### PR TITLE
Add note item for tests and split docs/forms

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,5 +5,7 @@ Fixed issues | #`issue`
 Related version | 1.3.0-dev
 Bugfix, feature or docs? |
 Keeps backward-compatibility? |❌/✔️
-Updated docs/config-forms? |❌/✔️
+Includes tests? |❌/✔️
+Updated docs? |❌/✔️
+Updated config forms? |❌/✔️
 Added CHANGELOG entry? |❌/✔️

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 Q | A
 --- | ---
 Feature branch/test site URL | [Link](add link here)
-Fixed issues | #`issue`
+Fixed issues | Fixes #ISSUENUMBER
 Related version | 1.3.0-dev
 Bugfix, feature or docs? |
 Keeps backward-compatibility? |❌/✔️


### PR DESCRIPTION
@LucyGwilliamAdmin  A tweak to the PR template - I realized that the test item was needed after all. And also thought maybe docs and forms could be on separate lines?