### PR TITLE
Quick fix for mobile menu accessibility issue

### DIFF
--- a/_includes/assets/js/menu.js
+++ b/_includes/assets/js/menu.js
@@ -72,6 +72,7 @@ $(function() {
       }
     } else if (target === 'search-mobile') {
       topLevelMenuToggle.setAttribute('aria-expanded', false);
+      $(topLevelMenuToggle).find('> button').attr('aria-expanded', false);
     } else {
       // menu click, always hide search:
       topLevelSearchLink.removeClass('open');


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-mobile-menu-search-fix/)
Fixed issues | Fixes #1383 
Related version | 1.6.0-dev
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This is a quick fix that should be followed up by a full refactor of this file. I think it could be simplified. There is also code that is not getting used, related to the "Search" button. (Like the label changing to "Hide", and the input box getting focus automatically.) I suspect that search button should also have the "aria-expanded" attribute.