### PR TITLE
Do not change map title when series changes

### DIFF
--- a/_includes/components/indicator/map.html
+++ b/_includes/components/indicator/map.html
@@ -1,5 +1,5 @@
 {% assign graph_title = page.indicator.graph_titles.first.title | default: page.indicator.graph_title %}
-<h4 id="map-heading" class="chart-title">{{ graph_title }}</h4>
+<h4 id="map-heading" class="map-title">{{ graph_title }}</h4>
 <div id="map" aria-describedby="table-alternative">
   <img class="map-loading-image" src="{{ site.baseurl }}/assets/img/loading.gif" alt="{{ page.t.indicator.loading_map }}" />
 </div>

--- a/_sass/bootstrap5/layouts/_indicator.scss
+++ b/_sass/bootstrap5/layouts/_indicator.scss
@@ -17,6 +17,9 @@
         margin-bottom: 1.5rem;
         margin-left: 20px;
     }
+    .map-title {
+        margin-bottom: 1.5rem;
+    }
 
     #indicatorData {
         margin-top: 20px;


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-map-title-should-not-react-to-series-changes/3-3-3/)
Fixed issues | Fixes #1600 
Related version | 2.0.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
