### PR TITLE
Keep sr-only class to avoid unneeded file changes

### DIFF
--- a/_includes/assets/js/chartjs/accessibleCharts-chartjs3.js
+++ b/_includes/assets/js/chartjs/accessibleCharts-chartjs3.js
@@ -35,7 +35,7 @@ Chart.register({
     },
     initElements: function() {
         $('<span/>')
-            .addClass('{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}')
+            .addClass('sr-only')
             .attr('id', 'chart-tooltip-status')
             .attr('role', 'status')
             .appendTo('#chart');

--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -522,7 +522,7 @@ var indicatorView = function (model, options) {
         },
         legendCallback: function(chart) {
             var text = [];
-            text.push('<h5 class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">' + translations.indicator.plot_legend_description + '</h5>');
+            text.push('<h5 class="sr-only">' + translations.indicator.plot_legend_description + '</h5>');
             text.push('<ul id="legend" class="legend-for-' + chart.config.type + '-chart">');
             _.each(chart.data.datasets, function(dataset) {
               text.push('<li>');

--- a/_includes/assets/js/view/chartHelpers.js
+++ b/_includes/assets/js/view/chartHelpers.js
@@ -263,7 +263,7 @@ function updateGraphAnnotationColors(contrast, chartInfo) {
  */
 function generateChartLegend(chart) {
     var text = [];
-    text.push('<h5 class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">' + translations.indicator.plot_legend_description + '</h5>');
+    text.push('<h5 class="sr-only">' + translations.indicator.plot_legend_description + '</h5>');
     text.push('<ul id="legend" class="legend-for-' + chart.config.type + '-chart">');
     _.each(chart.data.datasets, function (dataset) {
         text.push('<li>');

--- a/_includes/bootstrap5/components/header.html
+++ b/_includes/bootstrap5/components/header.html
@@ -1,5 +1,5 @@
 {% include multilingual-js.html key="header" %}
-<a class="visually-hidden-focusable" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
+<a class="sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
 <div id="disclaimer">
     {% include components/dev-disclaimer.html %}
 </div>

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -1,7 +1,7 @@
 {% if include.graph_type %}
 
     <div id="dataset-size-warning" style="display:none" role="alert">
-      <i class="fa fa-bolt"><span class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.general.label_warning }}</span></i>
+      <i class="fa fa-bolt"><span class="sr-only">{{ page.t.general.label_warning }}</span></i>
       {{ page.t.indicator.dataset_size_warning }}
     </div>
 

--- a/_includes/components/header/header-default.html
+++ b/_includes/components/header/header-default.html
@@ -1,5 +1,5 @@
 {% include multilingual-js.html key="header" %}
-<a class="{% if site.bootstrap_5 %}visually-hidden-focusable{% else %}sr-only sr-only-focusable{% endif %}" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
+<a class="sr-only sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
 <div id="disclaimer">
   {% include components/dev-disclaimer.html %}
 </div>

--- a/_includes/components/header/header-menu-left-aligned.html
+++ b/_includes/components/header/header-menu-left-aligned.html
@@ -1,5 +1,5 @@
 {% include multilingual-js.html key="header" %}
-<a class="{% if site.bootstrap_5 %}visually-hidden-focusable{% else %}sr-only sr-only-focusable{% endif %}" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
+<a class="sr-only sr-only-focusable" id="skiplink" href="#main-content" tabindex="0">{{ page.t.header.skip_link }}</a>
 <div id="disclaimer">
   {% include components/dev-disclaimer.html %}
 </div>

--- a/_includes/components/indicator/data-footer.html
+++ b/_includes/components/indicator/data-footer.html
@@ -10,7 +10,7 @@
 {% assign uniqSources = sources_list | uniq | join: ", " %}
 
 <div id="{{ include.footerId | default: 'selectionChartFooter' }}" class="table-footer-text">
-  <h5 class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">Chart details</h5>
+  <h5 class="sr-only">Chart details</h5>
     <dl>
         {% if uniqSources != '' %}
         <dt>{{ page.t.indicator.source }}:</dt>

--- a/_includes/components/indicator/fields-template.html
+++ b/_includes/components/indicator/fields-template.html
@@ -16,12 +16,12 @@
       >
         <% if(allowedFields.indexOf(fieldItem.field) == -1) { %><h6><% } else { %><h5><% } %>
           <span aria-hidden="true"><%=translations.t(fieldItem.label)%><i class="fa fa-chevron-down"></i></span>
-          <span class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.indicator.sub_categories_show }} <%=translations.t(fieldItem.label)%></span>
+          <span class="sr-only">{{ page.t.indicator.sub_categories_show }} <%=translations.t(fieldItem.label)%></span>
         <% if(allowedFields.indexOf(fieldItem.field) == -1) { %></h6><% } else { %></h5><% } %>
       </button>
       <div class="variable-options">
         <fieldset>
-          <legend class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.indicator.sub_categories }} - <%=translations.t(fieldItem.field)%></legend>
+          <legend class="sr-only">{{ page.t.indicator.sub_categories }} - <%=translations.t(fieldItem.field)%></legend>
           <div>
             <button data-type="select">{{ page.t.indicator.select_all }}</button>
             <button data-type="clear">{{ page.t.indicator.clear_all }}</button>

--- a/_includes/components/indicator/indicator-main.html
+++ b/_includes/components/indicator/indicator-main.html
@@ -30,7 +30,7 @@
   data-precision="{{ page.indicator.precision | jsonify | xml_escape }}"
 >
   {% if show_data %}
-  <span role="status" class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}" id="indicator-data-view-status"></span>
+  <span role="status" class="sr-only" id="indicator-data-view-status"></span>
   <div id="indicator-sidebar" class="indicator-sidebar col-md-3">
     {% include components/indicator/data-sidebar.html %}
   </div>

--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -21,7 +21,7 @@
 
             {% if page.indicator[indicator_metadata.name] contains "http" or page.indicator[indicator_metadata.name] contains "mailto" %}
               <a href="{{ page.indicator[indicator_metadata.name] }}" target="_blank">
-                {{ url_text }} <span class="{% if site.bootstrap_5 %}visually-hidden{% else %}visuallyhidden{% endif %}">{{ page.t.general.opens_new_window }}</span>
+                {{ url_text }} <span class="visuallyhidden">{{ page.t.general.opens_new_window }}</span>
               </a>
             {% endif %}
 

--- a/_includes/components/indicator/series-template.html
+++ b/_includes/components/indicator/series-template.html
@@ -4,7 +4,7 @@
   {% endif %}
     <h4>{{ page.t.indicator.series }}</h4>
     <fieldset>
-      <legend class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.indicator.series }}</legend>
+      <legend class="sr-only">{{ page.t.indicator.series }}</legend>
       <% _.each(serieses, function(seriesItem, index) { %>
         <% var checked = (selectedSeries) ? (selectedSeries==seriesItem) : (index==0); %>
         <label><input type="radio" name="series" value="<%=seriesItem%>" tabindex=0 <%=checked ? 'checked' : ''%> /> <%=translations.t(seriesItem)%></label>

--- a/_includes/components/indicator/tags.html
+++ b/_includes/components/indicator/tags.html
@@ -13,7 +13,7 @@
     <ul class="tags" aria-label="{{ page.t.indicator.tags }}">
     {% if show_reporting_status %}
         <li>
-        <span class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.indicator.status }}</span>
+        <span class="sr-only">{{ page.t.indicator.status }}</span>
         {% include components/reportingstatus/reporting-status-label.html indicator=include.indicator %}
         </li>
     {% endif %}

--- a/_includes/components/indicator/units-template.html
+++ b/_includes/components/indicator/units-template.html
@@ -4,7 +4,7 @@
   {% endif %}
     <h4>{{ page.t.indicator.unit_of_measurement }}</h4>
     <fieldset>
-      <legend class="{% if site.bootstrap_5 %}visually-hidden{% else %}sr-only{% endif %}">{{ page.t.indicator.unit_of_measurement }}</legend>
+      <legend class="sr-only">{{ page.t.indicator.unit_of_measurement }}</legend>
       <% _.each(units, function(unitsItem, index) { %>
         <% var checked = (selectedUnit) ? (selectedUnit==unitsItem) : (index==0); %>
         <label><input type="radio" name="unit" value="<%=unitsItem%>" tabindex=0 <%=checked ? 'checked' : ''%> /> <%=translations.t(unitsItem)%></label>

--- a/_sass/bootstrap5/base/_screenreaders.scss
+++ b/_sass/bootstrap5/base/_screenreaders.scss
@@ -1,0 +1,12 @@
+/* Backwards compatibility for the sr-only class from Bootstrap 3. */
+.visuallyhidden, .sr-only, .sr-only-focusable:not(:focus):not(:focus-within) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0,0,0,0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}

--- a/_sass/open-sdg-bootstrap5.scss
+++ b/_sass/open-sdg-bootstrap5.scss
@@ -9,6 +9,7 @@
 @import "bootstrap5/mixins/preserve_original_colors";
 @import "bootstrap5/mixins/search_bar";
 @import "base/no_javascript";
+@import "bootstrap5/base/screenreaders";
 @import "bootstrap5/base/high_contrast";
 @import "bootstrap5/base/buttons";
 @import "bootstrap5/base/focus";


### PR DESCRIPTION
The recent Bootstrap 5 upgrade changed a lot of files, but a large proportion of them were only changing the "sr-only" class to "visually-hidden". We can just keep support for "sr-only" with a few lines of CSS, and not have to change a lot of files. This should make the upgrade process easier for users.