### PR TITLE
Support for goal_content_heading site config

### DIFF
--- a/_includes/components/goal/goal-content.html
+++ b/_includes/components/goal/goal-content.html
@@ -2,6 +2,9 @@
 {% if goal_page_content_raw != '' %}
 <div class="row" id="page-content">
   <div class="col-xs-12">
+    {% if site.create_goals.goal_content_heading and site.create_goals.goal_content_heading != '' %}
+      <h2>{{ site.create_goals.goal_content_heading | t }}</h2>
+    {% endif %}
     {{ goal_page_content_raw | t | markdownify }}
   </div>
 </div>


### PR DESCRIPTION
Testing instructions:

Update the site config `create_goals` setting to include a `goal_content_heading` property. For example, to show some content on goal 1 with a heading, you could use this:

```
create_goals:
  previous_next_links: false
  goal_content_heading: 'My heading for goal content'
  goals:
    - goal: '1'
      content: 'My content for goal 1'
```

I believe this relies on the latest jekyll-open-sdg-plugins code (2.1.0-dev branch). So the Gemfile needs to have:

`gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '2.1.0-dev'`

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-goal-content-heading-config/2/)
Fixed issues | Fixes #1746
Related version | 1.6.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
