### PR TITLE
For no-js: hide hamburger toggle, expand hamburger menu, hide drop-downs

### DIFF
--- a/_sass/base/_no_javascript.scss
+++ b/_sass/base/_no_javascript.scss
@@ -8,6 +8,15 @@
 }
 
 .no-js {
+  [data-bs-target="#navbarSupportedContent"] {
+    display: none;
+  }
+  .nav-item.dropdown {
+    display: none;
+  }
+  #navbarSupportedContent {
+    display: block;
+  }
   .language-toggle-dropdown {
     display: none;
   }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-no-js-navigation-fixes/)
Fixed issues | Fixes #1653 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This PR changes has 3 effects when javascript in not available:
1. The hamburger menu is expanded
2. The hamburger toggle is hidden
3. Navigation drop-downs are hidden

The 3rd item is a temporary measure to hide a non-functional feature. The ultimate fix will be done later in this ticket: #1654 