### PR TITLE
Draw annotations after datasets

### DIFF
--- a/_includes/assets/js/view/chartTypeBase.js
+++ b/_includes/assets/js/view/chartTypeBase.js
@@ -183,7 +183,7 @@ opensdg.chartTypes.base = function(info) {
                 options: {
                     plugins: {
                         annotation: {
-                            drawTime: 'beforeDatasetsDraw',
+                            drawTime: 'afterDatasetsDraw',
                             annotations: annotations
                         }
                     }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-draw-annotations-after-datasets/)
Fixed issues | Fixes #1683 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

@phillipgardiner @otis-bath @LucyGwilliamAdmin This could help with #1683 and possibly #1684 too. If you would like, this could be added for 2.0.0 as a bug.

I would recommend testing this with at least four scenarios:
1. Line chart with a target line
2. Bar chart with a target line
3. Line chart with a series break
4. Bar chart with a series break

It's possible this may prompt other changes. Here is what it looks like locally with the 2nd scenario above:

![image](https://user-images.githubusercontent.com/1319083/174646870-6d0129a5-cec4-4d0f-8c5f-3bb04669c2fb.png)
