### PR TITLE
Fix closing tag in data footer

### DIFF
--- a/_includes/components/indicator/data-footer.html
+++ b/_includes/components/indicator/data-footer.html
@@ -60,5 +60,5 @@
         ></dd>
         {% endfor %}
         {% endif %}
-    <dl>
+    </dl>
 </div>


### PR DESCRIPTION
This is a small and straightforward fix, so there is no issue for it. A closing HTML tag just needs to be fixed. This is causing an alert in an accessibility audit, mentioned in #1593.

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-nested-dl-accessibility-fix/)
Fixed issues | N/A
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Added CHANGELOG entry
