### PR TITLE
Quick fixes for some zoom issues on maps

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -521,7 +521,11 @@
           }
           // Make sure the map is not too high.
           var heightPadding = 75;
+          var minHeight = 400;
           var maxHeight = $(window).height() - heightPadding;
+          if (maxHeight < minHeight) {
+            maxHeight = minHeight;
+          }
           if ($('#map').height() > maxHeight) {
             $('#map').height(maxHeight);
           }

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -78,6 +78,12 @@
         margin-right: 4px;
       }
     }
+    .leaflet-control-attribution {
+      @media only screen and (max-width: 480px) {
+        max-width: 100px;
+        text-align: right;
+      }
+    }
     .selection-legend {
       @media only screen and (max-width: 680px) {
         display: none;


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1194
Related version | 1.4.0-dev
Bugfix, feature or docs? | Bugfix
Keeps backward-compatibility? |✔️
Includes tests? |NA
Updated docs? |NA
Updated config forms? |NA
Added CHANGELOG entry? |❌

This has a quick fix to a couple of zoom-related issues mentioned in #1194:

1. On small-screens/high-zooms the attribution element has a max-width of 100px and aligns to the right
2. Even when loaded on small-screens/high-zooms, the map will never be shorter than 400px high.