### PR TITLE
Clarify button labels

### DIFF
--- a/_includes/assets/js/accessibility.js
+++ b/_includes/assets/js/accessibility.js
@@ -122,3 +122,13 @@ var accessibilitySwitcher = function () {
     }
 
 };
+
+// Dynamic aria labels on navbar toggle.
+$(document).ready(function() {
+    $('#navbarSupportedContent').on('shown.bs.collapse', function() {
+        $('.navbar-toggler').attr('aria-label', translations.header.hide_menu);
+    });
+    $('#navbarSupportedContent').on('hidden.bs.collapse', function() {
+        $('.navbar-toggler').attr('aria-label', translations.header.show_menu);
+    });
+});

--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -477,11 +477,20 @@
         plugin.updateColors();
 
         // Add zoom control.
-        plugin.zoomHome = L.Control.zoomHome();
+        plugin.zoomHome = L.Control.zoomHome({
+          zoomInTitle: translations.indicator.map_zoom_in,
+          zoomOutTitle: translations.indicator.map_zoom_out,
+          zoomHomeTitle: translations.indicator.map_zoom_home,
+        });
         plugin.map.addControl(plugin.zoomHome);
 
         // Add full-screen functionality.
-        plugin.map.addControl(new L.Control.FullscreenAccessible());
+        plugin.map.addControl(new L.Control.FullscreenAccessible({
+          title: {
+              'false': translations.indicator.map_fullscreen,
+              'true': translations.indicator.map_fullscreen_exit,
+          },
+        }));
 
         // Add the year slider.
         plugin.map.addControl(L.Control.yearSlider({

--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -477,7 +477,8 @@
         plugin.updateColors();
 
         // Add zoom control.
-        plugin.map.addControl(L.Control.zoomHome());
+        plugin.zoomHome = L.Control.zoomHome();
+        plugin.map.addControl(plugin.zoomHome);
 
         // Add full-screen functionality.
         plugin.map.addControl(new L.Control.FullscreenAccessible());
@@ -613,6 +614,8 @@
           plugin.map.invalidateSize();
           // Also zoom in/out as needed.
           plugin.map.fitBounds(plugin.getVisibleLayers().getBounds());
+          // Set the home button to return to that zoom.
+          plugin.zoomHome.setHomeBounds(plugin.getVisibleLayers().getBounds());
           // Limit the panning to what we care about.
           plugin.map.setMaxBounds(plugin.getVisibleLayers().getBounds());
           // Make sure the info pane is not too wide for the map.

--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -428,6 +428,7 @@
             .attr('download', '')
             .attr('class', 'btn btn-primary btn-download')
             .attr('title', translations.indicator.download_geojson_title + ' - ' + downloadLabel)
+            .attr('aria-label', translations.indicator.download_geojson_title + ' - ' + downloadLabel)
             .text(translations.indicator.download_geojson + ' - ' + downloadLabel);
           $(plugin.element).parent().append(downloadButton);
 

--- a/_includes/assets/js/plugins/leaflet.searchAccessible.js
+++ b/_includes/assets/js/plugins/leaflet.searchAccessible.js
@@ -23,6 +23,7 @@
       this._button.innerHTML = '<i class="fa fa-search" aria-hidden="true"></i>';
 
       this._cancel.setAttribute('role', 'button');
+      this._cancel.title = translations.indicator.map_search_cancel;
       this._cancel.setAttribute('aria-label', this._cancel.title);
       this._cancel.innerHTML = '<i class="fa fa-close" aria-hidden="true"></i>';
 

--- a/_includes/assets/js/plugins/leaflet.yearSlider.js
+++ b/_includes/assets/js/plugins/leaflet.yearSlider.js
@@ -61,9 +61,15 @@
           maxYear = years[years.length - 1],
           knobElement = knob._element;
 
+      control._buttonBackward.title = translations.indicator.map_slider_back;
+      control._buttonBackward.setAttribute('aria-label', control._buttonBackward.title);
+      control._buttonForward.title = translations.indicator.map_slider_forward;
+      control._buttonForward.setAttribute('aria-label', control._buttonForward.title);
+
       knobElement.setAttribute('tabindex', '0');
       knobElement.setAttribute('role', 'slider');
-      knobElement.setAttribute('aria-label', translations.indicator.map_year_slider);
+      knobElement.setAttribute('aria-label', translations.indicator.map_slider_keyboard);
+      knobElement.title = translations.indicator.map_slider_mouse;
       knobElement.setAttribute('aria-valuemin', minYear);
       knobElement.setAttribute('aria-valuemax', maxYear);
 

--- a/_includes/assets/js/view/utils.js
+++ b/_includes/assets/js/view/utils.js
@@ -63,6 +63,7 @@ function createDownloadButton(table, name, indicatorId, el) {
             .attr({
                 'download': fileName,
                 'title': translations.indicator.download_csv_title,
+                'aria-label': translations.indicator.download_csv_title,
                 'class': 'btn btn-primary btn-download',
                 'tabindex': 0
             });
@@ -94,6 +95,7 @@ function createDownloadButton(table, name, indicatorId, el) {
                 'href': opensdg.remoteDataBaseUrl + '/headline/' + id + '.csv',
                 'download': headlineId + '.csv',
                 'title': translations.indicator.download_headline_title,
+                'aria-label': translations.indicator.download_headline_title,
                 'class': 'btn btn-primary btn-download',
                 'tabindex': 0
             }));
@@ -113,6 +115,7 @@ function createSourceButton(indicatorId, el) {
             'href': opensdg.remoteDataBaseUrl + '/data/' + indicatorId + '.csv',
             'download': indicatorId + '.csv',
             'title': translations.indicator.download_source_title,
+            'aria-label': translations.indicator.download_source_title,
             'class': 'btn btn-primary btn-download',
             'tabindex': 0
         }));

--- a/_includes/components/charts/chart.html
+++ b/_includes/components/charts/chart.html
@@ -18,9 +18,13 @@
         </div>
       </figure>
       <div id="chartSelectionDownload" class="clearfix">
-        <button id="btnSave" title="{{ page.t.indicator.download_chart_image_title }}" class='btn btn-primary btn-download'>
+        <button
+          id="btnSave"
+          title="{{ page.t.indicator.download_chart_image_title }}"
+          aria-label="{{ page.t.indicator.download_chart_image_title }}"
+          class='btn btn-primary btn-download'>
           {{ page.t.indicator.download_chart_image }}
-        </button><!-- 
+        </button><!--
    --></div>
     </div>
 

--- a/_includes/components/goal-tiles.html
+++ b/_includes/components/goal-tiles.html
@@ -3,7 +3,7 @@
         {% for goal in page.goals %}
         <div class="col-4 col-md-2 col-lg-1 goal-tile">
             <a href="{{ goal.url }}">
-                <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+                <img src="{{ goal.icon }}" id="goal-{{ goal.number }}" alt="{{ page.t.general.goal }} {{ goal.number }} - {{ goal.short | escape }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
             </a>
         </div>
         {% endfor %}

--- a/_includes/components/header/logo.html
+++ b/_includes/components/header/logo.html
@@ -1,3 +1,3 @@
-<a class="navbar-brand" href="{{ page.baseurl }}" id="home">
+<a class="navbar-brand" href="{{ page.baseurl }}" id="home" aria-label="{{ page.t.header.logo_title }}" title="{{ page.t.header.logo_title }}">
     <img src="{{ page.logo.src }}" alt="{{ page.logo.alt }}" />
 </a>

--- a/_includes/components/indicator/breadcrumbs.html
+++ b/_includes/components/indicator/breadcrumbs.html
@@ -13,14 +13,22 @@
         </li>
         {% endfor %}
         <li class="breadcrumb-item">
-            <a href="{{ page.goal.url }}" title="{{ page.goal.name | escape }}">{{ page.t.general.goal }} {{ page.goal.number }}</a>
+            <a href="{{ page.goal.url }}"
+               title="{{ page.t.general.goal }} {{ page.goal.number }} - {{ page.goal.short | escape }}"
+               aria-label="{{ page.t.general.goal }} {{ goal.number }} - {{ goal.short | escape }}">
+               {{ page.t.general.goal }} {{ page.goal.number }}
+            </a>
         </li>
         {% else %}
         <li class="breadcrumb-item">
             <a href="{{ page.baseurl }}">{{ page.t.general.home }}</a>
         </li>
         <li class="breadcrumb-item">
-            <a href="{{ page.goal.url }}" title="{{ page.goal.name | escape }}">{{ page.t.general.goal }} {{ page.goal.number }}</a>
+            <a href="{{ page.goal.url }}"
+               title="{{ page.t.general.goal }} {{ page.goal.number }} - {{ page.goal.short | escape }}"
+               aria-label="{{ page.t.general.goal }} {{ goal.number }} - {{ goal.short | escape }}">
+               {{ page.t.general.goal }} {{ page.goal.number }}
+            </a>
         </li>
         <li class="breadcrumb-item active">{{ page.t.general.indicator }} {{ page.indicator.number }}</li>
         {% endif %}

--- a/_includes/components/indicator/header.html
+++ b/_includes/components/indicator/header.html
@@ -3,7 +3,7 @@
         <div class="row">
             {% unless page.indicator.standalone %}
             <div class="col-4 col-md-3 col-lg-2 goal-icon goal-tiles">
-                <a href="{{ page.goal.url }}" aria-label="{{ page.t.indicator.view_indicator_list }}" title="{{ page.t.indicator.view_indicator_list }}">
+                <a href="{{ page.goal.url }}" aria-label="{{ page.t.goal.indicators_for_goal }} {{ page.goal.number }}" title="{{ page.t.goal.indicators_for_goal }} {{ page.goal.number }}">
                     <img src="{{ page.goal.icon }}"
                         alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}"
                         id="goal-{{ page.goal.number }}"

--- a/_includes/components/indicator/header.html
+++ b/_includes/components/indicator/header.html
@@ -3,7 +3,7 @@
         <div class="row">
             {% unless page.indicator.standalone %}
             <div class="col-4 col-md-3 col-lg-2 goal-icon goal-tiles">
-                <a href="{{ page.goal.url }}" title="{{ page.t.indicator.view_indicator_list }}">
+                <a href="{{ page.goal.url }}" aria-label="{{ page.t.indicator.view_indicator_list }}" title="{{ page.t.indicator.view_indicator_list }}">
                     <img src="{{ page.goal.icon }}"
                         alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}"
                         id="goal-{{ page.goal.number }}"

--- a/_includes/components/reportingstatus/reporting-status-by-goal.html
+++ b/_includes/components/reportingstatus/reporting-status-by-goal.html
@@ -10,7 +10,7 @@
 {%- assign goal = goalreport.goal | strip | sdg_lookup -%}
 <div class="goal reporting-status-item">
     <div class="frame goal-tiles">
-        <a href="{{ goal.url }}">
+        <a href="{{ goal.url }}" title="{{ page.t.goal.indicators_for_goal }} {{ goal.number }}" aria-label="{{ page.t.goal.indicators_for_goal }} {{ goal.number }}">
         <img src="{{ goal.icon }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }} goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
         </a>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
     <div class="container">
         <nav class="navbar navbar-expand-lg navbar-light flex-wrap align-items-start">
             {% include components/header/logo.html %}
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ page.t.header.show_menu }}">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="d-flex flex-wrap w-100 justify-content-between">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,7 +16,7 @@
 <script src="https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>
 <script src="https://cdn.rawgit.com/socib/Leaflet.TimeDimension/master/dist/leaflet.timedimension.min.js"></script>
 <script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js'></script>
-<script src="https://bowercdn.net/c/leaflet.zoomhome-latest/dist/leaflet.zoomhome.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/torfsen/leaflet.zoomhome@master/dist/leaflet.zoomhome.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-search@2.9.7/dist/leaflet-search.min.js"></script>
 {% endif %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/autotrack/2.4.1/autotrack.js"></script>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -3,7 +3,7 @@
         <label class="visually-hidden" for="indicator_{{ include.id | default: 'search' }}">{{ page.t.search.search }}</label>
         <input class="form-control" type="search" name="q" id="indicator_{{ include.id | default: 'search' }}" title="{{ page.t.search.search }}">
         <span class="input-group-append">
-            <button class="btn btn-outline-secondary ms-n5" aria-label="{{ page.t.search.search }}" id="{{ include.id | default: 'search' }}-btn" type="submit">
+            <button class="btn btn-outline-secondary ms-n5" aria-label="{{ page.t.search.site_search }}" id="{{ include.id | default: 'search' }}-btn" type="submit">
                 <i class="fa fa-search"></i>
             </button>
         </span>


### PR DESCRIPTION
Testing instructions: The changes included in this PR are:
1. The aria-label for the mobile hamburger menu should be "Show navigation menu" when collapsed, and "Hide navigation menu" when expanded.
2. The aria-label of the search button should be "Site search".
3. The "Edit" button on indicator pages should now be "Edit Indicator"
4. The aria-labels on the map search buttons should be "Map search", "Show map search" and "Hide map search" respectively

In addition, this PR includes everything from the spreadsheet we developed in #1758 

Testing this PR requires using an sdg-translations branch in the data config: https://github.com/open-sdg/sdg-translations/pull/310. Eg:

```
translations:
  - class: TranslationInputSdgTranslations
    source: https://github.com/brockfanning/sdg-translations.git
    tag: clarify-button-aria-labels
```

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-clarify-button-aria-labels/)
Fixed issues | Fixes #1758 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
