### PR TITLE
Custom 404 page

### DIFF
--- a/_layouts/page-not-found.html
+++ b/_layouts/page-not-found.html
@@ -1,6 +1,10 @@
 {% include head.html %}
-<img class="page-not-found-image" src="{{ page.logo.src }}" alt="{{ page.logo.alt }}" />
-<h1>{{ page.title }}</h1>
-{{ content }}
+<img class="page-not-found-image" src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="Sustainable Development Goals logo" />
+<div id="main-content" class="container" role="main">
+    <div>
+        <h1>{{ page.title }}</h1>
+        {{ content }}
+    </div>
+</div>
 </body>
 </html>

--- a/_layouts/page-not-found.html
+++ b/_layouts/page-not-found.html
@@ -1,0 +1,6 @@
+{% include head.html %}
+<img class="page-not-found-image" src="{{ page.logo.src }}" alt="{{ page.logo.alt }}" />
+<h1>{{ page.title }}</h1>
+{{ content }}
+</body>
+</html>

--- a/_sass/layouts/_page-not-found.scss
+++ b/_sass/layouts/_page-not-found.scss
@@ -1,6 +1,8 @@
 .page-not-found-image {
+    margin-top: 40px;
     display: block;
     margin-left: auto;
     margin-right: auto;
     width: 50%;
+    max-width: 150px;
 }

--- a/_sass/layouts/_page-not-found.scss
+++ b/_sass/layouts/_page-not-found.scss
@@ -1,0 +1,6 @@
+.page-not-found-image {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 50%;
+}

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -46,3 +46,4 @@
 @import "layouts/config_bulder";
 @import "layouts/data_editor";
 @import "layouts/post";
+@import "layouts/page-not-found";

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 * Feature: Ignore disaggregation columns #1463
 * Feature: Control the order of the indicator tabs (chart/table/map/etc) #1462
+* Feature: Layout for page-not-found (404) pages #1421
 
 ## 1.6.0
 

--- a/tests/site/_pages/page-not-found.md
+++ b/tests/site/_pages/page-not-found.md
@@ -1,0 +1,10 @@
+---
+layout: page-not-found
+title: Page not found
+permalink: page-not-found.html
+---
+If you typed the web address, check it is correct.
+
+If you pasted the web address, check you copied the entire address.
+
+If the web address is correct or you selected a link or button, contact us if you need to speak to someone about the Sustainable Development Goals (SDGs).


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-custom-404-page/404.html)
Fixed issues | Fixes #1276 
Related version | 1.7.0-dev
Bugfix, feature or docs? | feature
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

To test this, the steps would be:

1. Point to this branch
2. Create a file in the _pages folder.
3. Copy the text below into the file.
4. Update the Github Pages settings according to these docs: https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site

(use "404.html" as the filename)

```
---
layout: page-not-found
title: Page not found
permalink: 404.html
---
If you typed the web address, check it is correct.

If you pasted the web address, check you copied the entire address.

If the web address is correct or you selected a link or button, contact us if you need to speak to someone about the Sustainable Development Goals (SDGs).
```