### PR TITLE
Remove the empty space by the normal search bar on the search page

### DIFF
--- a/_includes/assets/js/search.js
+++ b/_includes/assets/js/search.js
@@ -151,7 +151,7 @@ var indicatorSearch = function() {
     }));
 
     // Hide the normal header search.
-    $('#search').css('visibility', 'hidden');
+    $('.header-search-bar').hide();
   }
 
   // Helper function to make a search query "fuzzier", using the ~ syntax.


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-remove-empty-space-on-search-page/search/?q=news)
Fixed issues | Fixes #1626 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
