### PR TITLE
Prevent unit and series from being treated as edges

### DIFF
--- a/_includes/assets/js/model/dataHelpers.js
+++ b/_includes/assets/js/model/dataHelpers.js
@@ -116,6 +116,13 @@ function inputEdges(edges) {
       return true;
     });
   }
+  var unitAndSeries = [UNIT_COLUMN, SERIES_COLUMN];
+  edgesData = edgesData.filter(function(edge) {
+    if (unitAndSeries.includes(edge.To) || unitAndSeries.includes(edge.From)) {
+      return false;
+    }
+    return true;
+  });
   return edgesData;
 }
 


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | N/A
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This is a bit of safety code to prevent javascript errors that may happen when the unit and/or series are treated as "edges". This might happen if columns are set in the `data_fields` site configuration, but not set as `non_disaggregation_columns` in the data configuration.