### PR TITLE
Another status style refactor and post category fixes

### DIFF
--- a/_includes/components/post/post-listing.html
+++ b/_includes/components/post/post-listing.html
@@ -10,18 +10,18 @@
     </div>
     {% if post.categories %}
     <ul class="post-categories small-text">
-        {% for category in post.categories %}
+        {%- for category in post.categories -%}
         <li>
-            {% if include.category_links %}
+            {%- if include.category_links -%}
                 {% assign category_translated = category | t %}
                 <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">
-            {% endif %}
+            {%- endif -%}
             {{ category | t }}
-            {% if include.category_links %}
+            {%- if include.category_links -%}
                 </a>
-            {% endif %}
+            {%- endif -%}
         </li>
-        {% endfor %}
+        {%- endfor -%}
     </ul>
     {% endif %}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,28 +15,29 @@ layout: default
     <div class="{% if category_links %}col-md-9 push-md-3{% else %}col-md-12{% endif %}">
       <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
         <h1 class="post-title" itemprop="name headline">{{ page.title | t }}</h1>
-        <p><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | t_date: "standard" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+        <div class="post-header">
+          <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | t_date: "standard" }}</time>
+          {%- if page.categories -%}
+          <ul class="post-categories">
+          {%- for category in page.categories -%}
+            <li>
+            {%- if category_links -%}
+            {%- assign category_translated = category | t -%}
+            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">
+            {%- endif -%}
+            {{ category | t }}{%- if category_links -%}</a>{%- endif -%}
+            </li>
+          {%- endfor -%}
+          </ul>
+          {%- endif -%}
+          {%- if page.author -%}
+          <span class="post-author" itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>
+          {%- endif -%}
+        </div>
 
         <div class="post-content" itemprop="articleBody">
           {{ content }}
         </div>
-
-        {% if page.categories %}
-        <ul class="post-categories small-text">
-          {% for category in page.categories %}
-          <li>
-            {% if category_links %}
-            {% assign category_translated = category | t %}
-            <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">
-            {% endif %}
-            {{ category | t }}
-            {% if category_links %}
-            </a>
-            {% endif %}
-          </li>
-          {% endfor %}
-        </ul>
-        {% endif %}
       </article>
     </div>
     {% if category_links %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,9 +22,9 @@ layout: default
         </div>
 
         {% if page.categories %}
-        <ul class="post-categories">
+        <ul class="post-categories small-text">
           {% for category in page.categories %}
-          <li class="warning">
+          <li>
             {% if category_links %}
             {% assign category_translated = category | t %}
             <a href="{{ page.baseurl }}categories/#{{ category | slugize }}" title="{{ page.t.post.view_all_in_category | replace_first: '%category_name', category_translated }}">

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -117,7 +117,24 @@
     border: $tag-border;
     background: $tag-backgroundColor;
     white-space: nowrap;
+    a {
+      color: $tag-color;
+      text-decoration: underline;
+    }
   }
+}
+
+@mixin postCategories {
+  padding-left: 0;
+  list-style-type: none;
+  li {
+    display: inline-block;
+    margin-right: 20px;
+  }
+}
+
+@mixin postCategoriesHighContrast {
+  @include postCategories;
 }
 
 @mixin indicatorcards {

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -129,7 +129,14 @@
   list-style-type: none;
   li {
     display: inline-block;
-    margin-right: 20px;
+    &:after {
+      content: ',';
+      padding-right: 1ch;
+    }
+    &:last-child:after {
+      content: '';
+      padding-right: 0;
+    }
   }
 }
 

--- a/_sass/base/_mixins.scss
+++ b/_sass/base/_mixins.scss
@@ -21,29 +21,43 @@
   &.complete {
     color: $status-color-complete;
     border: $status-border-complete;
+    // Both background-color and background are included to allow the
+    // use of patterns.
+    background-color: $status-backgroundColor-complete;
+    background: $status-backgroundColor-complete;
     .status-inner {
       background-color: $status-backgroundColor-inner-complete;
+      background: $status-backgroundColor-inner-complete;
     }
   }
   &.inprogress{
     color: $status-color-inprogress;
     border: $status-border-inprogress;
+    background-color: $status-backgroundColor-inprogress;
+    background: $status-backgroundColor-inprogress;
     .status-inner {
       background-color: $status-backgroundColor-inner-inprogress;
+      background: $status-backgroundColor-inner-inprogress;
     }
   }
   &.notstarted {
     color: $status-color-notstarted;
     border: $status-border-notstarted;
+    background-color: $status-backgroundColor-notstarted;
+    background: $status-backgroundColor-notstarted;
     .status-inner {
       background-color: $status-backgroundColor-inner-notstarted;
+      background: $status-backgroundColor-inner-notstarted;
     }
   }
   &.notapplicable {
     color: $status-color-notapplicable;
     border: $status-border-notapplicable;
+    background-color: $status-backgroundColor-notapplicable;
+    background: $status-backgroundColor-notapplicable;
     .status-inner {
       background-color: $status-backgroundColor-inner-notapplicable;
+      background: $status-backgroundColor-inner-notapplicable;
     }
   }
 }
@@ -56,6 +70,7 @@
     color: $status-color-complete-highContrast !important;
     .status-inner {
       background-color: $status-backgroundColor-inner-complete-highContrast !important;
+      background: $status-backgroundColor-inner-complete-highContrast !important;
       color: $status-color-complete-highContrast !important;
     }
   }
@@ -66,6 +81,7 @@
     color: $status-color-inprogress-highContrast;
     .status-inner {
       background-color: $status-backgroundColor-inner-inprogress-highContrast !important;
+      background: $status-backgroundColor-inner-inprogress-highContrast !important;
       color: $status-color-inprogress-highContrast;
     }
   }
@@ -76,6 +92,7 @@
     color: $status-color-notstarted-highContrast !important;
     .status-inner {
       background-color: $status-backgroundColor-inner-notstarted-highContrast !important;
+      background: $status-backgroundColor-inner-notstarted-highContrast !important;
       color: $status-color-notstarted-highContrast !important;
     }
   }
@@ -86,6 +103,7 @@
     color: $status-color-notapplicable-highContrast !important;
     .status-inner {
       background-color: $status-backgroundColor-inner-notapplicable-highContrast !important;
+      background: $status-backgroundColor-inner-notapplicable-highContrast !important;
       color: $status-color-notapplicable-highContrast !important;
     }
   }
@@ -146,6 +164,20 @@
       display: inline;
       font-weight: normal;
       border-bottom: none;
+    }
+  }
+}
+
+@mixin indicatorcardsHighContrast {
+  .indicator-cards {
+    .indicator-card-number,
+    // @deprecated start
+    span:not(.tags):not(.tag):not(.sr-only):not(.status-inner) {
+    // @deprecated end (use .indicator-card-number instead)
+
+      &.status {
+        @include statusHighContrast;
+      }
     }
   }
 }

--- a/_sass/components/_goal_tiles.scss
+++ b/_sass/components/_goal_tiles.scss
@@ -6,7 +6,7 @@
     padding-bottom: 30px;
     &.goal-indicators {
       div {
-        span:not(.status-inner) {
+        span:not(.status-inner):not(.indicator-card-number) {
           border-color: $dark-c;
           color: $dark-c;
         }

--- a/_sass/layouts/_goal-by-target-vertical.scss
+++ b/_sass/layouts/_goal-by-target-vertical.scss
@@ -1,6 +1,10 @@
 $goal-by-target-indentation: 60px;
 
 .layout-goal-by-target-vertical {
+  #page-content {
+    margin-top: -20px;
+    margin-bottom: 10px;
+  }
   .goal-target, .goal-indicator {
     font-size: 16px;
     font-weight: normal;

--- a/_sass/layouts/_goal-by-target.scss
+++ b/_sass/layouts/_goal-by-target.scss
@@ -9,6 +9,10 @@
 // @deprecated end
 
 .layout-goal-by-target {
+  #page-content {
+    margin-top: -20px;
+    margin-bottom: 10px;
+  }
   .tags {
     margin-top: 10px;
     display: inline-block;

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -1,11 +1,8 @@
-.layout-goal, .layout-goal-by-target, .layout-goal-by-target-vertical {
+.layout-goal {
   #page-content {
     margin-top: -20px;
     margin-bottom: 10px;
   }
-}
-
-.layout-goal {
   .tags {
     display: inline-block;
     margin-top: 0;
@@ -15,43 +12,11 @@
   .indicator-placeholder-wrapper {
     padding: 1rem;
   }
-}
 
-body.contrast-high {
-  .goal-indicators {
-    div {
-      span {
-        border-color: $color-light-highContrast !important;
-        color: $color-light-highContrast !important;
-      }
+  &.contrast-high {
+    .status {
+      color: pink !important;
+      @include statusHighContrast;
     }
-    .indicator-cards {
-      &.target {
-        color: $color-light-highContrast !important;
-      }
-      span.status, .tags .tag {
-        color: $color-dark-highContrast !important;
-      }
-
-      span.status{
-        &.complete,
-        &.notapplicable{
-          color: $color-dark-highContrast !important;
-        }
-
-        &.notstarted,
-        &.inprogress{
-          color: $color-dark-highContrast !important;
-        }
-      }
-
-      span.status.notstarted{
-        color: $color-light-highContrast !important;
-        border: 1px solid $color-light-highContrast !important;
-      }
-    }
-  }
-  #main-content.goal-indicators.goal-by-target .indicator-cards a{
-    color: $color-highlight-highContrast;
   }
 }

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -568,6 +568,10 @@ body.contrast-high {
   #dataset-size-warning {
     color: $color-dark-highContrast;
   }
+
+  #main-content.goal-indicators {
+    @include indicatorcardsHighContrast;
+  }
 }
 
 .layout-indicator {

--- a/_sass/layouts/_news.scss
+++ b/_sass/layouts/_news.scss
@@ -4,11 +4,7 @@
     margin-bottom: 25px;
 
     .post-categories {
-      list-style-type: none;
-      li {
-        display: inline-block;
-        margin-right: 20px;
-      }
+      @include postCategories;
     }
 
     .post-title {
@@ -19,6 +15,12 @@
     .post-date {
       float: left;
       margin-right: 40px;
+    }
+  }
+
+  &.contrast-high {
+    .post-categories {
+      @include postCategoriesHighContrast;
     }
   }
 }

--- a/_sass/layouts/_post.scss
+++ b/_sass/layouts/_post.scss
@@ -1,0 +1,11 @@
+.layout-post {
+  .post-categories {
+    @include postCategories;
+  }
+
+  &.contrast-high {
+    .post-categories {
+      @include postCategoriesHighContrast;
+    }
+  }
+}

--- a/_sass/layouts/_post.scss
+++ b/_sass/layouts/_post.scss
@@ -1,6 +1,18 @@
 .layout-post {
+  .post-header {
+    margin-bottom: 20px;
+  }
   .post-categories {
     @include postCategories;
+    display: inline;
+  }
+
+  .post-categories, .post-author {
+    &:before {
+      content: '\2022';
+      padding-left: 10px;
+      padding-right: 10px;
+    }
   }
 
   &.contrast-high {

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -2,185 +2,179 @@
   .reporting-status-description {
     margin-bottom: 25px;
   }
-}
 
-.notapplicable {
-  background-color: $status-backgroundColor-notapplicable;
-  background: $status-backgroundColor-notapplicable;
-}
-.notstarted {
-  background-color: $status-backgroundColor-notstarted;
-  background: $status-backgroundColor-notstarted;
-}
-.inprogress {
-  background-color: $status-backgroundColor-inprogress;
-  background: $status-backgroundColor-inprogress;
-}
-.complete  {
-  background-color: $status-backgroundColor-complete;
-  background: $status-backgroundColor-complete;
-}
+  #main-content {
+    .statuses {
 
-#main-content {
-  .statuses {
-
-    strong {
-      font-weight: normal;
-    }
-    > div {
-      display: inline-block;
-      margin-bottom: 5px;
-      margin-right: 10px;
-
-      .status {
-        @include status;
+      strong {
+        font-weight: normal;
+      }
+      > div {
         display: inline-block;
-        margin-right: 3px;
-        padding: 2px 5px;
-        border-radius: 4px;
+        margin-bottom: 5px;
+        margin-right: 10px;
 
-        width: 40px;
-        text-align: center;
+        .status {
+          @include status;
+          display: inline-block;
+          margin-right: 3px;
+          padding: 2px 5px;
+          border-radius: 4px;
+
+          width: 40px;
+          text-align: center;
+          font-size: 16px;
+
+          .status-inner {
+            padding: 0 2px;
+            border-radius: 5px;
+          }
+        }
+      }
+    }
+    .value {
+      color: $text-color;
+      font-weight: bold;
+      margin-left: 3px;
+    }
+    .goal-stats {
+      @include preserveOriginalColors;
+      border: 1px solid $color-dark;
+      font-size: 0;
+      margin-top:10px;
+      & span {
+        display: inline-block;
+        height: 10px;
+        font-weight: bold;
+      }
+      .notapplicable {
+        background-color: $status-backgroundColor-notapplicable;
+        background: $status-backgroundColor-notapplicable;
+      }
+      .notstarted {
+        background-color: $status-backgroundColor-notstarted;
+        background: $status-backgroundColor-notstarted;
+      }
+      .inprogress {
+        background-color: $status-backgroundColor-inprogress;
+        background: $status-backgroundColor-inprogress;
+      }
+      .complete {
+        background-color: $status-backgroundColor-complete;
+        background: $status-backgroundColor-complete;
+      }
+    }
+    .divider {
+      height: 15px;
+    }
+    .goal {
+      clear: left;
+      margin-bottom: 4px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid $horizontalRule-color;
+      .total {
+        line-height: 1.2;
         font-size: 16px;
+        width: auto;
+        padding-left: 4px;
+        padding-right: 4px;
+        text-align: center;
+        display: inline-block;
+        margin-bottom: 10px;
+        border-radius: 4px;
+        border: 1px solid $horizontalRule-color;
+        @media screen and (min-width: 520px) {
+          margin-left: 10px;
+        }
+      }
+    }
+    .frame {
+      width: 115px;
+      float: left;
+      min-height: 1px;
+      > a:focus {
+        outline: 6px $focusOutlineColor solid !important;
+      }
+    }
+    .details {
+      width: calc(100% - 125px);
+      float: left;
+      h2 {
+        @media screen and (min-width: 520px) {
+          display: inline-block;
+        }
+      }
+      h3 {
+        margin-top: 10px;
+        @media screen and (min-width: 520px) {
+          display: inline-block;
+        }
+        @media only screen and (max-width: 720px) {
+          margin-top: 3px;
+        }
+        @media only screen and (max-width: 520px) {
+          margin-bottom: 3px;
+        }
+        line-height: 1.2;
+      }
+    }
+    [data-extra-field] {
+      .details {
+        width: 100%;
+      }
+    }
+    .goal-overall {
+      margin-bottom: 20px;
 
-        .status-inner {
-          padding: 0 2px;
-          border-radius: 5px;
+      .details {
+        width: 100%;
+      }
+    }
+  }
+
+  #main-content .reporting-status-item {
+    margin-bottom: 20px;
+  }
+
+  &.contrast-high {
+
+    #main-content {
+
+      .goal-stats{
+        border: 1px solid $color-light-highContrast !important;
+        .notapplicable {
+          background-color: $status-backgroundColor-notapplicable-highContrast;
+          background: $status-backgroundColor-notapplicable-highContrast;
+        }
+        .notstarted {
+          background-color: $status-backgroundColor-notstarted-highContrast;
+          background: $status-backgroundColor-notstarted-highContrast;
+        }
+        .inprogress {
+          background-color: $status-backgroundColor-inprogress-highContrast;
+          background: $status-backgroundColor-inprogress-highContrast;
+        }
+        .complete {
+          background-color: $status-backgroundColor-complete-highContrast;
+          background: $status-backgroundColor-complete-highContrast;
+        }
+      }
+
+      .statuses {
+        strong {
+          color: $color-light-highContrast;
+        }
+        .value {
+          color: $color-light-highContrast !important;
+        }
+        .status {
+          @include statusHighContrast;
+          border: none !important;
+          &.notstarted {
+            border: $status-border-notstarted-highContrast !important;
+          }
         }
       }
     }
   }
-  .value {
-    color: $text-color;
-    font-weight: bold;
-    margin-left: 3px;
-  }
-  .goal-stats {
-    @include preserveOriginalColors;
-    border: 1px solid $color-dark;
-    font-size: 0;
-    margin-top:10px;
-    & span {
-      display: inline-block;
-      height: 10px;
-      font-weight: bold;
-    }
-  }
-  .divider {
-    height: 15px;
-  }
-  .goal {
-    clear: left;
-    margin-bottom: 4px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid $horizontalRule-color;
-    .total {
-       line-height: 1.2;
-       font-size: 16px;
-       width: auto;
-       padding-left: 4px;
-       padding-right: 4px;
-       text-align: center;
-       display: inline-block;
-       margin-bottom: 10px;
-       border-radius: 4px;
-       border: 1px solid $horizontalRule-color;
-       @media screen and (min-width: 520px) {
-         margin-left: 10px;
-       }
-    }
-  }
-  .frame {
-    width: 115px;
-    float: left;
-    min-height: 1px;
-    > a:focus {
-      outline: 6px $focusOutlineColor solid !important;
-    }
-  }
-  .details {
-    width: calc(100% - 125px);
-    float: left;
-    h2 {
-      @media screen and (min-width: 520px) {
-        display: inline-block;
-      }
-    }
-    h3 {
-      margin-top: 10px;
-      @media screen and (min-width: 520px) {
-        display: inline-block;
-      }
-      @media only screen and (max-width: 720px) {
-        margin-top: 3px;
-      }
-      @media only screen and (max-width: 520px) {
-        margin-bottom: 3px;
-      }
-      line-height: 1.2;
-    }
-  }
-  [data-extra-field] {
-    .details {
-      width: 100%;
-    }
-  }
-  .goal-overall {
-    margin-bottom: 20px;
-
-    .details {
-      width: 100%;
-    }
-  }
-}
-
-#main-content .reporting-status-item {
-  margin-bottom: 20px;
-}
-
-body.contrast-high {
-
-  .goal-stats{
-    border: 1px solid $color-light-highContrast !important;
-  }
-
-  .statuses {
-    strong {
-      color: $color-light-highContrast;
-    }
-    .value {
-      color: $color-light-highContrast !important;
-    }
-
-  }
-
-  .summary .statuses .notstarted{
-    border: $status-border-notstarted-highContrast !important;
-  }
-
-  .complete {
-    @include statusHighContrast;
-    border: none !important;
-  }
-
-  .inprogress{
-    @include statusHighContrast;
-    border: none !important;
-  }
-
-  .notstarted {
-    @include statusHighContrast;
-    border: none !important;
-  }
-
-  .notapplicable{
-    @include statusHighContrast;
-    border: none !important;
-  }
-
-  .reporting-status-description {
-    color: $color-light-highContrast;
-    border: none !important;
-  }
-
 }

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -43,3 +43,4 @@
 @import "layouts/goals";
 @import "layouts/config_bulder";
 @import "layouts/data_editor";
+@import "layouts/post";

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -63,7 +63,7 @@ $status-backgroundColor-notapplicable-highContrast: $status-backgroundColor-nota
 $status-backgroundColor-inner-complete-highContrast: $status-backgroundColor-complete-highContrast !default;
 $status-backgroundColor-inner-inprogress-highContrast: $status-backgroundColor-inprogress-highContrast !default;
 $status-backgroundColor-inner-notstarted-highContrast: $status-backgroundColor-notstarted-highContrast !default;
-$status-backgroundColor-inner-notapplicable-highContrast: $status-backgroundColor-notapplicable-highContrast !default;
+$status-backgroundColor-inner-notapplicable-highContrast: $status-backgroundColor-inner-notapplicable !default;
 
 $status-border-complete: 1px solid transparent !default;
 $status-border-inprogress: 1px solid transparent !default;


### PR DESCRIPTION
Fixes #1325 
Fixes #1326 

Q | A
--- | ---
Feature branch/test site URL | [goal-by-target-vertical](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-status-style-revamp-take-2/)</br>[goal-by-target](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-status-style-revamp-take-2-goal-by-target/)</br>[goal](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-status-style-revamp-take-2-goal/)
Fixed issues | Fixes #1325 and #1326
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This is a further revamp of the status styles. I think there is way more we could do, but it would be too much for now. To test this thoroughly, I would recommend 3 separate feature branches, with all three types of goal pages:

```
create_goals:
  layout: goal
```

```
create_goals:
  layout: goal-by-target
```

```
create_goals:
  layout: goal-by-target-vertical
```

And ideally the data would have examples of all four status types:
* notstarted
* complete
* inprogress
* notapplicable

I'm also bundling in with this PR a fix for the issue about the post categories, #1326 