### PR TITLE
Less space above frontpage card sections

### DIFF
--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -7,6 +7,7 @@
         border-top: 2px solid;
         border-color: $card-horizontalRule-color;
         padding-top: 7px;
+        margin-top: 0px;
     }
     img {
         max-width: 100%;

--- a/_sass/components/_frontpage_cards.scss
+++ b/_sass/components/_frontpage_cards.scss
@@ -1,5 +1,8 @@
 .frontpage-cards {
-    margin-top: 40px;
+    margin-top: 20px;
+    @media only screen and (min-width: 992px) {
+        margin-top: 40px;
+    }
     .row {
         margin-bottom: 20px;
     }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-frontpage-section-margin-mobile/)
Fixed issues | Fixes #1620 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
