### PR TITLE
Specificity fix for chart focus in high-contrast

### DIFF
--- a/_sass/bootstrap5/layouts/_indicator.scss
+++ b/_sass/bootstrap5/layouts/_indicator.scss
@@ -5,6 +5,7 @@
         padding-top: 10px;
     }
 
+    &.contrast-high canvas,
     canvas {
         @include noselect;
         &:focus {


### PR DESCRIPTION
Quick fix of chart background color when focused (clicked on) in high-contrast mode. The chart should only have a yellow outline; not a full yellow background.