### PR TITLE
Recover rescaler

### DIFF
--- a/_includes/assets/js/chartjs/rescaler.js
+++ b/_includes/assets/js/chartjs/rescaler.js
@@ -1,4 +1,7 @@
-Chart.plugins.register({
+// This "crops" the charts so that empty years are not displayed
+// at the beginning or end of each dataset. This ensures that the
+// chart will fill all the available space.
+Chart.{% unless site.chartjs_3 %}plugins.{% endunless %}register({
   id: 'rescaler',
   beforeInit: function (chart, options) {
     chart.config.data.allLabels = chart.config.data.labels.slice(0);
@@ -13,31 +16,34 @@ Chart.plugins.register({
   },
   afterUpdate: function (chart) {
 
+    // Ensure this only runs once.
     if (chart.isScaleUpdate) {
       chart.isScaleUpdate = false;
       return;
     }
 
-    var datasets = _.filter(chart.data.datasets, function (ds, index) {
-      var meta = chart.getDatasetMeta(index).$filler;
-      return meta && meta.visible;
-    });
-
-    var ranges = _.chain(datasets).map('allData').map(function (data) {
+    // For each dataset, create an object showing the
+    // index of the minimum value and the index of the
+    // maximum value (not counting empty/null values).
+    var ranges = _.chain(chart.data.datasets).map('allData').map(function (data) {
       return {
         min: _.findIndex(data, function(val) { return val !== null }),
         max: _.findLastIndex(data, function(val) { return val !== null })
       };
     }).value();
 
+    // Figure out the overal minimum and maximum
+    // considering all of the datasets.
     var dataRange = ranges.length ? {
       min: _.chain(ranges).map('min').min().value(),
       max: _.chain(ranges).map('max').max().value()
     } : undefined;
 
     if (dataRange) {
+      // "Crop" the labels according to the min/max.
       chart.data.labels = chart.data.allLabels.slice(dataRange.min, dataRange.max + 1);
 
+      // "Crop" the data of each dataset according to the min/max.
       chart.data.datasets.forEach(function (dataset) {
         dataset.data = dataset.allData.slice(dataRange.min, dataRange.max + 1);
       });

--- a/_includes/assets/js/chartjs/rescaler.js
+++ b/_includes/assets/js/chartjs/rescaler.js
@@ -1,0 +1,49 @@
+Chart.plugins.register({
+  id: 'rescaler',
+  beforeInit: function (chart, options) {
+    chart.config.data.allLabels = chart.config.data.labels.slice(0);
+  },
+  afterDatasetsUpdate: function (chart) {
+    _.each(chart.data.datasets, function (ds) {
+      if (!ds.initialised) {
+        ds.initialised = true;
+        ds.allData = ds.data.slice(0);
+      }
+    });
+  },
+  afterUpdate: function (chart) {
+
+    if (chart.isScaleUpdate) {
+      chart.isScaleUpdate = false;
+      return;
+    }
+
+    var datasets = _.filter(chart.data.datasets, function (ds, index) {
+      var meta = chart.getDatasetMeta(index).$filler;
+      return meta && meta.visible;
+    });
+
+    var ranges = _.chain(datasets).map('allData').map(function (data) {
+      return {
+        min: _.findIndex(data, function(val) { return val !== null }),
+        max: _.findLastIndex(data, function(val) { return val !== null })
+      };
+    }).value();
+
+    var dataRange = ranges.length ? {
+      min: _.chain(ranges).map('min').min().value(),
+      max: _.chain(ranges).map('max').max().value()
+    } : undefined;
+
+    if (dataRange) {
+      chart.data.labels = chart.data.allLabels.slice(dataRange.min, dataRange.max + 1);
+
+      chart.data.datasets.forEach(function (dataset) {
+        dataset.data = dataset.allData.slice(dataRange.min, dataRange.max + 1);
+      });
+
+      chart.isScaleUpdate = true;
+      chart.update();
+    }
+  }
+});

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -438,6 +438,8 @@ var indicatorView = function (model, options) {
     view_obj._chartInstance.data.datasets = chartInfo.datasets;
     view_obj._chartInstance.data.labels = chartInfo.labels;
     this.updateHeadlineColor(this.isHighContrast() ? 'high' : 'default', view_obj._chartInstance);
+    // TODO: Investigate assets/js/chartjs/rescaler.js and why "allLabels" is needed.
+    view_obj._chartInstance.data.allLabels = chartInfo.labels;
 
     if(chartInfo.selectedUnit) {
       view_obj._chartInstance.options.scales.yAxes[0].scaleLabel.labelString = translations.t(chartInfo.selectedUnit);

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -438,8 +438,6 @@ var indicatorView = function (model, options) {
     view_obj._chartInstance.data.datasets = chartInfo.datasets;
     view_obj._chartInstance.data.labels = chartInfo.labels;
     this.updateHeadlineColor(this.isHighContrast() ? 'high' : 'default', view_obj._chartInstance);
-    // TODO: Investigate assets/js/chartjs/rescaler.js and why "allLabels" is needed.
-    view_obj._chartInstance.data.allLabels = chartInfo.labels;
 
     if(chartInfo.selectedUnit) {
       view_obj._chartInstance.options.scales.yAxes[0].scaleLabel.labelString = translations.t(chartInfo.selectedUnit);

--- a/assets/js/sdg.js
+++ b/assets/js/sdg.js
@@ -3,6 +3,7 @@
 ---
 {%- include assets/js/autotrack-element.js -%}
 {%- include assets/js/plugins/jquery.sdgMap.js -%}
+{%- include assets/js/chartjs/rescaler.js -%}
 {%- include assets/js/chartjs/noDataMessage.js -%}
 {% if site.accessible_charts %}
 {% if site.chartjs_3 %}


### PR DESCRIPTION
This recovers the "rescaler" plugin which had been removed. This plugin is responsible for "cropping" the chart datasets so that empty years at the beginning/end of each dataset are not shown. This ensures that the chart will take up all the available space.

This PR also adds a bit of documentation and simplifies the code a bit, to avoid confusion in the future.

This show work whether `chartjs_3` is true or false.