### PR TITLE
Hotfix for 1.8.0 - Pin to 2.6.1 of json-editor

### DIFF
--- a/_layouts/config-builder.html
+++ b/_layouts/config-builder.html
@@ -35,7 +35,7 @@
   <div class="row" id="results-status" role="status"></div>
   <div class="row" id="editor_holder"></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@2.6.1/dist/jsoneditor.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@3.14.0/dist/js-yaml.min.js"></script>
   <script src="https://cdn.jsdelivr.net/g/filesaver.js"></script>
   <script>


### PR DESCRIPTION
This is a duplicate of #1660 but for 1.8.0, so that we can release a hotfix for that.