### PR TITLE
More margin above H2 when it is in content of 'page' and 'post' layouts

### DIFF
--- a/_sass/layouts/_page.scss
+++ b/_sass/layouts/_page.scss
@@ -1,0 +1,7 @@
+.layout-page {
+    #main-content {
+        h2 {
+            margin-top: 30px;
+        }
+    }
+}

--- a/_sass/layouts/_post.scss
+++ b/_sass/layouts/_post.scss
@@ -1,4 +1,9 @@
 .layout-post {
+  #main-content {
+    h2 {
+        margin-top: 30px;
+    }
+  }
   .post-header {
     margin-bottom: 20px;
   }

--- a/_sass/open-sdg.scss
+++ b/_sass/open-sdg.scss
@@ -55,6 +55,7 @@
 @import "layouts/default";
 @import "layouts/goal";
 @import "layouts/indicator";
+@import "layouts/page";
 @import "layouts/reporting_status";
 @import "layouts/goals";
 @import "layouts/config_builder";


### PR DESCRIPTION
This PR adds more margin above any H2 elements within the content of 'page' and 'post' layouts.

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-content-h2-margin-top/publications/)
Fixed issues | Fixes #1631 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
