### PR TITLE
Handle null values in current series/unit for footer fields

### DIFF
--- a/_includes/components/indicator/data-footer.html
+++ b/_includes/components/indicator/data-footer.html
@@ -38,12 +38,12 @@
         {% if page.indicator.footer_fields and page.indicator.footer_fields.size > 0 %}
         {% for footer_field in page.indicator.footer_fields %}
         <dt
-          data-for-series={{ footer_field.series | jsonify }}
-          data-for-unit={{ footer_field.unit | jsonify }}
+          data-for-series={{ footer_field.series | default: "" | jsonify }}
+          data-for-unit={{ footer_field.unit | default: "" | jsonify }}
         >{{ footer_field.label | t  }}:</dt>
         <dd
-          data-for-series={{ footer_field.series | jsonify }}
-          data-for-unit={{ footer_field.unit | jsonify }}
+          data-for-series={{ footer_field.series | default: "" | jsonify }}
+          data-for-unit={{ footer_field.unit | default: "" | jsonify }}
         >{{ footer_field.value | t  }}</dd>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-footer-fields-test/1-1-1/)
Fixed issues | Fixes #1651 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
