### PR TITLE
Avoid highlighting entire div on focus

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -110,8 +110,15 @@ input[type="checkbox"]:focus, body.contrast-high input[type="checkbox"]:focus {
 }
 .tabPanel:focus,
 input[type="text"]:focus,
-body.contrast-high input[type="text"]:focus {
+body.contrast-high input[type="text"]:focus,
+div[tabindex]:focus {
   background-color: $backgroundColor !important;
   box-shadow: none !important;
   outline: 3px solid $focusOutlineColor !important;
+}
+
+body.contrast-high div[tabindex]:focus {
+  background-color: $color-dark-highContrast !important;
+  box-shadow: none !important;
+  outline: 3px solid $focusOutlineColor-highContrast !important;
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://sdgdev-813006012.eu-west-1.elb.amazonaws.com/high-contrast-focus-outside-chart)
Fixed issues | Fixes #1109
Related version | 1.3.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Updated docs/config-forms? |NA
Added CHANGELOG entry? |❌
