### PR TITLE
Fix javascript error on non-search pages

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -1,6 +1,9 @@
 var indicatorSearch = function() {
 
   function sanitizeInput(input) {
+    if (input === null) {
+      return null;
+    }
     var doc = new DOMParser().parseFromString(input, 'text/html');
     var stripped = doc.body.textContent || "";
     var map = {


### PR DESCRIPTION
This fixes a regression caused by hotfix 1.5.1. I believe that without this change, all non-search pages will have a javascript error in the console. The error doesn't seem to be causing problems with other functionality, as far as I can tell, but should be fixed. I'm putting this PR against 1.5.0-dev on the assumption that it will be another hotfix release.