### PR TITLE
Fix reporting status type styling in goal-by-target-vertical

### DIFF
--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -31,6 +31,25 @@
   }
 }
 
+@mixin statusHighContrast {
+  &.complete {
+    color: $status-color-complete-highContrast;
+    border: $status-border-complete-highContrast;
+  }
+  &.inprogress{
+    color: $status-color-inprogress-highContrast;
+    border: $status-border-inprogress-highContrast;
+  }
+  &.notstarted {
+    color: $status-color-notstarted-highContrast;
+    border: $status-border-notstarted-highContrast;
+  }
+  &.notapplicable {
+    color: $status-color-notapplicable-highContrast;
+    border: $status-border-notapplicable-highContrast;
+  }
+}
+
 @mixin tags {
   .tag {
     @include status;

--- a/_sass/layouts/_goal-by-target-vertical.scss
+++ b/_sass/layouts/_goal-by-target-vertical.scss
@@ -91,4 +91,10 @@ $goal-by-target-indentation: 60px;
   .status, .tags {
     margin-left: $goal-by-target-indentation;
   }
+
+  &.contrast-high {
+    .status {
+      @include statusHighContrast;
+    }
+  }
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/high-contrast-status-notstarted-outline)
Fixed issues | #1108
Related version | 1.3.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |❌
