### PR TITLE
Year-slider starts with the most recent year

### DIFF
--- a/_includes/assets/js/plugins/jquery.sdgMap.js
+++ b/_includes/assets/js/plugins/jquery.sdgMap.js
@@ -470,7 +470,8 @@
         plugin.setColorScale();
 
         plugin.years = _.uniq(availableYears).sort();
-        plugin.currentYear = plugin.years[0];
+        //Start the map with the most recent year
+        plugin.currentYear = plugin.years.slice(-1)[0];
 
         // And we can now update the colors.
         plugin.updateColors();

--- a/_includes/assets/js/plugins/leaflet.yearSlider.js
+++ b/_includes/assets/js/plugins/leaflet.yearSlider.js
@@ -122,7 +122,8 @@
       // cause any problems. This converts the array of years into a comma-
       // delimited string of YYYY-MM-DD dates.
       times: years.map(function(y) { return y.time }).join(','),
-      currentTime: new Date(years[0].time).getTime(),
+      //Set the map to the most recent year
+      currentTime: new Date(years.slice(-1)[0].time).getTime(),
     });
     // Create the player.
     options.player = new L.TimeDimension.Player(options.playerOptions, options.timeDimension);


### PR DESCRIPTION
This is my first contribution to open-sdg

I hope I do everything right...

Starting the map wit the most recent year (as @MoBosse implementet for his SDG 1.8.0)

Example Indicator: [https://christoph-lsn.github.io/MT_Site/2-1-1/](https://christoph-lsn.github.io/MT_Site/2-1-1/)




Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #1650 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
