### PR TITLE
Remove bottom margin from tags in goals-with-progress layout

### DIFF
--- a/_sass/layouts/_goal-with-progress.scss
+++ b/_sass/layouts/_goal-with-progress.scss
@@ -100,6 +100,7 @@ $goal-by-target-indentation: 60px;
     display: inline-block;
     clear: left;
     @include tags;
+    margin-bottom: 0;
     .tag {
       display: block;
       float: left;


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-remove-tag-margin-bottom/1/)
Fixed issues | Fixes #1407 
Related version | 1.6.0-beta1
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This removes the 10 pixel margin bottom that was present on all lists, from the list of tags on the goal-with-progress layout.