### PR TITLE
Google Analytics: _ga instead of ga

### DIFF
--- a/_includes/cookies-config.js
+++ b/_includes/cookies-config.js
@@ -45,9 +45,9 @@ var klaroConfig = {
             default: false,
             purposes: ['analytics'],
             {% if site.analytics.extra_cookies %}
-            cookies: [].concat(['_gat', '_gid', 'ga'], {{ site.analytics.extra_cookies | jsonify }}),
+            cookies: [].concat(['_gat', '_gid', '_ga'], {{ site.analytics.extra_cookies | jsonify }}),
             {% else %}
-            cookies: ['_gat', '_gid', 'ga'],
+            cookies: ['_gat', '_gid', '_ga'],
             {% endif %}
             required: false,
             optOut: false,


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.5.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

For Google Analytics cookies, I believe that it should be "_ga" instead of "ga", judging from: https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage