### PR TITLE
New approach for sorting hierarchical fields, based on top-level parents

### DIFF
--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -186,25 +186,56 @@ function sortFieldsForView(fieldItemStates, edges) {
 
     // We need to sort the edges so that we process parents before children.
     var parents = edges.map(function(edge) { return edge.From; });
-    edges.sort(function(a, b) {
-      if (!parents.includes(a.To) && parents.includes(b.To)) {
-        return 1;
-      }
-      if (!parents.includes(b.To) && parents.includes(a.To)) {
-        return -1;
-      }
-      return 0;
+    var children = edges.map(function(edge) { return edge.To; });
+    var topLevelParents = parents.filter(function(parent) {
+      return !(children.includes(parent));
     });
 
-    edges.forEach(function(edge) {
-      // This makes sure children are right after their parents.
-      var parentIndex = fieldItemStates.findIndex(function(fieldItem) {
-        return fieldItem.field == edge.From;
+    var topLevelParentsByChild = {};
+    children.forEach(function(child) {
+      var currentParent = edges.find(function(edge) { return edge.To === child; }),
+          currentChild = child;
+      while (currentParent) {
+        currentParent = edges.find(function(edge) { return edge.To === currentChild; });
+        if (currentParent) {
+          currentChild = currentParent.From;
+          topLevelParentsByChild[child] = currentParent.From;
+        }
+      }
+    });
+    fieldItemStates.forEach(function(fieldItem) {
+      if (topLevelParents.includes(fieldItem.field)) {
+        fieldItem.topLevelParent = '';
+      }
+      else {
+        fieldItem.topLevelParent = topLevelParentsByChild[fieldItem.field];
+      }
+    })
+
+    // As an intermediary step, create a hierarchical structure grouped
+    // by the top-level parent.
+    var tempHierarchy = [];
+    var tempHierarchyHash = {};
+    fieldItemStates.forEach(function(fieldItem) {
+      if (fieldItem.topLevelParent === '') {
+        fieldItem.children = [];
+        tempHierarchyHash[fieldItem.field] = fieldItem;
+        tempHierarchy.push(fieldItem);
+      }
+    });
+    fieldItemStates.forEach(function(fieldItem) {
+      if (fieldItem.topLevelParent !== '') {
+        tempHierarchyHash[fieldItem.topLevelParent].children.push(fieldItem);
+      }
+    });
+
+    // Now we clear out the field items and add them back as a flat list.
+    fieldItemStates.length = 0;
+    tempHierarchy.forEach(function(fieldItem) {
+      fieldItemStates.push(fieldItem);
+      fieldItem.children.forEach(function(child) {
+        fieldItemStates.push(child);
       });
-      var childIndex = fieldItemStates.findIndex(function(fieldItem) {
-        return fieldItem.field == edge.To;
-      });
-      arrayMove(fieldItemStates, childIndex, parentIndex + 1);
     });
   }
 }

--- a/_includes/assets/js/model/utils.js
+++ b/_includes/assets/js/model/utils.js
@@ -134,38 +134,3 @@ function getMatchesByUnitSeries(items, selectedUnit, selectedSeries) {
   }
   return matches;
 }
-
-/**
- * Move an item from one position in an array to another, in place.
- */
-function arrayMove(arr, fromIndex, toIndex) {
-
-  // if moving something "forwards", then the toIndex needs to be 1 less,
-  // because after removing the fromIndex, the array will be 1 shorter.
-  if (toIndex > fromIndex) {
-    toIndex -= 1;
-  }
-
-  while (fromIndex < 0) {
-    fromIndex += arr.length;
-  }
-  while (toIndex < 0) {
-    toIndex += arr.length;
-  }
-  var paddingAdded = [];
-  if (toIndex >= arr.length) {
-    var k = toIndex - arr.length;
-    while ((k--) + 1) {
-      arr.push(undefined);
-      paddingAdded.push(arr.length - 1);
-    }
-  }
-  arr.splice(toIndex, 0, arr.splice(fromIndex, 1)[0]);
-
-  // Get rid of the undefined elements that were added.
-  paddingAdded.sort();
-  while (paddingAdded.length > 0) {
-    var paddingIndex = paddingAdded.pop() - 1;
-    arr.splice(paddingIndex, 1);
-  }
-}


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1334 
Related version | 1.6.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Previously there was some (pretty complex) code dedicated to sorting the disaggregation fields for display, so that the "child" dropdowns would appear just beneath the "parent" dropdowns. This re-sorting, however, interfered with any order that might have been in the data schema (whether a custom order, or alphabetical, or based on the order of the columns/rows in the data).

This is a refactor of that sorting logic. The idea here is to give up on trying to handle multiple levels of hierarchy, and just deal with two layers: top-level parents (parents that are not children of any other parents) and everything else. Since Open SDG only visualizes those two layers (ie, there are only two different indentation-levels for the dropdowns) maybe we don't need to worry about it.

So the result of this change is that the order of the dropdowns should be identical to the order of the fields in the data schema, except that any children appear after their top-level parent, and before the next top-level parent. Hopefully this results in an intuitive and expected order.

But a lot of testing here would be good.