### PR TITLE
Default to accessibile chart colorset

### DIFF
--- a/_includes/assets/js/chartColors.js
+++ b/_includes/assets/js/chartColors.js
@@ -21,13 +21,13 @@ opensdg.chartColors = function(indicatorId) {
                 ['56c02b', '337319', '99d97f', '112608', 'ddf2d4', '449922', '77cc55', '224c11', 'bbe5aa'],
                 ['00689d', '00293e', '99c2d7', '00486d', '4c95ba', '126b80', 'cce0eb', '5a9fb0', 'a1c8d2'],
                 ['19486a', '0a1c2a', '8ca3b4', '16377c', 'd1dae1', '11324a', '466c87', '5b73a3', '0f2656']];
-  this.colorSets = {'default':['7e984f', '8d73ca', 'aaa533', 'c65b8a', '4aac8d', 'c95f44'],
+  this.colorSets = {'classic':['7e984f', '8d73ca', 'aaa533', 'c65b8a', '4aac8d', 'c95f44'],
                   'sdg':['e5243b', 'dda63a', '4c9f38', 'c5192d', 'ff3a21', '26bde2', 'fcc30b', 'a21942', 'fd6925', 'dd1367','fd9d24','bf8b2e','3f7e44','0a97d9','56c02b','00689d','19486a'],
                   'goal': this.goalColors[this.goalNumber-1],
                   'custom': customColorList,
                   'accessible': ['cd7a00', '339966', '9966cc', '8d4d57', 'A33600', '054ce6']};
   if(Object.keys(this.colorSets).indexOf(colorSet) == -1 || (colorSet=='custom' && customColorList == null)){
-    return this.colorSets['default'];
+    return this.colorSets['accessible'];
   }
   this.numberOfColors = (numberOfColors>this.colorSets[colorSet].length || numberOfColors == null || numberOfColors == 0) ? this.colorSets[colorSet].length : numberOfColors;
   this.colors = this.colorSets[colorSet].slice(0,this.numberOfColors);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,8 +439,8 @@ _Optional_: This setting can be used to control the color of the "headline" (eg,
 
 _Optional_: This setting can be used to customize the color set used in the charts. There are five possible entries:
 
-* `graph_color_set: 'accessible'` a 6-color set that is specifically chosen for optimal accessibility (recommended)
-* `graph_color_set: 'default'` a deprecated 6-color set that is still the default (for reasons of backwards compatibility)
+* `graph_color_set: 'accessible'` a 6-color set that is specifically chosen for optimal accessibility (default)
+* `graph_color_set: 'classic'` a deprecated 6-color set that was the default in Open SDG 1.x (it was previously called 'default' but was renamed to 'classic' in Open SDG 2.0.0)
 * `graph_color_set: 'sdg'` to use the 17 SDG colors in all charts
 * `graph_color_set: 'goal'` to use shades of the color of the current indicator's goal
 * `graph_color_set: 'custom'` to use a set of customized colors. In this case, write the hexadecimal color codes of the colors you want to use to the list in `graph_color_list` (see below).
@@ -448,7 +448,7 @@ _Optional_: This setting can be used to customize the color set used in the char
 > **NOTE**: Whatever color scheme you choose here, please ensure that all colors satisfy
 > the accessibility (minimum contrast) standards in your region. These colors will need to
 > be visible on white and black backgrounds. The `accessible` color scheme is designed to
-> meet this requirement, and so it is recommended.
+> meet this requirement, and so it is recommended, and it is the default.
 
 ### graph_color_list
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-default-to-accessible-chart-colors/)
Fixed issues | Fixes #1681 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [x] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

@phillipgardiner @otis-bath @LucyGwilliamAdmin This actually is not just a documentation issue - we actually forgot to make "accessible" the new default. So I think this should go into 2.0.0, if possible.

The PR changes "accessible" to be the default, and also changes the old "default" colorset to be called "classic". If a site was previously configured to be "default", with this PR that site will now display the accessible colors. Sites who want to continue using the old default can configure their site to "classic".