### PR TITLE
Better pruning of map disaggregations to hide region columns

### DIFF
--- a/_includes/assets/js/plugins/leaflet.disaggregationControls.js
+++ b/_includes/assets/js/plugins/leaflet.disaggregationControls.js
@@ -41,6 +41,7 @@
             this.hasSeries = (this.allSeries.length > 0);
             this.hasUnits = (this.allUnits.length > 0);
             this.hasDisaggregations = this.hasDissagregationsWithValues();
+            this.hasDisaggregationsWithMultipleValues = this.hasDisaggregationsWithMultipleValues();
         },
 
         getVisibleDisaggregations: function() {
@@ -130,6 +131,16 @@
             var hasDisaggregations = false;
             this.allDisaggregations.forEach(function(disaggregation) {
                 if (disaggregation.values.length > 0 && disaggregation.values[0] !== '') {
+                    hasDisaggregations = true;
+                }
+            });
+            return hasDisaggregations;
+        },
+
+        hasDisaggregationsWithMultipleValues: function () {
+            var hasDisaggregations = false;
+            this.allDisaggregations.forEach(function(disaggregation) {
+                if (disaggregation.values.length > 1 && disaggregation.values[1] !== '') {
                     hasDisaggregations = true;
                 }
             });
@@ -314,7 +325,7 @@
                     numUnits = this.allUnits.length,
                     displayForm = this.displayForm;
 
-                if (displayForm && (this.hasDisaggregations || (numSeries > 1 || numUnits > 1))) {
+                if (displayForm && (this.hasDisaggregationsWithMultipleValues || (numSeries > 1 || numUnits > 1))) {
 
                     var button = L.DomUtil.create('button', 'disaggregation-button');
                     button.innerHTML = translations.indicator.change_breakdowns;


### PR DESCRIPTION
Testing instructions:

For any indicator with a map, add a new column in the data, and give each row the same value. For example add a new column called "Foo" and give each row a value of "Bar" in that column.

Without this PR, that new disaggregation value ("Foo: Bar") will *not* appear in the lower-left map disaggregation box. But with this PR, it should appear.

If you would like to test the button for changing the map disaggregations, the site configuration for that is "disaggregation_controls" under "map_options", as shown here: https://open-sdg.readthedocs.io/en/latest/maps/#map_options (it needs to be "true" for the button to appear)

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-map-identify-region-columns/3-3-3/)
Fixed issues | Fixes #ISSUENUMBER
Related version | 1.6.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
