### PR TITLE
Maintain focus when changing series

### DIFF
--- a/_includes/assets/js/view/seriesHelpers.js
+++ b/_includes/assets/js/view/seriesHelpers.js
@@ -3,7 +3,10 @@
  * @return null
  */
 function initialiseSerieses(args) {
-    var templateElement = $('#series_template');
+    var activeSeriesInput = $('#serieses').find(document.activeElement),
+        seriesWasFocused = (activeSeriesInput.length > 0) ? true : false,
+        focusedValue = (seriesWasFocused) ? $(activeSeriesInput).val() : null,
+        templateElement = $('#series_template');
     if (templateElement.length > 0) {
         var template = _.template(templateElement.html()),
             serieses = args.serieses || [],
@@ -25,5 +28,9 @@ function initialiseSerieses(args) {
         else {
             $(OPTIONS.rootElement).removeClass('no-serieses');
         }
+    }
+    // Return focus if necessary.
+    if (seriesWasFocused) {
+        $('#serieses :input[value="' + focusedValue + '"]').focus();
     }
 }


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1757 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

To recreate the problem:
1. Go to https://onsdigital.github.io/sdg-indicators/15-2-1/
2. Press the TAB key until "Woodland area net change" has focus
3. Press the down arrow to switch to "Above-ground biomass stock"
4. Press the down arrow again
5. Note that it does not switch to the next series, and instead just scrolls the page a bit

If you make a feature branch with this PR, after step 4 it should switch to the next series ("Percent of woodland within protected areas").