### PR TITLE
Quick start revamp 1.4.0

### DIFF
--- a/docs/automation/github.md
+++ b/docs/automation/github.md
@@ -4,6 +4,22 @@ Whatever service you choose for automation, you will need to enable the "hooks" 
 
 The procedure is the same for both the site repository and the data repository:
 
+First you will need to have created any pull request and merged it. You can skip this part if you have already done created a pull request and merged it in both repositories.
+
+1. Go to the repository in GitHub.
+1. Go to any file in the repository, such as README.md, and click the pencil icon to edit it.
+1. Make any change to the file.
+1. Towards the bottom, select "Create a new branch for this commit and start a pull request."
+1. Beneath this, click "Propose changes".
+1. Click on the green "Create pull request" button.
+1. Wait a moment to see the message that says "Test PRs / test (pull_request) - in progress"
+1. Wait until you see "All checks have passed". This takes about 5 minutes.
+1. Click on the green "Merge pull request" button.
+
+Perform the steps above for both the site repository and the data repository.
+
+Next you can add the "branch protection rule" to require these tests to pass:
+
 1. Go to the repository in GitHub.
 1. Under the repository name, click "Settings".
 1. In the left sidebar, click "Branches".
@@ -11,6 +27,8 @@ The procedure is the same for both the site repository and the data repository:
 1. Under "Branch protection rules" click "Add rule"
 1. Under "Branch name pattern" enter `develop`
 1. Check the box "Require status checks to pass before merging"
-1. Under "Status checks found in the last week for this repository" check the appropriate box.
+1. In "Search for status checks in the last week for this repository" type "test" and select the "test" option.
 
-The last step above depends on your choice of automation service, but that is where you tell GitHub that some tests need to pass. Perform the steps above for both the site repository and the data repository.
+The last step above may be different depending on your choice of automation service, but that is where you tell GitHub that some tests need to pass.
+
+Perform the steps above for both the site repository and the data repository.

--- a/docs/automation/github.md
+++ b/docs/automation/github.md
@@ -4,7 +4,7 @@ Whatever service you choose for automation, you will need to enable the "hooks" 
 
 The procedure is the same for both the site repository and the data repository:
 
-First you will need to have created any pull request and merged it. You can skip this part if you have already done created a pull request and merged it in both repositories.
+First you will need to have created any pull request and merged it. You can skip this part if you have already created a pull request and merged it in both repositories.
 
 1. Go to the repository in GitHub.
 1. Go to any file in the repository, such as README.md, and click the pencil icon to edit it.

--- a/docs/automation/github.md
+++ b/docs/automation/github.md
@@ -4,6 +4,8 @@ Whatever service you choose for automation, you will need to enable the "hooks" 
 
 The procedure is the same for both the site repository and the data repository:
 
+## Initial pull-requests
+
 First you will need to have created any pull request and merged it. You can skip this part if you have already created a pull request and merged it in both repositories.
 
 1. Go to the repository in GitHub.
@@ -17,6 +19,8 @@ First you will need to have created any pull request and merged it. You can skip
 1. Click on the green "Merge pull request" button.
 
 Perform the steps above for both the site repository and the data repository.
+
+## Add branch protection rules
 
 Next you can add the "branch protection rule" to require these tests to pass:
 
@@ -32,3 +36,7 @@ Next you can add the "branch protection rule" to require these tests to pass:
 The last step above may be different depending on your choice of automation service, but that is where you tell GitHub that some tests need to pass.
 
 Perform the steps above for both the site repository and the data repository.
+
+## Results
+
+Now that you have set up these branch protection rules, any time a pull-request is created, the "Merge" button will be disabled until the pull-requests passed all tests. This helps avoid the possibility of a breaking change making it onto your site.

--- a/docs/automation/triggered-site-builds.md
+++ b/docs/automation/triggered-site-builds.md
@@ -1,24 +1,26 @@
 <h1>Triggered site builds</h1>
 
-When the site repository is separate from the data repository, there can be a long delay before changes to data appear on the site. This is because the change to the data only triggers a data rebuild, but the site will not change until it is rebuilt. Out of the box, site rebuilds only happen during the nightly build, and whenever a file in the site repository is changed.
+When the site repository is separate from the data repository, making a change to the data will *not* cause those changes to appear on the site. This is because the change to the data only triggers a data rebuild, but the site will not change until it is rebuilt. Out of the box, the only way to rebuild the site is to change a file in the site repository.
 
-This means that, in order to see their updated data on the site, data managers must either:
+This means that, in order to see their updated data on the site, data managers must change a site file to trigger a site build. To avoid this hassle, we recommend that you automate this process. There are two ways to automated the process:
 
-1. Wait until the next day, or
-1. Change a site file to trigger a site build
+1. Automatically trigger a site build when data changes
+2. Perform scheduled builds on a nightly basis
 
-To solve this problem, the following steps can be taken to set up an automatic site rebuild whenever the data changes.
+We recommend the first option. Both are detailed below.
 
-## Creating an access token
+## 1. Automatically trigger a site build when data changes
+
+### Creating an access token
 
 1. Create an access token described in [this official GitHub documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token). Notes:
     * Select the `repo` permission, as indicated in those instructions.
     * Save the token somewhere private.
 1. Copy the access token so that you can paste in the next steps.
 
-## Adding the access token as a "secret"
+### Adding the access token as a "secret"
 
-1. Go to the site repository.
+1. Go to the *site repository*.
 1. Under the repository name, click "Settings".
 1. In the left sidebar, click "Secrets".
 1. Click "New repository secret".
@@ -28,7 +30,7 @@ To solve this problem, the following steps can be taken to set up an automatic s
 
 Then repeat this for the data repository, as follows:
 
-1. Go to the data repository.
+1. Go to the *data repository*.
 1. Under the repository name, click "Settings".
 1. In the left sidebar, click "Secrets".
 1. Click "New repository secret".
@@ -36,12 +38,30 @@ Then repeat this for the data repository, as follows:
 1. Under "Value", paste in the access token you copied earlier.
 1. Click the green "Add secret" button.
 
-## Configuring the automatic rebuild
+### Configuring the automatic rebuild
 
-1. In the list of files in the data repository, click on `.github/workflows`.
+1. In the list of files in the *data repository*, click on `.github/workflows`.
 1. Click on `deploy-to-staging.yml`.
 1. Click the pencil to edit the file.
 1. Make changes to the file by following the instructions in the notes.
+1. Towards the right, click "Start commit"
+1. Select "Create a new branch for this commit and start a pull request."
+1. Beneath this, click "Propose changes".
+1. Click on the green "Create pull request" button.
+1. Wait a moment to see the message that says "Test PRs / test (pull_request) - in progress"
+1. Wait until you see "All checks have passed". This takes about 5 minutes.
+1. Click on the green "Merge pull request" button.
+
+## 2. Perform scheduled builds on a nightly basis
+
+Alternatively, you can instead set up scheduled nightly builds. This is easier to setup, but is not preferred, because of the 24 hour delay before changes become visible on the site.
+
+### Configuring the scheduled build
+
+1. In the list of files in the *site repository*, click on `.github/workflows`.
+1. Click on `deploy-to-staging.yml`.
+1. Click the pencil to edit the file.
+1. Uncomment the line that says `schedule:` and also uncomment the `cron` line below it. To "uncomment" a line simply remove the `#` character, making no other changes.
 1. Towards the right, click "Start commit"
 1. Select "Create a new branch for this commit and start a pull request."
 1. Beneath this, click "Propose changes".

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -46,9 +46,9 @@ You now have a working site and a working data service, however they are not yet
 1. From the previous step you should now be on your *site*. If not, go back there using your bookmark.
 1. In the footer menu at the bottom of any page, click "Configuration".
 1. Scroll down to the "Remote data prefix" setting.
-1. In this field, paste in the URL of your *data service* (which you bookmarked above).
+1. In this field, replacing what is already there, paste in the URL of your *data service* (which you bookmarked above).
 1. Continue down to the "Repository URL - Data" setting.
-1. In this field, paste in the URL of your *data repository* (which you bookmarked above).
+1. In this field, replacing what is already there, paste in the URL of your *data repository* (which you bookmarked above).
 1. Scroll to the top and press "Download configuration". You will receive a file download called "site_config.yml".
 1. Press "Go to repository".
 1. Upload the downloaded "site_config.yml" file by dragging it onto the page.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,63 +2,64 @@
 
 This document will go over the quickest way to get this platform up and running. Here we will choose the simplest approach for automation and hosting, which is to use GitHub. Note, however, that there are alternatives to this approach, as detailed under the Automation and Hosting sections.
 
-> #### Need a quicker quick start?
-> This document recommends a double-repository approach,
-> which separates your platform into a "site repository" and a "data repository".
-> This is a good practice in general, and provides several logistical benefits.
-> However, a simpler single-repository approach may be preferred if you just
-> want to try out Open SDG locally. In this case, see
-> the [open-sdg-simple-starter project](https://github.com/open-sdg/open-sdg-simple-starter).
-
 ## Signing up and creating repositories
 
 1. If you don't already have a Github.com account, [go to Github.com](https://github.com/) to sign up and then log in.
 1. Go to the [site starter](https://github.com/open-sdg/open-sdg-site-starter) and click the green "Use this template" button.
-1. Next you will be prompted to choose a name for your new repository. This will affect the URL at which you access the site later, so choose carefully. A suggestion might be: `sdg-site-australia` (adjusted for your country). Note that you can change this later if needed.
-1. Enter a description if you would like. Leave "Public" selected, check the "Include all branches" box, and click "Create repository from template".
-    * Bookmark the created repository -- this is your "__site repository__".
+1. You can enter any name for the repository. Here we recommend using "site".
+1. Leave "Public" selected. (**required**)
+1. Check the "Include all branches" box. (**required**)
+1. Click "Create repository from template".
+    * Bookmark the created repository -- this is your *site repository*.
 1. Go to the [data starter](https://github.com/open-sdg/open-sdg-data-starter) and click the green "Use this template" button.
-1. As before, choose a name. This one should refer to "data" instead of "site" (eg, `sdg-data-australia`). As before, leave "Public" selected, check the "Include all branches" box, and click "Create repository from template".
-    * Bookmark the created repository -- this is your "__data repository__".
+1. As before, you can enter any name for the repository. Here we recommend using "data".
+1. As before, leave "Public" selected. (**required**)
+1. As before, check the "Include all branches" box. (**required**)
+1. Click "Create repository from template".
+    * Bookmark the created repository -- this is your *data repository*.
 
-## Update the data repository configuration
+## Wait for the builds to complete
 
-This step is necessary before continuing, and also serves to demonstrate how to edit files on Github.com.
+At this point, both your site repository and your data repository will be performing automatic "builds". These take about 5 minutes to complete. You can monitor the progress in each repository by going to the "Actions" section under the repository name. When you see a green checkmark here, the build is complete.
 
-1. Go to the data repository.
-1. In the list of files, click on `config_data.yml`.
-1. Click the pencil icon on the right (You can find it next to the "Raw" and "Blame" buttons.)
-1. Add a new line at the top: `# This is a comment`
-1. Towards the bottom, select "Create a new branch for this commit and start a pull request."
-1. Beneath this, click "Propose changes".
-1. Click on the green "Create pull request" button.
-1. Wait a moment to see the message that says "Test PRs / test (pull_request) - in progress"
-1. Wait until you see "All checks have passed". This takes about 5 minutes.
-1. Click on the green "Merge pull request" button.
+## View the completed builds
 
-## Update the site repository configuration
+Once the builds are complete, you can view them, using the following steps:
 
-1. Go to the site repository.
-1. In the list of files, click on `_config.yml`.
-1. Click the pencil icon on the right (You can find it next to the "Raw" and "Blame" buttons.)
-1. Update the `baseurl` (line 8) according to the instructions above it. Note that the instructions refer to your **site** repository.
-1. Update the `remote_data_prefix` (line 12) according to the instruction above it. Note that the instructions refer to your **data** repository.
-1. Update the `data_edit_url` and `metadata_edit_url` (lines 16 and 18) according to the instructions above them.
-1. Towards the bottom, select "Create a new branch for this commit and start a pull request."
-1. Beneath this, click "Propose changes".
-1. Click on the green "Create pull request" button.
-1. Wait a moment to see the message that says "Test PRs / test (pull_request) - in progress"
-1. Wait until you see "All checks have passed". This takes about 5 minutes.
-1. Click on the green "Merge pull request" button.
-
-## View the site
-
-1. GitHub will now build and publish the site. Wait about 5 minutes.
-1. Go to the site repository.
+1. Go to the *data repository*.
 1. Under the repository name, click "Settings".
-1. Scroll down to the "GitHub Pages" section.
+1. In the sidebar, click on "Pages".
 1. You should see "Your site is published at" next to a link.
-1. Click that link to view your site.
+1. Click that link to view your data service.
+1. Bookmark this page -- this is your *data service*.
+1. Go to the *site repository*.
+1. Under the repository name, click "Settings".
+1. In the sidebar, click on "Pages".
+1. You should see "Your site is published at" next to a link.
+1. Click that link to view your data service.
+1. Bookmark this page -- this is your *site*.
+
+## Connect your site to your data service
+
+You now have a working site and a working data service, however they are not yet connected to each other. We need to tell the site where to find the data service.
+
+1. From the previous step you should now be on your *site*. If not, go back there using your bookmark.
+1. In the footer menu at the bottom of any page, click "Configuration".
+1. Scroll down to the "Remote data prefix" setting.
+1. In this field, paste in the URL of your *data service* (which you bookmarked above).
+1. Continue down to the "Repository URL - Data" setting.
+1. In this field, paste in the URL of your *data repository* (which you bookmarked above).
+1. Scroll to the top and press "Download configuration". You will receive a file download called "site_config.yml".
+1. Press "Go to repository".
+1. Upload the downloaded "site_config.yml" file by dragging it onto the page.
+1. Scroll down and press "Commit changes".
+
+## Recommended
+
+To help with maintenance of your implementation, the following automation is *strongly* recommended:
+
+1. [Protection from breaking changes](automation/github.md)
+1. [Triggered site builds](automation/triggered-site-builds.md)
 
 ## Next steps
 
@@ -70,13 +71,6 @@ To get started with customising your implementation of Open SDG, try any of thes
 1. [Adding languages](tutorials/add-language.md)
 1. [Changing colors](tutorials/change-colors.md)
 1. [Changing the site-wide banner](tutorials/change-banner.md)
-
-## Maintenance
-
-To help with maintenance of your implementation, the following automation is recommended:
-
-1. [Protection from breaking changes](automation/github.md)
-1. [Triggered site builds](automation/triggered-site-builds.md)
 
 ## Troubleshooting
 

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -23,7 +23,7 @@ country:
   name: Australia
   adjective: Australian
 create_goals:
-  layout: goal
+  layout: goal-by-target-vertical
   previous_next_links: true
   goals:
     - content: custom.goal_1_content

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -23,7 +23,7 @@ country:
   name: Australia
   adjective: Australian
 create_goals:
-  layout: goal-by-target-vertical
+  layout: goal
   previous_next_links: true
   goals:
     - content: custom.goal_1_content


### PR DESCRIPTION
These are documentation updates to get a simpler quickstart. These depend on two other PRs:
* https://github.com/open-sdg/open-sdg-site-starter/pull/75
* https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/102

Since there a lot of changes here are links directly to the new versions of the 3 files:
* https://github.com/brockfanning/open-sdg/blob/quick-start-revamp-1-4-0/docs/quick-start.md
* https://github.com/brockfanning/open-sdg/blob/quick-start-revamp-1-4-0/docs/automation/github.md
* https://github.com/brockfanning/open-sdg/blob/quick-start-revamp-1-4-0/docs/automation/triggered-site-builds.md