### PR TITLE
Translation replacement fixes

### DIFF
--- a/_includes/components/dev-disclaimer.html
+++ b/_includes/components/dev-disclaimer.html
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="disclaimer-alert">
     <strong class="phase-tag">{{ site.disclaimer.phase | default: page.t.header.alpha | t }}</strong>
-    {% assign disclaimer_message_default = page.t.header.disclaimer | replace_first: '%email_address', site.email_contacts.suggestions %}
+    {% assign disclaimer_message_default = page.t.header.disclaimer | t%}
     {{ site.disclaimer.message | default: disclaimer_message_default | t }}
     {% include components/dev-disclaimer-custom.html %}
   </div>

--- a/_includes/components/dev-disclaimer.html
+++ b/_includes/components/dev-disclaimer.html
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="disclaimer-alert">
     <strong class="phase-tag">{{ site.disclaimer.phase | default: page.t.header.alpha | t }}</strong>
-    {% assign disclaimer_message_default = page.t.header.disclaimer | t%}
+    {% assign disclaimer_message_default = page.t.header.disclaimer | t %}
     {{ site.disclaimer.message | default: disclaimer_message_default | t }}
     {% include components/dev-disclaimer-custom.html %}
   </div>

--- a/_includes/components/indicator/metadata-panes-default.html
+++ b/_includes/components/indicator/metadata-panes-default.html
@@ -5,8 +5,7 @@
             <p>
                 {% assign country_name = site.country.name | t %}
                 {% assign country_adjective = site.country.adjective | t %}
-                {{ page.t.indicator.national_metadata_blurb | replace: '%country_name', country_name | replace:
-                '%country_adjective', country_adjective }}
+                {{ page.t.indicator.national_metadata_blurb | t }}
             </p>
             {% include components/indicator/metadata.html scope='national' %}
         </article>


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-translation-replacement-fixes/1-1-1/)
Fixed issues | Fixes #1702 
Related version | 2.0.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This fixes the "parameter-replacement" in the default dev disclaimer and the default national metadata blurb. This needs the latest jekyll-open-sdg-plugins code from branch 2.0.0-dev.
