### PR TITLE
Remove top padding on main-content

### DIFF
--- a/_sass/layouts/_default.scss
+++ b/_sass/layouts/_default.scss
@@ -1,4 +1,4 @@
 #main-content {
-    padding-top: 15px;
+    padding-top: 0px;
     padding-bottom: 15px;
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-less-top-padding-on-main-content/)
Fixed issues | Fixes #1624 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
