### PR TITLE
Refresh keyboard navigation plugin on chart update

### DIFF
--- a/_includes/assets/js/chartjs/accessibleCharts.js
+++ b/_includes/assets/js/chartjs/accessibleCharts.js
@@ -30,6 +30,9 @@ Chart.register({
             });
         }
     },
+    afterUpdate: function(chart) {
+        this.setMeta();
+    },
     setMeta: function() {
         this.meta = this.chart.getDatasetMeta(this.currentDataset);
     },


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-chart-keyboard-navigation-fix/15-2-1/)
Fixed issues | Fixes #1756
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [x] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Note on testing: This problem only happens after switching to a different series. To see the problem:

1. Go to https://onsdigital.github.io/sdg-indicators/15-2-1/
2. Click on the chart
3. Note that you can use the right-arrow on your keyboard to cycle through all 8 data points
4. Switch to the "Above-ground biomass stock" series
5. Note that there are now 9 data points
6. Click on the chart
7. Note that when using the right-arrow, you can't get to the 9th data point

If you put this PR on a feature branch, you should be able to go through the steps, but in step 7 you should be able to get to the 9th data point.