### PR TITLE
Pin to mkdocs 1.1.2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+   - requirements: docs/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build: clean cache
 	cd site-starter && bundle exec jekyll build
 
 build.docs:
-	pip install mkdocs
+	pip install -r docs/requirements.txt
 	mkdocs build
 
 serve: build

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# Defining the exact version will make sure things don't break
+mkdocs==1.1.2


### PR DESCRIPTION
Mkdocs just released 1.2 which is failing tests. I think it needs some extra configuration, but a quick fix is to pin to the known working version 1.1.2, which is a good practice anyway. We can upgrade to 1.2 in the future if there is some feature we need. This also adds a readthedocs config file which should ensure that readthedocs uses that pinned version.
