### PR TITLE
Pin to Ubuntu 18.04 because 20.04 doesn't work for tests

### DIFF
--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This is needed because Github Actions is migrating to Ubuntu 20.04, but our test suite fails in those cases with random "Page crashed" errors from Puppeteer.
