### PR TITLE
Document repository_url_data and repository_url_site fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -725,6 +725,26 @@ reporting_status:
 
 As always, for multilingual support, the title/description settings can refer to translation keys, and description can include Markdown.
 
+### repository_url_data
+
+_Optional_: This setting specifies the URL of the data repository, which is used in other settings. Currently this -- if available -- will be used as a prefix for the "repository_link" options in `indicator_config_form`, `indicator_metadata_form`, and `indicator_data_form`.
+
+Here is an example of using this setting:
+
+```yaml
+repository_url_data: https://github.com/my-github-org/data
+```
+
+### repository_url_site
+
+_Optional_: This setting specifies the URL of the site repository, which is used in other settings. Currently this -- if available -- will be used as a prefix for the "repository_link" option in `site_config_form`.
+
+Here is an example of using this setting:
+
+```yaml
+repository_url_site: https://github.com/my-github-org/site
+```
+
 ### search_index_boost
 
 _Optional_: This setting can be used to give a "boost" to one or more fields in the search index. The boost number should be a positive integer. The higher the number, the more "relevant" that field will be in search results. If omitted, the following defaults will be used:

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -147,15 +147,15 @@ indicator_config_form:
       labels:
         - Not started
         - Complete
-  repository_link: 'https://example.com'
+  repository_link: '/tree/master/tests/data/indicator-config'
   translation_link: ''
 indicator_data_form:
   enabled: true
-  repository_link: 'https://example.com'
+  repository_link: '/tree/master/tests/data/data'
 indicator_metadata_form:
   enabled: true
   dropdowns: []
-  repository_link: 'https://example.com'
+  repository_link: '/tree/master/tests/data/meta'
   translation_link: 'https://example.com?[id]&[group]&[key]'
   scopes:
     - national
@@ -247,6 +247,8 @@ reporting_status:
   title: custom.reporting_status_title
   description: custom.reporting_status_description
   disaggregation_tabs: true
+repository_url_data: https://github.com/open-sdg/open-sdg
+repository_url_site: https://github.com/open-sdg/open-sdg
 search_index_boost: []
 search_index_extra_fields:
   - un_custodian_agency
@@ -266,7 +268,7 @@ site_config_form:
         - goal
         - goal-by-target
         - goal-by-target-vertical
-  repository_link: ''
+  repository_link: '/tree/master/tests/site/_data'
   translation_link: ''
 validate_indicator_config: true
 validate_site_config: true


### PR DESCRIPTION
This depends on https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/101

Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | NA
Related version | 1.4.0-dev
Bugfix, feature or docs? | docs
Keeps backward-compatibility? |✔️
Includes tests? |❌
Updated docs? |✔️
Updated config forms? |✔️
Added CHANGELOG entry? |❌

These 2 new config settings may be useful in the future for various purposes, but the immediate purpose is to allow for a smoother quickstart process. As we switch to using the config forms in the quickstart, we'll need to populate the "repository_link" settings, to enable the "Go to repository" links on the forms. This feature is critical to the user-friendliness of the forms, in my opinion.

With these new settings, a new user would only need to fill in these two URLs, and the four "repository_link" settings could be pre-filled so that they work out-of-the-box.

I'm working up a re-write of the quickstart that will show an example.
