### PR TITLE
Placeholder for empty metadata

### DIFF
--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -9,6 +9,7 @@
           {% continue %}
         {% else %}
           {% assign metadata_content = site.empty_metadata_placeholder | default: page.t.indicator.empty_metadata_placeholder %}
+          {% assign metadata_content = '<span class="empty-metadata-placeholder">' | append: metadata_content | append: '</span>' %}
           {% assign placeholder_not_needed = false %}
         {% endif %}
       {% endunless %}

--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -2,11 +2,16 @@
   {% for indicator_metadata in site.data.schema %}
     {%- assign metadata_label = indicator_metadata.name | translate_metadata_field -%}
     {% if indicator_metadata.field.scope == include.scope %}
-      {% if site.hide_empty_metadata %}
-        {% unless page.indicator[indicator_metadata.name] and page.indicator[indicator_metadata.name] != '' %}
+      {% assign metadata_content = page.indicator[indicator_metadata.name] %}
+      {% assign placeholder_not_needed = true %}
+      {% unless metadata_content and metadata_content != '' %}
+        {% if site.hide_empty_metadata %}
           {% continue %}
-        {% endunless %}
-      {% endif %}
+        {% else %}
+          {% assign metadata_content = site.empty_metadata_placeholder | default: page.t.indicator.empty_metadata_placeholder %}
+          {% assign placeholder_not_needed = false %}
+        {% endif %}
+      {% endunless %}
       {% unless indicator_metadata.name contains "_url_text" or indicator_metadata.name contains "_link_text" %}
       <tr>
         <th scope="row">{{ metadata_label }} </th>
@@ -19,20 +24,20 @@
               {% assign url_text = 'Link' %}
             {% endunless %}
 
-            {% if page.indicator[indicator_metadata.name] contains "http" or page.indicator[indicator_metadata.name] contains "mailto" %}
-              <a href="{{ page.indicator[indicator_metadata.name] }}" target="_blank">
+            {% if metadata_content contains "http" or metadata_content contains "mailto" %}
+              <a href="{{ metadata_content }}" target="_blank">
                 {{ url_text }} <span class="visuallyhidden">{{ page.t.general.opens_new_window }}</span>
               </a>
             {% endif %}
 
-          {% elsif indicator_metadata.field.element == 'multiselect' %}
-            {% for item in page.indicator[indicator_metadata.name] %}
+          {% elsif indicator_metadata.field.element == 'multiselect' and placeholder_not_needed %}
+            {% for item in metadata_content %}
               {{ item | t }}{% unless forloop.last %}, {% endunless %}
             {% endfor %}
-          {% elsif indicator_metadata.name contains "_date" %}
-            {{ page.indicator[indicator_metadata.name] | t_date: "standard" }}
+          {% elsif indicator_metadata.name contains "_date" and placeholder_not_needed %}
+            {{ metadata_content | t_date: "standard" }}
           {% else %}
-            {{ page.indicator[indicator_metadata.name] | markdownify }}
+            {{ metadata_content | markdownify }}
           {% endif %}
         </td>
         </tr>

--- a/_sass/layouts/_indicator.scss
+++ b/_sass/layouts/_indicator.scss
@@ -43,3 +43,8 @@
         }
     }
 }
+
+.empty-metadata-placeholder {
+    font-style: italic;
+    color: $indicator-metadata-empty-color;
+}

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -166,3 +166,5 @@ $indicator-fieldOption-backgroundColor-hover: $text-backgroundColor-hover !defau
 $indicator-datasetWarning-backgroundColor: #FFCC0B !default;
 $indicator-legendSwatch-fillColor: #666 !default;
 $indicator-legendSwatch-backgroundColor-hover: #eee !default;
+
+$indicator-metadata-empty-color: #505A5F !default;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,6 +301,16 @@ email_contacts:
   functional: test@example.com
 ```
 
+### empty_metadata_placeholder
+
+_Optional_: This setting controls the text that displays for any metadata field which has no content. Note that this setting is not used if `hide_empty_metadata` is set to `true`. If the omitted, the following default is used:
+
+```nohighlight
+empty_metadata_placeholder: indicator.empty_metadata_placeholder
+```
+
+The above default refers to a translation key which currently translates to "Not available for this indicator" in English.
+
 ### environment
 
 **_Required_**: This setting should be either `staging` or `production`. Certain features of the platform, such as data management links, will only appear on `staging`. Typically you will have this set to `staging` in the `_config.yml` file, and set to `production` in the `_config_prod.yml` file.


### PR DESCRIPTION
This relies on a PR in sdg-translations: https://github.com/open-sdg/sdg-translations/pull/297

To test the default ("Not available for this indicator"), you don't need to use the new config. Just make sure that `hide_empty_metadata` is false:

```
hide_empty_metadata: false
```

To test a custom placeholder, you also need to use the new site config:

```
hide_empty_metadata: false
empty_metadata_placeholder: My placeholder
```

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-empty-metadata-placeholder)
Fixed issues | Fixes #1726 
Related version | 2.1.0-dev
Bugfix, feature or docs? | Feature
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
