### PR TITLE
Selection legend revamp moving name to the left

### DIFF
--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -66,30 +66,45 @@
 
     update: function() {
       var selectionList = L.DomUtil.get('selection-list');
-      var selectionTpl = '' +
+      var selectionTplHighValue = '' +
         '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
         '<dd class="selection-value-item {valueStatus}">' +
           '<span class="selection-bar" style="width: {percentage}%;">' +
-            '<span class="selection-value">{value}</span>' +
+            '<span class="selection-value selection-value-high">' +
+              '<span class="selection-value-high-background">{value}</span>' +
+            '</span>' +
           '</span>' +
           '<i class="selection-close fa fa-remove"></i>' +
         '</dd>';
+      var selectionTplLowValue = '' +
+      '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
+      '<dd class="selection-value-item {valueStatus}">' +
+        '<span class="selection-bar" style="width: {percentage}%;"></span>' +
+        '<span class="selection-value selection-value-low" style="left: {percentage}%;">' +
+          '<span class="selection-value-low-background">{value}</span>' +
+        '</span>' +
+        '<i class="selection-close fa fa-remove"></i>' +
+      '</dd>';
       var plugin = this.plugin;
       var valueRange = this.plugin.valueRange;
       selectionList.innerHTML = this.selections.map(function(selection) {
         var value = plugin.getData(selection.feature.properties);
         var percentage, valueStatus;
+        var templateToUse = selectionTplHighValue;
         if (value) {
           valueStatus = 'has-value';
           var fraction = (value - valueRange[0]) / (valueRange[1] - valueRange[0]);
           percentage = Math.round(fraction * 100);
+          if (percentage <= 50) {
+            templateToUse = selectionTplLowValue;
+          }
         }
         else {
           value = '';
           valueStatus = 'no-value';
           percentage = 0;
         }
-        return L.Util.template(selectionTpl, {
+        return L.Util.template(templateToUse, {
           name: selection.feature.properties.name,
           valueStatus: valueStatus,
           percentage: percentage,

--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -69,7 +69,7 @@
       var selectionTplHighValue = '' +
         '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
         '<dd class="selection-value-item {valueStatus}">' +
-          '<span class="selection-bar" style="width: {percentage}%;">' +
+          '<span class="selection-bar" style="background-color: {color}; width: {percentage}%;">' +
             '<span class="selection-value selection-value-high">' +
               '<span class="selection-value-high-background">{value}</span>' +
             '</span>' +
@@ -79,7 +79,7 @@
       var selectionTplLowValue = '' +
       '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
       '<dd class="selection-value-item {valueStatus}">' +
-        '<span class="selection-bar" style="width: {percentage}%;"></span>' +
+        '<span class="selection-bar" style="background-color: {color}; width: {percentage}%;"></span>' +
         '<span class="selection-value selection-value-low" style="left: {percentage}%;">' +
           '<span class="selection-value-low-background">{value}</span>' +
         '</span>' +
@@ -89,9 +89,11 @@
       var valueRange = this.plugin.valueRange;
       selectionList.innerHTML = this.selections.map(function(selection) {
         var value = plugin.getData(selection.feature.properties);
+        var color = '#FFFFFF';
         var percentage, valueStatus;
         var templateToUse = selectionTplHighValue;
         if (value) {
+          color = plugin.colorScale(value).hex();
           valueStatus = 'has-value';
           var fraction = (value - valueRange[0]) / (valueRange[1] - valueRange[0]);
           percentage = Math.round(fraction * 100);
@@ -109,6 +111,7 @@
           valueStatus: valueStatus,
           percentage: percentage,
           value: plugin.alterData(opensdg.dataRounding(value)),
+          color: color,
         });
       }).join('');
 

--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -69,8 +69,9 @@
       var selectionTpl = '' +
         '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
         '<dd class="selection-value-item {valueStatus}">' +
-          '<span class="selection-value" style="left: {percentage}%;">{value}</span>' +
-          '<span class="selection-bar" style="width: {percentage}%;"></span>' +
+          '<span class="selection-bar" style="width: {percentage}%;">' +
+            '<span class="selection-value">{value}</span>' +
+          '</span>' +
           '<i class="selection-close fa fa-remove"></i>' +
         '</dd>';
       var plugin = this.plugin;

--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -35,15 +35,17 @@
 
     onAdd: function() {
       var controlTpl = '' +
-        '<ul id="selection-list"></ul>' +
-        '<div class="legend-swatches">' +
-          '{legendSwatches}' +
-        '</div>' +
-        '<div class="legend-values">' +
-          '<span class="legend-value left">{lowValue}</span>' +
-          '<span class="arrow left"></span>' +
-          '<span class="legend-value right">{highValue}</span>' +
-          '<span class="arrow right"></span>' +
+        '<dl id="selection-list"></dl>' +
+        '<div class="legend-footer">' +
+          '<div class="legend-swatches">' +
+            '{legendSwatches}' +
+          '</div>' +
+          '<div class="legend-values">' +
+            '<span class="legend-value left">{lowValue}</span>' +
+            '<span class="arrow left"></span>' +
+            '<span class="legend-value right">{highValue}</span>' +
+            '<span class="arrow right"></span>' +
+          '</div>' +
         '</div>';
       var swatchTpl = '<span class="legend-swatch" style="width:{width}%; background:{color};"></span>';
       var swatchWidth = 100 / this.plugin.options.colorRange.length;
@@ -65,12 +67,12 @@
     update: function() {
       var selectionList = L.DomUtil.get('selection-list');
       var selectionTpl = '' +
-        '<li class="{valueStatus}">' +
-          '<span class="selection-name">{name}</span>' +
+        '<dt class="selection-name">{name}</dt>' +
+        '<dd class="selection-value-item {valueStatus}">' +
           '<span class="selection-value" style="left: {percentage}%;">{value}</span>' +
           '<span class="selection-bar" style="width: {percentage}%;"></span>' +
           '<i class="selection-close fa fa-remove"></i>' +
-        '</li>';
+        '</dd>';
       var plugin = this.plugin;
       var valueRange = this.plugin.valueRange;
       selectionList.innerHTML = this.selections.map(function(selection) {
@@ -95,10 +97,11 @@
       }).join('');
 
       // Assign click behavior.
-      var control = this;
-      $('#selection-list li').click(function(e) {
-        var index = $(e.target).closest('li').index()
-        var selection = control.selections[index];
+      var control = this,
+          clickSelector = '#selection-list dd';
+      $(clickSelector).click(function(e) {
+        var index = $(clickSelector).index(this),
+            selection = control.selections[index];
         control.removeSelection(selection);
         control.plugin.unhighlightFeature(selection);
       });

--- a/_includes/assets/js/plugins/leaflet.selectionLegend.js
+++ b/_includes/assets/js/plugins/leaflet.selectionLegend.js
@@ -67,7 +67,7 @@
     update: function() {
       var selectionList = L.DomUtil.get('selection-list');
       var selectionTpl = '' +
-        '<dt class="selection-name">{name}</dt>' +
+        '<dt class="selection-name"><span class="selection-name-background">{name}</span></dt>' +
         '<dd class="selection-value-item {valueStatus}">' +
           '<span class="selection-value" style="left: {percentage}%;">{value}</span>' +
           '<span class="selection-bar" style="width: {percentage}%;"></span>' +

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -93,6 +93,7 @@
       }
       padding: 0;
       min-width: 360px;
+      margin-right: 25px;
       .legend-footer {
         position: relative;
         width: 150px;
@@ -162,6 +163,10 @@
           width: 200px;
           text-align: right;
           padding-top: 4px;
+          .selection-name-background {
+            background-color: rgba(255,255,255,0.6);
+            padding: 5px;
+          }
         }
         dd {
           margin-left: 210px;
@@ -195,10 +200,11 @@
             border-radius: 2px;
           }
           .selection-close {
-            top: 6px;
-            right: 5px;
+            top: 1px;
+            right: -20px;
             position: absolute;
             z-index: 3;
+            padding: 6px;
           }
         }
       }

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -184,7 +184,6 @@
           }
           .selection-bar {
             border-radius: 2px 0 0 2px;
-            background: $map-legendBar-color;
             z-index: 1;
           }
           &.no-value {
@@ -200,7 +199,6 @@
           .selection-value-high {
             right: 0;
             text-align: right;
-            background-color: $map-legendValue-color;
             .selection-value-high-background {
               background-color: $map-legendValue-backgroundColor;
               padding: 2px;

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -194,10 +194,11 @@
           }
           .selection-value {
             z-index: 2;
-            margin-right: 5px;
             background-color: $map-legendValue-color;
             padding: 3px;
             border-radius: 2px;
+            right: 0;
+            text-align: right;
           }
           .selection-close {
             top: 1px;

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -92,12 +92,12 @@
         display: none;
       }
       padding: 0;
-      min-width: 360px;
+      min-width: 460px;
       margin-right: 25px;
       .legend-footer {
         position: relative;
         width: 150px;
-        left: 210px;
+        left: 310px;
         bottom: 0;
         .legend-swatches, .legend-values {
           @include preserveOriginalColors;
@@ -160,7 +160,7 @@
         dt {
           float: left;
           clear: left;
-          width: 200px;
+          width: 300px;
           text-align: right;
           padding-top: 4px;
           .selection-name-background {
@@ -169,7 +169,7 @@
           }
         }
         dd {
-          margin-left: 210px;
+          margin-left: 310px;
           position: relative;
           width: 150px;
           background-color: rgba(150, 150, 150, 0.6);

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -194,11 +194,25 @@
           }
           .selection-value {
             z-index: 2;
-            background-color: $map-legendValue-color;
             padding: 3px;
             border-radius: 2px;
+          }
+          .selection-value-high {
             right: 0;
             text-align: right;
+            background-color: $map-legendValue-color;
+            .selection-value-high-background {
+              background-color: $map-legendValue-backgroundColor;
+              padding: 2px;
+              border-radius: 5px;
+            }
+          }
+          .selection-value-low {
+            .selection-value-low-background {
+              background-color: $map-legendValue-backgroundColor;
+              padding: 2px;
+              border-radius: 5px;
+            }
           }
           .selection-close {
             top: 1px;

--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -91,71 +91,90 @@
       @media only screen and (max-width: 680px) {
         display: none;
       }
-      background-color: rgba(150, 150, 150, 0.6);
       padding: 0;
-      width: 300px;
-      .legend-swatches {
-        @include preserveOriginalColors;
-        height: 10px;
-        .legend-swatch {
-          display: block;
-          float: left;
-          height: 10px;
+      min-width: 360px;
+      .legend-footer {
+        position: relative;
+        width: 150px;
+        left: 210px;
+        bottom: 0;
+        .legend-swatches, .legend-values {
+          @include preserveOriginalColors;
+          position: relative;
+          bottom: 0;
+          width: 150px;
+          left: 0;
         }
-      }
-      .legend-values {
-        @include preserveOriginalColors;
-        position: absolute;
-        bottom: -10px;
-        width: 100%;
-        .arrow {
-          width: 0;
-          height: 0;
-          border-style: solid;
-          position: absolute;
-          top: -10px;
-          z-index: 1;
-          &.left {
-            border-width: 20px 0 0 20px;
-            border-color: transparent transparent transparent $backgroundColor;
-            left: 0;
+        .legend-swatches {
+          height: 10px;
+          .legend-swatch {
+            display: block;
+            float: left;
+            height: 10px;
           }
-          &.right {
-            border-width: 0 0 20px 20px;
-            border-color: transparent transparent $backgroundColor transparent;
-            right: 1px;
+        }
+        .legend-values {
+          bottom: -10px;
+          .arrow {
+            width: 0;
+            height: 0;
+            border-style: solid;
+            position: absolute;
+            top: -10px;
+            z-index: 1;
+            &.left {
+              border-width: 20px 0 0 20px;
+              border-color: transparent transparent transparent $backgroundColor;
+              left: 0;
+            }
+            &.right {
+              border-width: 0 0 20px 20px;
+              border-color: transparent transparent $backgroundColor transparent;
+              right: 1px;
+              box-shadow: 1px 1px 1px 0px $map-legendValue-shadowColor;
+            }
+          }
+          .legend-value {
+            color: $text-color;
+            padding: 0 4px;
+            background: $backgroundColor;
+            position: absolute;
+            z-index: 2;
+            &.left {
+              left: 0;
+            }
+            &.right {
+              right: 1px;
+            }
             box-shadow: 1px 1px 1px 0px $map-legendValue-shadowColor;
           }
         }
-        .legend-value {
-          color: $text-color;
-          padding: 0 4px;
-          background: $backgroundColor;
-          position: absolute;
-          z-index: 2;
-          &.left {
-            left: 0;
-          }
-          &.right {
-            right: 1px;
-          }
-          box-shadow: 1px 1px 1px 0px $map-legendValue-shadowColor;
-        }
       }
       #selection-list {
-        list-style: none;
         margin-bottom: 0;
-        padding-left: 0;
-        li {
+        dt, dd {
+          min-height: 25px;
+          margin-bottom: 5px;
+        }
+        dt {
+          float: left;
+          clear: left;
+          width: 200px;
+          text-align: right;
+          padding-top: 4px;
+        }
+        dd {
+          margin-left: 210px;
           position: relative;
-          margin-top: 3px;
-          &:first-child {
-            margin-top: 0;
-          }
+          width: 150px;
+          background-color: rgba(150, 150, 150, 0.6);
           cursor: pointer;
-          height: 23px;
-          .selection-bar, .selection-name, .selection-value {
-            height: 23px;
+          .selection-value, .selection-bar {
+            position: absolute;
+            left: 0;
+          }
+          .selection-bar, .selection-value {
+            height: 25px;
             position: absolute;
           }
           .selection-bar {
@@ -163,14 +182,7 @@
             background: $map-legendBar-color;
             z-index: 1;
           }
-          .selection-name {
-            z-index: 2;
-            padding: 3px 20px 3px 3px;
-          }
           &.no-value {
-            .selection-name {
-              background: $map-legendValue-color-noValue;
-            }
             .selection-bar, .selection-value {
               display: none;
             }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -150,6 +150,7 @@ $languageToggle-dropDown-shadowColor: #a6a6a6 !default;
 $map-legendValue-shadowColor: #666 !default;
 $map-legendValue-color-noValue: repeating-linear-gradient(45deg, #FFF, #FFF 2px, #CCC 2px, #CCC 4px) !default;
 $map-legendValue-color: white !default;
+$map-legendValue-backgroundColor: #ddd !default;
 $map-legendBar-color: white !default;
 
 $table-row-backgroundColor-hover: $text-backgroundColor-hover !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -149,7 +149,7 @@ $languageToggle-dropDown-shadowColor: #a6a6a6 !default;
 
 $map-legendValue-shadowColor: #666 !default;
 $map-legendValue-color-noValue: repeating-linear-gradient(45deg, #FFF, #FFF 2px, #CCC 2px, #CCC 4px) !default;
-$map-legendValue-color: #ddd !default;
+$map-legendValue-color: white !default;
 $map-legendBar-color: white !default;
 
 $table-row-backgroundColor-hover: $text-backgroundColor-hover !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -148,10 +148,7 @@ $goalTiles-tile-shadowColor-hover: rgba(5,5,5,0.6) !default;
 $languageToggle-dropDown-shadowColor: #a6a6a6 !default;
 
 $map-legendValue-shadowColor: #666 !default;
-$map-legendValue-color-noValue: repeating-linear-gradient(45deg, #FFF, #FFF 2px, #CCC 2px, #CCC 4px) !default;
-$map-legendValue-color: white !default;
 $map-legendValue-backgroundColor: #ddd !default;
-$map-legendBar-color: white !default;
 
 $table-row-backgroundColor-hover: $text-backgroundColor-hover !default;
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-selection-legend-text-to-the-left/3-3-4/)
Fixed issues | Fixes #1677 
Related version | 2.0.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This changes the markup and styling of the "selection legend" on maps, so that the names of regions appear to the left of the horizontal bar. It also changes from `<ul>` tags to `<dl>` tags, which is a bit more semantically correct.