### PR TITLE
Time series attributes

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -287,6 +287,14 @@ var indicatorModel = function (options) {
       filteredData = helpers.getDataByUnit(filteredData, this.selectedUnit);
     }
 
+    var timeSeriesAttributes = [];
+    if (filteredData.length > 0) {
+      timeSeriesAttributes = helpers.getTimeSeriesAttributes(filteredData);
+    }
+    else if (headline.length > 0) {
+      timeSeriesAttributes = helpers.getTimeSeriesAttributes(headline);
+    }
+
     filteredData = helpers.sortData(filteredData, this.selectedUnit);
     if (headline.length > 0) {
       headline = helpers.sortData(headline, this.selectedUnit);
@@ -328,6 +336,7 @@ var indicatorModel = function (options) {
       chartType: this.graphType,
       indicatorDownloads: this.indicatorDownloads,
       precision: helpers.getPrecision(this.precision, this.selectedUnit, this.selectedSeries),
+      timeSeriesAttributes: timeSeriesAttributes,
     });
   };
 };

--- a/_includes/assets/js/indicatorView-chartjs3.js
+++ b/_includes/assets/js/indicatorView-chartjs3.js
@@ -73,6 +73,7 @@ var indicatorView = function (model, options) {
         helpers.updateChartTitle(args.chartTitle);
         helpers.updateSeriesAndUnitElements(args.selectedSeries, args.selectedUnit);
         helpers.updateUnitElements(args.selectedUnit);
+        helpers.updateTimeSeriesAttributes(args.timeSeriesAttributes);
     });
 
     MODEL.onFieldsComplete.attach(function (sender, args) {

--- a/_includes/assets/js/model/dataHelpers.js
+++ b/_includes/assets/js/model/dataHelpers.js
@@ -118,3 +118,27 @@ function inputEdges(edges) {
   {% endif %}
   return edgesData;
 }
+
+/**
+ * @param {Array} rows
+ * @return {Array} Objects containing 'field' and 'value', to be placed in the footer.
+ */
+function getTimeSeriesAttributes(rows) {
+  if (rows.length === 0) {
+    return [];
+  }
+  var timeSeriesAttributes = [],
+      possibleAttributes = {{ site.time_series_attributes | jsonify }},
+      firstRow = rows[0],
+      firstRowKeys = Object.keys(firstRow);
+  possibleAttributes.forEach(function(possibleAttribute) {
+    var field = possibleAttribute.field;
+    if (firstRowKeys.includes(field) && firstRow[field]) {
+      timeSeriesAttributes.push({
+        field: field,
+        value: firstRow[field],
+      });
+    }
+  });
+  return timeSeriesAttributes;
+}

--- a/_includes/assets/js/model/helpers.js
+++ b/_includes/assets/js/model/helpers.js
@@ -105,6 +105,7 @@
     getGraphAnnotations: getGraphAnnotations,
     getColumnsFromData: getColumnsFromData,
     inputEdges: inputEdges,
+    getTimeSeriesAttributes: getTimeSeriesAttributes,
     inputData: inputData,
     // Backwards compatibility.
     footerFields: deprecated('helpers.footerFields'),

--- a/_includes/assets/js/model/utils.js
+++ b/_includes/assets/js/model/utils.js
@@ -65,6 +65,10 @@ function nonFieldColumns() {
     'Unit multiplier',
     'Unit measure',
   ];
+  var timeSeriesAttributes = {{ site.time_series_attributes | jsonify }};
+  timeSeriesAttributes.forEach(function(tsAttribute) {
+    columns.push(tsAttribute.field);
+  });
   if (SERIES_TOGGLE) {
     columns.push(SERIES_COLUMN);
   }

--- a/_includes/assets/js/view/fieldHelpers.js
+++ b/_includes/assets/js/view/fieldHelpers.js
@@ -61,3 +61,30 @@ function sortFieldGroup(fieldGroupElement) {
         .sort(sortLabels)
         .appendTo(fieldGroupElement.find('#indicatorData .variable-options'));
 }
+
+/**
+ * @param {Array} tsAttributeValues
+ *   Array of objects containing 'field' and 'value'.
+ * @return null
+ */
+function updateTimeSeriesAttributes(tsAttributeValues) {
+    var timeSeriesAttributes = {{ site.time_series_attributes | jsonify }};
+    timeSeriesAttributes.forEach(function(tsAttribute) {
+        var field = tsAttribute.field,
+            valueMatch = tsAttributeValues.find(function(tsAttributeValue) {
+                return tsAttributeValue.field === field;
+            }),
+            value = (valueMatch) ? valueMatch.value : '',
+            $labelElement = $('dt[data-ts-attribute="' + field + '"]'),
+            $valueElement = $('dd[data-ts-attribute="' + field + '"]');
+
+        if (!value) {
+            $labelElement.hide();
+            $valueElement.hide();
+        }
+        else {
+            $labelElement.show();
+            $valueElement.show().text(translations.t(value));
+        }
+    });
+}

--- a/_includes/assets/js/view/helpers.js
+++ b/_includes/assets/js/view/helpers.js
@@ -31,6 +31,7 @@
     updateWithSelectedFields: updateWithSelectedFields,
     updateSeriesAndUnitElements: updateSeriesAndUnitElements,
     updateUnitElements: updateUnitElements,
+    updateTimeSeriesAttributes: updateTimeSeriesAttributes,
     updatePlot: updatePlot,
     isHighContrast: isHighContrast,
     getHeadlineColor: getHeadlineColor,

--- a/_includes/components/indicator/data-footer.html
+++ b/_includes/components/indicator/data-footer.html
@@ -47,5 +47,18 @@
         >{{ footer_field.value | t  }}</dd>
         {% endfor %}
         {% endif %}
+
+        {% if site.time_series_attributes and site.time_series_attributes.size > 0 %}
+        {% for ts_attribute in site.time_series_attributes %}
+        <dt
+          class="data-controlled-footer-field"
+          data-ts-attribute={{ ts_attribute.field | jsonify }}
+        >{{ ts_attribute.label | t  }}:</dt>
+        <dd
+          class="data-controlled-footer-field"
+          data-ts-attribute={{ ts_attribute.field | jsonify }}
+        ></dd>
+        {% endfor %}
+        {% endif %}
     <dl>
 </div>

--- a/tests/data/config_data.yml
+++ b/tests/data/config_data.yml
@@ -51,3 +51,11 @@ datapackage:
 data_schema:
   class: DataSchemaInputTableSchemaYaml
   source: data-schema/*.yml
+
+indicator_options:
+  non_disaggregation_columns:
+    - Year
+    - Units
+    - Series
+    - Value
+    - GeoCode

--- a/tests/data/data/indicator_1-1-1.csv
+++ b/tests/data/data/indicator_1-1-1.csv
@@ -1,10 +1,10 @@
-Year,COMPOSITE_BREAKDOWN,Value
-2015,A,1
-2015,B,3
-2015,,2
-2016,A,
-2016,B,
-2016,,
-2017,A,2
-2017,B,4
-2017,,3
+Year,COMPOSITE_BREAKDOWN,COMMENT_TS,Value
+2015,A,Comment for series A,1
+2015,B,,3
+2015,,Comment for headline,2
+2016,A,Comment for series A,
+2016,B,,
+2016,,Comment for headline,
+2017,A,Comment for series A,2
+2017,B,,
+2017,,Comment for headline,3

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '1.8.0-dev'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'time-series-attributes'

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -324,9 +324,6 @@ site_config_form:
         - goal-by-target-vertical
   repository_link: /tree/master/tests/site/_data
   translation_link: ''
-time_series_attributes:
-  - field: COMMENT_TS
-    label: Comment
 validate_indicator_config: true
 validate_site_config: true
 x_axis_label: Year

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -324,6 +324,9 @@ site_config_form:
         - goal-by-target-vertical
   repository_link: /tree/master/tests/site/_data
   translation_link: ''
+time_series_attributes:
+  - field: COMMENT_TS
+    label: Comment
 validate_indicator_config: true
 validate_site_config: true
 x_axis_label: Year


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.8.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This depends on a PR in jekyll-open-sdg-plugins: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/126

That PR provides default support for one time-series attribute (COMMENT_TS) but a new `time_series_attributes` site config setting can be used to have full control over this.

More notes to come.
