### PR TITLE
Fix focus color on dropdowns in high-contrast

### DIFF
--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -521,6 +521,11 @@ body.contrast-high {
       background-color: $color-dark-highContrast;
       border-color: $color-light-highContrast;
       color: $color-light-highContrast;
+      &:focus {
+        span {
+          color: $color-dark-highContrast;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/high-contrast-dropdown-focus-color)
Fixed issues | #1107
Related version | 1.3.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |❌
