### PR TITLE
Fix for metadata content overflow on high magnification

### DIFF
--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -1,4 +1,5 @@
 <table class="table metadata-content">
+  <tbody>
   {% for indicator_metadata in site.data.schema %}
     {%- assign metadata_label = indicator_metadata.name | translate_metadata_field -%}
     {% if indicator_metadata.field.scope == include.scope %}
@@ -39,4 +40,5 @@
         {% endunless %}
       {% endif %}
   {% endfor %}
+  </tbody>
 </table>

--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table metadata-content">
   {% for indicator_metadata in site.data.schema %}
     {%- assign metadata_label = indicator_metadata.name | translate_metadata_field -%}
     {% if indicator_metadata.field.scope == include.scope %}

--- a/_sass/components/_metadata.scss
+++ b/_sass/components/_metadata.scss
@@ -6,7 +6,7 @@
             max-width: 1px;
         }
         > th {
-          width: 33%;  
+          width: 40%;  
         }
     }
 }

--- a/_sass/components/_metadata.scss
+++ b/_sass/components/_metadata.scss
@@ -5,5 +5,8 @@
             word-wrap: break-word;
             max-width: 1px;
         }
+        th {
+          width: 33%;  
+        }
     }
 }

--- a/_sass/components/_metadata.scss
+++ b/_sass/components/_metadata.scss
@@ -1,11 +1,11 @@
-.metadata-content {
+.metadata-content > tbody > tr {
     @media only screen and (max-width: 500px) {
         table-layout: fixed;
-        th, td {
+        > th, > td {
             word-wrap: break-word;
             max-width: 1px;
         }
-        th {
+        > th {
           width: 33%;  
         }
     }

--- a/_sass/components/_metadata.scss
+++ b/_sass/components/_metadata.scss
@@ -1,0 +1,9 @@
+.metadata-content {
+    @media only screen and (max-width: 500px) {
+        table-layout: fixed;
+        th, td {
+            word-wrap: break-word;
+            max-width: 1px;
+        }
+    }
+}

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -47,6 +47,7 @@
 @import "components/indicator_tags";
 @import "components/indicator_reporting_status";
 @import "components/previous_next_buttons";
+@import "components/metadata";
 @import "components/sources";
 @import "components/tabs";
 @import "layouts/default";


### PR DESCRIPTION
This is meant to fix the second issue mentioned in #1761. It only has an effect on 500 pixels width and narrower, so this should only affect phones, and browsers on high zoom. To confirm I would recommend testing a variety of indicator metadata on:
1. Normal desktop
2. Desktop zoomed to 400%
3. Phones

Things to look out for include:
* Metadata that is overflowing outside of the column
* Metadata that seems too narrow to read

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-zoom-metadata-overflow-fix)
Fixed issues | Fixes #1761 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
