### PR TITLE
Use new site config/default for empty metadata placeholder for sources

### DIFF
--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -10,6 +10,9 @@
           {% continue %}
         {% else %}
           {% assign metadata_content = site.empty_metadata_placeholder | t | default: page.t.indicator.empty_metadata_placeholder %}
+          {% if include.scope contains 'source_' %}
+            {% assign metadata_content = site.empty_metadata_placeholder_sources | t | default: page.t.indicator.empty_metadata_placeholder_sources %}
+          {% endif %}
           {% assign metadata_content = '<span class="empty-metadata-placeholder">' | append: metadata_content | append: '</span>' %}
           {% assign placeholder_not_needed = false %}
         {% endif %}

--- a/_includes/components/indicator/metadata.html
+++ b/_includes/components/indicator/metadata.html
@@ -13,7 +13,9 @@
           {% if include.scope contains 'source_' %}
             {% assign metadata_content = site.empty_metadata_placeholder_sources | t | default: page.t.indicator.empty_metadata_placeholder_sources %}
           {% endif %}
-          {% assign metadata_content = '<span class="empty-metadata-placeholder">' | append: metadata_content | append: '</span>' %}
+          {% unless indicator_metadata.name contains "_url" or indicator_metadata.name contains "_link" %}
+            {% assign metadata_content = '<span class="empty-metadata-placeholder">' | append: metadata_content | append: '</span>' %}
+          {% endunless %}
           {% assign placeholder_not_needed = false %}
         {% endif %}
       {% endunless %}
@@ -28,8 +30,9 @@
             {% unless url_text %}
               {% assign url_text = 'Link' %}
             {% endunless %}
-
-            {% if metadata_content contains "http" or metadata_content contains "mailto" %}
+            {% if placeholder_not_needed == false %}
+              <span class="empty-metadata-placeholder">{{ metadata_content }}</span>
+            {% elsif metadata_content contains "http" or metadata_content contains "mailto" %}
               <a href="{{ metadata_content }}" target="_blank">
                 {{ url_text }} <span class="visuallyhidden">{{ page.t.general.opens_new_window }}</span>
               </a>

--- a/_includes/components/indicator/sources-alt.html
+++ b/_includes/components/indicator/sources-alt.html
@@ -8,7 +8,7 @@ file is controlled by the 'sources' indicator configuration option.
 {% unless site.hide_empty_metadata %}
     {% assign show_placeholders = true %}
 {% endunless %}
-{% assign placeholder = site.empty_metadata_placeholder | t | default: page.t.indicator.empty_metadata_placeholder %}
+{% assign placeholder = site.empty_metadata_placeholder_sources | t | default: page.t.indicator.empty_metadata_placeholder_sources %}
 {% assign placeholder = '<span class="empty-metadata-placeholder">' | append: placeholder | append: '</span>' %}
 <div class="row">
 {% for source in page.indicator.sources %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,6 +329,16 @@ empty_metadata_placeholder: indicator.empty_metadata_placeholder
 
 The above default refers to a translation key which currently translates to "Not available for this indicator" in English.
 
+### empty_metadata_placeholder_sources
+
+_Optional_: This setting controls the text that displays for any *sources* field which has no content. Note that this setting is not used if `hide_empty_metadata` is set to `true`. If the omitted, the following default is used:
+
+```nohighlight
+empty_metadata_placeholder_sources: indicator.empty_metadata_placeholder_sources
+```
+
+The above default refers to a translation key which currently translates to "Not available for this source" in English.
+
 ### environment
 
 **_Required_**: This setting should be either `staging` or `production`. Certain features of the platform, such as data management links, will only appear on `staging`. Typically you will have this set to `staging` in the `_config.yml` file, and set to `production` in the `_config_prod.yml` file.


### PR DESCRIPTION
To test this, there will need to be a site configuration for `empty_metadata_placeholder_sources`, like this:

```
empty_metadata_placeholder_sources: Not available for this source
```

Note that this PR also fixes another bug that I just noticed related to link fields in sources (eg, source_url_1, etc.). When testing can you please confirm that the source link fields are working as expected?

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-empty-metadata-placeholder-sources/5-5-1/)
Fixed issues | Fixes #1848 
Related version | 2.1.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
