### PR TITLE
Google Analytics cookies: _ga instead of ga

### DIFF
--- a/_includes/cookies-config.js
+++ b/_includes/cookies-config.js
@@ -45,9 +45,9 @@ var klaroConfig = {
             default: false,
             purposes: ['analytics'],
             {% if site.analytics.extra_cookies %}
-            cookies: [].concat(['_gat', '_gid', 'ga'], {{ site.analytics.extra_cookies | jsonify }}),
+            cookies: [].concat(['_gat', '_gid', '_ga'], {{ site.analytics.extra_cookies | jsonify }}),
             {% else %}
-            cookies: ['_gat', '_gid', 'ga'],
+            cookies: ['_gat', '_gid', '_ga'],
             {% endif %}
             required: false,
             optOut: false,

--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -1,3 +1,3 @@
 # These are the Python requirements for building the data.
 git+git://github.com/dougmet/yamlmd
-git+git://github.com/open-sdg/sdg-build@1.5.0-dev
+git+git://github.com/open-sdg/sdg-build@1.6.0-dev

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '1.5.0-dev'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '1.6.0-dev'


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

For the Google Analytics cookies, I believe that it should be "_ga" instead of "ga", judging from https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage