### PR TITLE
Standard background color for hovering over table rows and field options

### DIFF
--- a/_sass/base/_tables.scss
+++ b/_sass/base/_tables.scss
@@ -1,6 +1,6 @@
 .table-hover {
   tbody tr:hover {
-    background: darken($backgroundColor, 12%);
+    background: $table-row-backgroundColor-hover;
   }
 }
 

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -220,7 +220,7 @@
           }
 
           &:hover {
-            background: $indicator-fieldButton-borderColor-hover;
+            background: $indicator-fieldOption-backgroundColor-hover;
           }
 
           &[data-has-data="false"] {

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -35,6 +35,7 @@ $link-color-dark: #0275d8 !default;
 $link-color-hover: #003078 !default;
 $link-color-visited: #4c2c92 !default;
 $link-color-visited-highContrast: #AD6800 !default;
+$text-backgroundColor-hover: #EEEEEE !default;
 
 $horizontalRule-color: #ccc !default;
 
@@ -148,6 +149,8 @@ $map-legendValue-color-noValue: repeating-linear-gradient(45deg, #FFF, #FFF 2px,
 $map-legendValue-color: #ddd !default;
 $map-legendBar-color: white !default;
 
+$table-row-backgroundColor-hover: $text-backgroundColor-hover !default;
+
 $indicator-field-color-disabled: #777 !default;
 $indicator-field-backgroundColor-disabled: #ccc !default;
 $indicator-field-borderColor-hover: #acacac !default;
@@ -161,6 +164,7 @@ $indicator-hint-color: #666 !default;
 $indicator-fieldButton-borderColor: #555 !default;
 $indicator-fieldButton-borderColor-hover: #f5f3f3 !default;
 $indicator-fieldLabel-borderColor: #cdcdcd !default;
+$indicator-fieldOption-backgroundColor-hover: $text-backgroundColor-hover !default;
 $indicator-datasetWarning-backgroundColor: #FFCC0B !default;
 $indicator-legendSwatch-fillColor: #666 !default;
 $indicator-legendSwatch-backgroundColor-hover: #eee !default;


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](https://lucygwilliamadmin.github.io/sdg-indicators/1-2-1/)
Fixed issues | Fixes #1113 
Related version | 1.4.0-dev
Bugfix, feature or docs? | Feature
Keeps backward-compatibility? |✔️(technically is a change but very minor)
Includes tests? |NA
Updated docs? |NA
Updated config forms? |NA
Added CHANGELOG entry? |❌
