### PR TITLE
Not applicable - white background on goal pages

### DIFF
--- a/_includes/components/reportingstatus/reporting-status-label.html
+++ b/_includes/components/reportingstatus/reporting-status-label.html
@@ -11,5 +11,5 @@
 {% endcase %}
 
 <span class="status {{ status_css }}">
-    {{ status_desc }}
+    <span class="status-inner">{{ status_desc }}</span>
 </span>

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -13,40 +13,81 @@
   padding: 4px;
   font-size: 12px;
 
+  .status-inner {
+    padding: 0 2px;
+    border-radius: 5px;
+  }
+
   &.complete {
     color: $status-color-complete;
     border: $status-border-complete;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-complete;
+    }
   }
   &.inprogress{
     color: $status-color-inprogress;
     border: $status-border-inprogress;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-inprogress;
+    }
   }
   &.notstarted {
     color: $status-color-notstarted;
     border: $status-border-notstarted;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-notstarted;
+    }
   }
   &.notapplicable {
     color: $status-color-notapplicable;
     border: $status-border-notapplicable;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-notapplicable;
+    }
   }
 }
 
 @mixin statusHighContrast {
   &.complete {
-    color: $status-color-complete-highContrast;
     border: $status-border-complete-highContrast;
+    background-color: $status-backgroundColor-complete-highContrast;
+    background: $status-backgroundColor-complete-highContrast;
+    color: $status-color-complete-highContrast !important;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-complete-highContrast !important;
+      color: $status-color-complete-highContrast !important;
+    }
   }
   &.inprogress{
-    color: $status-color-inprogress-highContrast;
     border: $status-border-inprogress-highContrast;
+    background-color: $status-backgroundColor-inprogress-highContrast;
+    background: $status-backgroundColor-inprogress-highContrast;
+    color: $status-color-inprogress-highContrast;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-inprogress-highContrast !important;
+      color: $status-color-inprogress-highContrast;
+    }
   }
   &.notstarted {
-    color: $status-color-notstarted-highContrast;
     border: $status-border-notstarted-highContrast;
+    background-color: $status-backgroundColor-notstarted-highContrast;
+    background: $status-backgroundColor-notstarted-highContrast;
+    color: $status-color-notstarted-highContrast !important;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-notstarted-highContrast !important;
+      color: $status-color-notstarted-highContrast !important;
+    }
   }
   &.notapplicable {
-    color: $status-color-notapplicable-highContrast;
     border: $status-border-notapplicable-highContrast;
+    background-color: $status-backgroundColor-notapplicable-highContrast;
+    background: $status-backgroundColor-notapplicable-highContrast;
+    color: $status-color-notapplicable-highContrast !important;
+    .status-inner {
+      background-color: $status-backgroundColor-inner-notapplicable-highContrast !important;
+      color: $status-color-notapplicable-highContrast !important;
+    }
   }
 }
 
@@ -77,7 +118,7 @@
 
     .indicator-card-number,
     // @deprecated start
-    span:not(.tags):not(.tag):not(.sr-only) {
+    span:not(.tags):not(.tag):not(.sr-only):not(.status-inner) {
     // @deprecated end (use .indicator-card-number instead)
       display: block;
       margin-bottom: 0.5rem;

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -6,7 +6,7 @@
     padding-bottom: 30px;
     &.goal-indicators {
       div {
-        span {
+        span:not(.status-inner) {
           border-color: $dark-c;
           color: $dark-c;
         }

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -33,6 +33,7 @@
       margin-right: 10px;
 
       .status {
+        @include status;
         display: inline-block;
         margin-right: 3px;
         padding: 2px 5px;
@@ -45,35 +46,6 @@
         .status-inner {
           padding: 0 2px;
           border-radius: 5px;
-        }
-
-        &.complete {
-          border: $status-border-complete;
-          color: $status-color-complete;
-          .status-inner {
-            background-color: $status-backgroundColor-inner-complete;
-          }
-        }
-        &.inprogress {
-          border: $status-border-inprogress;
-          color: $status-color-inprogress;
-          .status-inner {
-            background-color: $status-backgroundColor-inner-inprogress;
-          }
-        }
-        &.notstarted {
-          border: $status-border-notstarted;
-          color: $status-color-notstarted;
-          .status-inner {
-            background-color: $status-backgroundColor-inner-notstarted;
-          }
-        }
-        &.notapplicable {
-          border: $status-border-notapplicable;
-          color: $status-color-notapplicable;
-          .status-inner {
-            background-color: $status-backgroundColor-inner-notapplicable;
-          }
         }
       }
     }
@@ -186,44 +158,20 @@ body.contrast-high {
     border: $status-border-notstarted-highContrast !important;
   }
 
-  .complete{
-    background-color: $status-backgroundColor-complete-highContrast;
-    background: $status-backgroundColor-complete-highContrast;
-    color: $status-color-complete-highContrast !important;
-    .status-inner {
-      background-color: $status-backgroundColor-inner-complete-highContrast !important;
-      color: $status-color-complete-highContrast !important;
-    }
+  .complete {
+    @include statusHighContrast;
   }
 
   .inprogress{
-    background-color: $status-backgroundColor-inprogress-highContrast;
-    background: $status-backgroundColor-inprogress-highContrast;
-    color: $status-color-inprogress-highContrast;
-    .status-inner {
-      background-color: $status-backgroundColor-inner-inprogress-highContrast !important;
-      color: $status-color-inprogress-highContrast;
-    }
+    @include statusHighContrast;
   }
 
   .notstarted {
-    background-color: $status-backgroundColor-notstarted-highContrast;
-    background: $status-backgroundColor-notstarted-highContrast;
-    color: $status-color-notstarted-highContrast !important;
-    .status-inner {
-      background-color: $status-backgroundColor-inner-notstarted-highContrast !important;
-      color: $status-color-notstarted-highContrast !important;
-    }
+    @include statusHighContrast;
   }
 
   .notapplicable{
-    background-color: $status-backgroundColor-notapplicable-highContrast;
-    background: $status-backgroundColor-notapplicable-highContrast;
-    color: $status-color-notapplicable-highContrast !important;
-    .status-inner {
-      background-color: $status-backgroundColor-inner-notapplicable-highContrast !important;
-      color: $status-color-notapplicable-highContrast !important;
-    }
+    @include statusHighContrast;
   }
 
   .reporting-status-description {

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -160,22 +160,27 @@ body.contrast-high {
 
   .complete {
     @include statusHighContrast;
+    border: none !important;
   }
 
   .inprogress{
     @include statusHighContrast;
+    border: none !important;
   }
 
   .notstarted {
     @include statusHighContrast;
+    border: none !important;
   }
 
   .notapplicable{
     @include statusHighContrast;
+    border: none !important;
   }
 
   .reporting-status-description {
     color: $color-light-highContrast;
+    border: none !important;
   }
 
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link (goal-by-target-vertical)](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-na-style/1/)<br>[Link (goal-by-target)](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-na-goal-by-target/reporting-status/)<br>[Link (goal)](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-na-goal/1/)
Fixed issues | Fixes #1239 
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Disclaimer: Our styles for these elements are kind of a mess. I've tried to clean things up a little in this PR. But this means that I may have broken something else, so I think that this should be tested with a critical eye towards anything that involves the status types:

* goal layout
* goal-by-target layout
* goal-by-target-vertical layout
* reporting-status page

And both normal and high contrast needs to be tested.