### PR TITLE
Add setting for favicons to default to legacy

### DIFF
--- a/_includes/components/favicons.html
+++ b/_includes/components/favicons.html
@@ -1,4 +1,15 @@
+{% assign use_favicon_io = true %}
+{% comment %}@deprecated start{% endcomment %}
+{% if site.favicons != 'favicon.io' %}
+    {% assign use_favicon_io = false %}
+{% endif %}
+{% comment %}@deprecated end{% endcomment %}
+{% if use_favicon_io %}
 <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/img/favicons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/assets/img/favicons/favicon-16x16.png">
 <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/assets/img/favicons/favicon.ico" />
+{% else %}
+<link rel="shortcut icon" type="image/ico" href="{{ site.baseurl }}/assets/img/favicons/favicon.ico">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/img/favicons/favicon.png">
+{% endif %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,6 +326,14 @@ email_contacts:
 environment: staging
 ```
 
+### favicons
+
+_Optional_: This setting controls the favicon markup. Possible settings are `legacy` and `favicon.io`. We recommend using `favicon.io` and will default to this in the future. But currently the default is `legacy` if omitted.
+
+```nohighlight
+favicons: favicon.io
+```
+
 ### footer_language_toggle
 
 _Optional_: This setting controls the type of language toggle to be used in the footer. Possible settings are `dropdown`, `links`, and `none`. If this is omitted, the default is `none`.


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-1.5.0-beta1/)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [x] Updated docs
* [x] Updated config forms
* [ ] Added CHANGELOG entry

This is to avoid a breaking change. We'll have the starter repos use the `favicon.io` setting, even though the default will be `legacy` so that existing sites' favicons don't break.

Corresponding PR for the config setting: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/111
