### PR TITLE
Various chart-related fixes

### DIFF
--- a/_includes/assets/js/chartjs/accessibleCharts.js
+++ b/_includes/assets/js/chartjs/accessibleCharts.js
@@ -95,6 +95,10 @@ Chart.register({
         return isEmpty;
     },
     activateNext: function() {
+        // Abort early if no data.
+        if (this.chart.data.datasets.length === 0) {
+            return;
+        }
         this.selectedIndex += 1;
         if (this.selectedIndex >= this.meta.data.length) {
             this.selectedIndex = 0;
@@ -110,6 +114,10 @@ Chart.register({
         this.activate();
     },
     activatePrev: function() {
+        // Abort early if no data.
+        if (this.chart.data.datasets.length === 0) {
+            return;
+        }
         this.selectedIndex -= 1;
         if (this.selectedIndex < 0) {
             if (this.chart.config.type !== 'line') {

--- a/_includes/assets/js/chartjs/noDataMessage.js
+++ b/_includes/assets/js/chartjs/noDataMessage.js
@@ -17,6 +17,15 @@ function getTextLinesOnCanvas(ctx, text, maxWidth) {
   return lines;
 }
 
+function isHighContrast(contrast) {
+  if (contrast) {
+      return contrast === 'high';
+  }
+  else {
+      return $('body').hasClass('contrast-high');
+  }
+}
+
 // This plugin displays a message to the user whenever a chart has no data.
 Chart.register({
   id: 'open-sdg-no-data-message',
@@ -33,6 +42,7 @@ Chart.register({
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.font = "normal 40px 'Open Sans', Helvetica, Arial, sans-serif";
+      ctx.fillStyle = (isHighContrast()) ? 'white' : 'black';
       var lines = getTextLinesOnCanvas(ctx, translations.indicator.data_not_available, width);
       var numLines = lines.length;
       var lineHeight = 50;

--- a/_includes/assets/js/view/chartHelpers.js
+++ b/_includes/assets/js/view/chartHelpers.js
@@ -215,7 +215,7 @@ function createPlot(chartInfo) {
     // If we have changed type, we will need to destroy and recreate the chart.
     // So we can abort here.
     var updatedConfig = getChartConfig(chartInfo);
-    if (updatedConfig.type !== VIEW._chartInstance.type) {
+    if (updatedConfig.type !== VIEW._chartInstance.config.type) {
         VIEW._chartInstance.destroy();
         createPlot(chartInfo);
         return;
@@ -229,8 +229,9 @@ function createPlot(chartInfo) {
     }
 
     alterChartConfig(updatedConfig, chartInfo);
-    VIEW._chartInstance.type = updatedConfig.type;
-    VIEW._chartInstance.data = updatedConfig.data;
+    VIEW._chartInstance.config.type = updatedConfig.type;
+    VIEW._chartInstance.data.datasets = updatedConfig.data.datasets;
+    VIEW._chartInstance.data.labels = updatedConfig.data.labels;
     VIEW._chartInstance.options = updatedConfig.options;
 
     VIEW._chartInstance.update();


### PR DESCRIPTION
This should fix a few random chart-related things that I've noticed:

## Avoids an infinite loop that was happening when the no-data message was clicked on

To replicate:

1. Open the developer console
2. Go to an indicator in which you can get the no-data message (ie, "This data is not available. Please choose alternative data to display.")
3. Click on the no-data message
4. Wait a few seconds and notice the infinite loop in the developer console

## Proper color contrast for the no-data message

To replicate:

1. Switch to high contrast
2. Go to an indicator in which you can get the no-data message (ie, "This data is not available. Please choose alternative data to display.")
3. Notice that the no-data message is not visible

## Fix for chart updates to allow the screenreader announcement (and other things) to happen

To replicate:

1. Turn on a screenreader
2. Go to an indicator with disaggregation
3. Tick any disaggregation checkbox
4. Notice there is no screenreader announcement

In addition to testing the three items above, I would recommend a general spot-checking of a few charts to make sure that things generally still work. The reason I say that is that, due to a bug, a whole chunk of code was being skipped. That code is now no longer being skipped, and so I want to make sure it doesn't introduce a problem.

Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1656 
Related version | 2.0.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This is also mentioned in #1593 