### PR TITLE
Update data download card to use new translations

### DIFF
--- a/_includes/components/download-all-data.html
+++ b/_includes/components/download-all-data.html
@@ -4,7 +4,7 @@
         {{ page.t.frontpage.download_all }}
     </a>
     <div id="zip-download-info">
-        {{ page.t.frontpage.zip_file }} - {{ site.data.zip.size_human }}
+        {{ page.t.frontpage.file_size }}: {{ site.data.zip.size_human }}
         {% if site.data.zip.timestamp %}
             <br>
             {{ page.t.metadata_fields.national_data_update_url }} - {{ site.data.zip.timestamp | t_date: 'standard' }}


### PR DESCRIPTION
This PR depends on an sdg-translations PR: https://github.com/open-sdg/sdg-translations/pull/290

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-download-button-update/1-1-1/)
Fixed issues | Fixes #1727 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
