### PR TITLE
Support translation keys in the ignored_disaggregation site config

### DIFF
--- a/_includes/assets/js/model/dataHelpers.js
+++ b/_includes/assets/js/model/dataHelpers.js
@@ -95,9 +95,9 @@ function getPrecision(precisions, selectedUnit, selectedSeries) {
  */
 function inputData(data) {
   var dropKeys = [];
-  {% if site.ignored_disaggregations and site.ignored_disaggregations.size > 0 %}
-  dropKeys = {{ site.ignored_disaggregations | jsonify }};
-  {% endif %}
+  if (opensdg.ignoredDisaggregations && opensdg.ignoredDisaggregations.length > 0) {
+    dropKeys = opensdg.ignoredDisaggregations;
+  }
   return convertJsonFormatToRows(data, dropKeys);
 }
 
@@ -107,15 +107,15 @@ function inputData(data) {
  */
 function inputEdges(edges) {
   var edgesData = convertJsonFormatToRows(edges);
-  {% if site.ignored_disaggregations and site.ignored_disaggregations.size > 0 %}
-  var ignoredDisaggregations = {{ site.ignored_disaggregations | jsonify }};
-  edgesData = edgesData.filter(function(edge) {
-    if (ignoredDisaggregations.includes(edge.To) || ignoredDisaggregations.includes(edge.From)) {
-      return false;
-    }
-    return true;
-  });
-  {% endif %}
+  if (opensdg.ignoredDisaggregations && opensdg.ignoredDisaggregations.length > 0) {
+    var ignoredDisaggregations = opensdg.ignoredDisaggregations;
+    edgesData = edgesData.filter(function(edge) {
+      if (ignoredDisaggregations.includes(edge.To) || ignoredDisaggregations.includes(edge.From)) {
+        return false;
+      }
+      return true;
+    });
+  }
   return edgesData;
 }
 

--- a/_includes/javascript-variables.html
+++ b/_includes/javascript-variables.html
@@ -30,6 +30,9 @@ var opensdg = {
     this.dataDisplayAlterations.push(callback);
   },
 
+  // Disaggregations which should be ignored on indicator pages.
+  ignoredDisaggregations: {{ page.indicator.ignored_disaggregations | jsonify }},
+
   language: '{{ page.language }}',
 };
 

--- a/tests/data/custom-translations/en/custom.yml
+++ b/tests/data/custom-translations/en/custom.yml
@@ -15,3 +15,4 @@ x_axis_label: English X Axis Label
 country_name: Australia
 country_adjective: Australian
 page_title: My English page title
+ignore_me: Ignore me

--- a/tests/data/data/indicator_1-2-1.csv
+++ b/tests/data/data/indicator_1-2-1.csv
@@ -1,7 +1,7 @@
-Year,Group,Value
-2015,A,1
-2015,B,3
-2015,,2
-2016,A,1
-2016,B,3
-2016,,2
+Year,Group,custom.ignore_me,Value
+2015,A,foo,1
+2015,B,foo,3
+2015,,foo,2
+2016,A,foo,1
+2016,B,foo,3
+2016,,foo,2

--- a/tests/features/Disaggregation.feature
+++ b/tests/features/Disaggregation.feature
@@ -79,3 +79,8 @@ Feature: Disaggregation
     And I am on "/2-2-2"
     And I wait 3 seconds
     Then I should see 1 "disaggregation filter" element
+
+  Scenario: Translation keys can be used to ignore disaggregations
+    And I am on "/1-2-1"
+    And I wait 3 seconds
+    Then I should see 1 "disaggregation filter" element

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -134,6 +134,7 @@ hide_single_series: false
 hide_single_unit: false
 ignored_disaggregations:
   - ignored disaggregation column
+  - custom.ignore_me
 indicator_config_form:
   enabled: true
   dropdowns:


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1722 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [x] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

This depends on a pull-request in jekyll-open-sdg-plugins: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/140

Tests here will fail until that PR is merged.

To test this manually:
1. Add a column to an indicator's data that uses a translation key. For example, the first line of a CSV file might be: `Year,custom.my_translation_key,Value`
2. Configure the site config's `ignored_disaggregations` to have the same translation key, eg: `ignored_disaggregations: ['custom.my_translation_key']`
3. Confirm that the column does *not* appear as a disaggregation dropdown (ie, confirm that it gets ignored)
