### PR TITLE
Do not float icon on goal page on mobile

### DIFF
--- a/_includes/components/goal/header.html
+++ b/_includes/components/goal/header.html
@@ -1,10 +1,10 @@
 <div class="heading goal-banner goal-{{ page.goal.number }}">
     <div class="container">
         <div class="row">
-            <div class="col-4 col-md-3 col-lg-2 goal-tiles">
+            <div class="col-4 col-md-3 col-lg-2 goal-icon goal-tiles">
                 <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
             </div>
-            <div class="col-8 col-md-9 col-lg-10">
+            <div class="col-8 col-md-9 col-lg-10 goal-details">
                 <h1>{{ page.goal.name }}</h1>
             </div>
         </div>

--- a/_sass/layouts/_goal.scss
+++ b/_sass/layouts/_goal.scss
@@ -59,4 +59,16 @@ $goal-by-target-indentation: 60px;
     .tags {
         margin-top: 10px;
     }
+
+    @media only screen and (max-width: 500px) {
+        .container {
+            .goal-icon {
+                float: none;
+            }
+            .goal-details {
+                float: none;
+                width: 100%;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-goals-page-icon-floating)
Fixed issues | Fixes #1621 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
