### PR TITLE
Bootstrap5 accessible tabs fix

### DIFF
--- a/_includes/assets/js/bootstrap5/accessibleTabs.js
+++ b/_includes/assets/js/bootstrap5/accessibleTabs.js
@@ -60,7 +60,7 @@ $(document).ready(function() {
         panes.first().attr('aria-hidden', 'false').show();
 
         // Set state for the first tabsList li
-        tabsList.find('li:first').addClass('active').find(' > a').attr({
+        tabsList.find('li:first').addClass('active').find(' > button').attr({
             'aria-selected': 'true',
             'tabindex': '0',
         });


### PR DESCRIPTION
Quick fix for accessible tabs if bootstrap_5 is enabled. Without this fix users cannot use the tab key to navigate to the Chart/Table/etc tabs.