### PR TITLE
Map disaggregation index bug

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -233,7 +233,7 @@
     // Get the data from a feature's properties, according to the current year.
     getData: function(props) {
       var ret = false;
-      if (props.values && props.values.length) {
+      if (props.values && props.values.length && this.currentDisaggregation < props.values.length) {
         var value = props.values[this.currentDisaggregation][this.currentYear];
         if (typeof value === 'number') {
           ret = opensdg.dataRounding(value);


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1713 
Related version | 2.0.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This PR adds some quick safety code to prevent an out-of-index error when a particular map reason has fewer disaggregations than others. Though I don't know why that would happen, so there may be a deeper investigation to do there, on the sdg-build side. But in the meantime, this avoids the error and should display no data for that part of the map.