### PR TITLE
Update title of map play/pause button dynamically

### DIFF
--- a/_includes/assets/js/plugins/leaflet.yearSlider.js
+++ b/_includes/assets/js/plugins/leaflet.yearSlider.js
@@ -126,6 +126,12 @@
     });
     // Create the player.
     options.player = new L.TimeDimension.Player(options.playerOptions, options.timeDimension);
+    options.player.on('play', function() {
+      $('.timecontrol-play').attr('title', 'Pause');
+    });
+    options.player.on('stop', function() {
+      $('.timecontrol-play').attr('title', 'Play');
+    });
     // Listen for time changes.
     if (typeof options.yearChangeCallback === 'function') {
       options.timeDimension.on('timeload', options.yearChangeCallback);


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-map-slider-aria-fix/3-3-3/)
Fixed issues | Fixes #1755
Related version | 2.1.0-dev
Bugfix, feature or docs? | Feature
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Testing notes: In order to test this, you can either inspect the map's play-button element in the browser's developer console, and confirm that its title attribute changes to "Pause" while it is playing. Or I believe you could also use a screenreader to test it, but I'm not sure exactly how it should behave.