### PR TITLE
Use different status types for disagg status

### DIFF
--- a/_includes/components/reportingstatus/reporting-status-by-field.html
+++ b/_includes/components/reportingstatus/reporting-status-by-field.html
@@ -4,6 +4,11 @@
 {%- assign indicator_singular = page.t.general.indicator | downcase -%}
 {%- assign indicators_plural = page.t.general.indicators | downcase -%}
 
+{%- assign status_types = site.reporting_status.status_types -%}
+{%- if include.status_types and site[include.status_types] -%}
+    {%- assign status_types = site[include.status_types].status_types -%}
+{%- endif -%}
+
 <h2>{{ include.title | replace: "%field", extra_field_translated }}</h2>
 {%- for fieldreport in include.extra_field[1] -%}
     <div class="goal details reporting-status-item">
@@ -19,7 +24,7 @@
         </span>
         <div class="summary">
             <div class="statuses">
-                {%- for status_type in site.reporting_status.status_types -%}
+                {%- for status_type in status_types -%}
                     {% assign status_stats = fieldreport.statuses | where: "status", status_type.value | first %}
                     {% if status_stats %}
                     <div>
@@ -31,7 +36,7 @@
             </div>
         </div>
         <div class="goal-stats">
-            {%- for status_type in site.reporting_status.status_types -%}
+            {%- for status_type in status_types -%}
                 {% assign status_stats = fieldreport.statuses | where: "status", status_type.value | first %}
                 {% if status_stats %}
                 {% assign status_count_precise = status_stats.count | times: 1.0 %}

--- a/_includes/components/reportingstatus/reporting-status-by-goal.html
+++ b/_includes/components/reportingstatus/reporting-status-by-goal.html
@@ -1,5 +1,10 @@
 {%- assign indicators_plural = page.t.general.indicators | downcase -%}
 
+{%- assign status_types = site.reporting_status.status_types -%}
+{%- if include.status_types and site[include.status_types] -%}
+    {%- assign status_types = site[include.status_types].status_types -%}
+{%- endif -%}
+
 <h2>{{ include.title }}</h2>
 {%- for goalreport in include.goals -%}
 {%- assign goal = goalreport.goal | strip | sdg_lookup -%}
@@ -16,7 +21,7 @@
         <span class="total">{{ goalreport.totals.total }} {{ indicators_plural }}</span>
         <div class="summary">
             <div class="statuses">
-                {%- for status_type in site.reporting_status.status_types -%}
+                {%- for status_type in status_types -%}
                 {% assign status_stats = goalreport.statuses | where: "status", status_type.value | first %}
                 {% if status_stats %}
                 <div>
@@ -28,7 +33,7 @@
             </div>
         </div>
         <div class="goal-stats">
-            {%- for status_type in site.reporting_status.status_types -%}
+            {%- for status_type in status_types -%}
                 {% assign status_stats = goalreport.statuses | where: "status", status_type.value | first %}
                 {% if status_stats %}
                 {% assign status_count_precise = status_stats.count | times: 1.0 %}

--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -1,6 +1,11 @@
 {%- assign overall = include.overall -%}
 {%- assign indicators_plural = page.t.general.indicators | downcase -%}
 
+{%- assign status_types = site.reporting_status.status_types -%}
+{%- if include.status_types and site[include.status_types] -%}
+    {%- assign status_types = site[include.status_types].status_types -%}
+{%- endif -%}
+
 <div class="goal goal-overall">
     <div class="details">
         <h2 class="status-goal">
@@ -9,7 +14,7 @@
         <span class="total"><span>{{ overall.totals.total }}</span> {{ indicators_plural }}</span>
         <div class="summary">
             <div class="statuses">
-            {%- for status_type in site.reporting_status.status_types -%}
+            {%- for status_type in status_types -%}
             {% assign status_stats = overall.statuses | where: "status", status_type.value | first %}
             {% if status_stats %}
             <div>
@@ -22,7 +27,7 @@
             </div>
         </div>
         <div class="goal-stats">
-            {%- for status_type in site.reporting_status.status_types -%}
+            {%- for status_type in status_types -%}
             {% assign status_stats = overall.statuses | where: "status", status_type.value | first %}
             {% if status_stats %}
             {% assign status_count_precise = status_stats.count | times: 1.0 %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -66,8 +66,8 @@
   <div class="tab-content reporting-status-view">
     <div role="tabpanel" class="tab-pane active" id="goalsview">
   {% endif %}
-  {% include components/reportingstatus/reporting-status-overall.html overall=reporting_data.overall title=page.t.status.overall_reporting_status %}
-  {% include components/reportingstatus/reporting-status-by-goal.html goals=reporting_data.goals title=page.t.status.status_by_goal %}
+  {% include components/reportingstatus/reporting-status-overall.html overall=reporting_data.overall title=page.t.status.overall_reporting_status status_types="reporting_status" %}
+  {% include components/reportingstatus/reporting-status-by-goal.html goals=reporting_data.goals title=page.t.status.status_by_goal status_types="reporting_status" %}
   {% if show_tabs %}
     </div>
   {% endif %}
@@ -76,24 +76,24 @@
     {%- for extra_field in reporting_data.extra_fields -%}
     {% assign extra_field_name = extra_field[0] %}
     <div role="tabpanel" class="tab-pane" id="{{ extra_field_name }}view" data-extra-field="true">
-      {% include components/reportingstatus/reporting-status-overall.html overall=reporting_data.overall title=page.t.status.overall_reporting_status %}
-      {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.status_by_field %}
+      {% include components/reportingstatus/reporting-status-overall.html overall=reporting_data.overall title=page.t.status.overall_reporting_status status_types="reporting_status" %}
+      {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.status_by_field status_types="reporting_status" %}
     </div>
     {%- endfor -%}
   {% endif %}
 
   {% if site.reporting_status.disaggregation_tabs and disagg_data %}
     <div role="tabpanel" class="tab-pane" id="disaggregationsview">
-      {% include components/reportingstatus/reporting-status-overall.html overall=disagg_data.overall title=page.t.status.disaggregation_status_overall %}
-      {% include components/reportingstatus/reporting-status-by-goal.html goals=disagg_data.goals title=page.t.status.status_by_goal %}
+      {% include components/reportingstatus/reporting-status-overall.html overall=disagg_data.overall title=page.t.status.disaggregation_status_overall status_types="disaggregation_status" %}
+      {% include components/reportingstatus/reporting-status-by-goal.html goals=disagg_data.goals title=page.t.status.status_by_goal status_types="disaggregation_status" %}
     </div>
 
     {% if extra_fields %}
       {%- for extra_field in disagg_data.extra_fields -%}
       {% assign extra_field_name = extra_field[0] %}
       <div role="tabpanel" class="tab-pane" id="{{ extra_field_name }}-disaggregationsview" data-extra-field="true">
-        {% include components/reportingstatus/reporting-status-overall.html overall=disagg_data.overall title=page.t.status.disaggregation_status_overall %}
-        {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.disaggregation_status_by_field %}
+        {% include components/reportingstatus/reporting-status-overall.html overall=disagg_data.overall title=page.t.status.disaggregation_status_overall status_types="disaggregation_status" %}
+        {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.disaggregation_status_by_field status_types="disaggregation_status" %}
       </div>
       {%- endfor -%}
     {% endif %}


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-disaggregation-status-types)
Fixed issues | Fixes #1397 
Related version | 1.6.0-beta1
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This PR depends on two other PRs:
* https://github.com/open-sdg/sdg-build/pull/281
* https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/115

This moves translations of disaggregation status types out of sdg-build so that it works with the new layout.