### PR TITLE
Fix aria-controls attributes on reporting status page

### DIFF
--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -33,7 +33,7 @@
   {% if show_tabs %}
   <ul class="nav nav-tabs reporting-status-view" role="tablist">
     <li role="presentation" class="nav-item active">
-      <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#goalsview" aria-controls="goals" role="tab" {% include autotrack.html preset="tab_reporting_status_goals" category="Tab change" action="Change reporting status view" label="Change reporting status view to goals" %}>{{ page.t.status.reporting_status }}</button>
+      <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#goalsview" aria-controls="goalsview" role="tab" {% include autotrack.html preset="tab_reporting_status_goals" category="Tab change" action="Change reporting status view" label="Change reporting status view to goals" %}>{{ page.t.status.reporting_status }}</button>
     </li>
     {% if extra_fields %}
       {% for extra_field in reporting_data.extra_fields %}
@@ -41,14 +41,14 @@
       {% assign extra_field_translated = extra_field_name | translate_metadata_field %}
       {% assign extra_field_autotrack = 'Change reporting status view to ' | append: extra_field_name %}
       <li role="presentation" class="nav-item">
-        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{ extra_field_name }}view" aria-controls="{{ extra_field_name }}" role="tab" {% include autotrack.html preset="tab_reporting_status_extra_field" category="Tab change" action="Change reporting status view" label=extra_field_autotrack %}>{{ page.t.status.status_by_field | replace: "%field", extra_field_translated }}</button>
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{ extra_field_name }}view" aria-controls="{{ extra_field_name }}view" role="tab" {% include autotrack.html preset="tab_reporting_status_extra_field" category="Tab change" action="Change reporting status view" label=extra_field_autotrack %}>{{ page.t.status.status_by_field | replace: "%field", extra_field_translated }}</button>
       </li>
       {% endfor %}
     {% endif %}
 
     {% if site.reporting_status.disaggregation_tabs %}
       <li role="presentation" class="nav-item">
-        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#disaggregationsview" aria-controls="disaggregations" role="tab" {% include autotrack.html preset="tab_reporting_status_disaggregations" category="Tab change" action="Change reporting status view" label="Change reporting status view to disaggregations" %}>{{ page.t.status.disaggregation_status }}</button>
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#disaggregationsview" aria-controls="disaggregationsview" role="tab" {% include autotrack.html preset="tab_reporting_status_disaggregations" category="Tab change" action="Change reporting status view" label="Change reporting status view to disaggregations" %}>{{ page.t.status.disaggregation_status }}</button>
       </li>
       {% if extra_fields %}
         {% for extra_field in reporting_data.extra_fields %}
@@ -56,7 +56,7 @@
         {% assign extra_field_translated = extra_field_name | translate_metadata_field %}
         {% assign extra_field_autotrack = 'Change disaggregation status view to ' | append: extra_field_name %}
         <li role="presentation" class="nav-item">
-          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{ extra_field_name }}-disaggregationsview" aria-controls="{{ extra_field_name }}-disaggregations" role="tab" {% include autotrack.html preset="tab_disaggregation_status_extra_field" category="Tab change" action="Change disaggregation status view" label=extra_field_autotrack %}>{{ page.t.status.disaggregation_status_by_field | replace: "%field", extra_field_translated }}</button>
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{ extra_field_name }}-disaggregationsview" aria-controls="{{ extra_field_name }}-disaggregationsview" role="tab" {% include autotrack.html preset="tab_disaggregation_status_extra_field" category="Tab change" action="Change disaggregation status view" label=extra_field_autotrack %}>{{ page.t.status.disaggregation_status_by_field | replace: "%field", extra_field_translated }}</button>
         </li>
         {% endfor %}
       {% endif %}


### PR DESCRIPTION
This should help with: https://github.com/open-sdg/open-sdg/issues/1593#issuecomment-1157478708

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-status-tab-controls-fix/)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.6.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
