### PR TITLE
Allow keyboard access to cookie settings link in footer

### DIFF
--- a/_includes/assets/js/cookieConsent.js
+++ b/_includes/assets/js/cookieConsent.js
@@ -2,9 +2,14 @@
 // Add the cookie settings link in the footer.
 $(document).ready(function() {
 if (klaroConfig && klaroConfig.noAutoLoad !== true) {
-  var cookieLink = $('<li class="cookie-settings"><a>' + translations.cookies.cookie_settings + '</a></li>');
+  var cookieLink = $('<li class="cookie-settings"><a role="button" tabindex="0">' + translations.cookies.cookie_settings + '</a></li>');
   $(cookieLink).click(function() {
+    klaro.show();
+  });
+  $(cookieLink).keypress(function(event) {
+    if (event.key === 'Enter') {
       klaro.show();
+    }
   });
   $('#footerLinks ul').append(cookieLink);
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-cookie-setting-tab-index)
Fixed issues | N/A
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Without this PR, it is impossible to get to the "Cookie settings" link in the footer using a keyboard. (Note @otis-bath that this link is not applicable on the UK site because of the different way that cookie consent is handled, so this might be a tough one to test.)

Mentioned in #1593 