### PR TITLE
Add slash after 'search' in URL

### DIFF
--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,5 +1,5 @@
 <div id="{{ include.id | default: 'search' }}" {% unless include.not_in_menu %}class="menu-target"{% endunless %}>
-  <form action="{{ page.baseurl }}search">
+  <form action="{{ page.baseurl }}search/">
     <label class="sr-only" for="indicator_{{ include.id | default: 'search' }}">{{ page.t.search.search }}</label>
     <input type="text" name="q" id="indicator_{{ include.id | default: 'search' }}" title="{{ page.t.search.search }}" /><!--
     --><button aria-label="{{ page.t.search.search }}" id="{{ include.id | default: 'search' }}-btn" type="submit"><i class="fa fa-search" aria-hidden="false"></i></button>


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](https://1-4-0-site.github.io/)
Fixed issues | Fixes #1254 
Related version | 1.4.0-dev
Bugfix, feature or docs? |
Keeps backward-compatibility? |❌/✔️
Includes tests? |❌/✔️
Updated docs? |❌/✔️
Updated config forms? |❌/✔️
Added CHANGELOG entry? |❌/✔️
