### PR TITLE
Remove hover styles for high-contrast chart legend

### DIFF
--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -554,10 +554,6 @@ body.contrast-high {
     li {
       color: $color-light-highContrast !important;
       border: 1px solid transparent;
-      &:hover {
-        background: transparent !important;
-        border: 1px solid $color-light-highContrast;
-      }
     }
   }
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/high-contrast-chart-legend-hover/)
Fixed issues | Fixes #1105
Related version | 1.3.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |❌
