### PR TITLE
Custom headings and subheadings for goal pages

### DIFF
--- a/_includes/components/goal/goal-content.html
+++ b/_includes/components/goal/goal-content.html
@@ -2,8 +2,8 @@
 {% if goal_page_content_raw != '' %}
 <div class="row" id="page-content">
   <div class="col-xs-12">
-    {% if site.create_goals.goal_content_heading and site.create_goals.goal_content_heading != '' %}
-      <h2>{{ site.create_goals.goal_content_heading | t }}</h2>
+    {% if page.goal_content_heading and page.goal_content_heading != '' %}
+      <h2>{{ page.goal_content_heading | t }}</h2>
     {% endif %}
     {{ goal_page_content_raw | t | markdownify }}
   </div>

--- a/_includes/components/goal/header.html
+++ b/_includes/components/goal/header.html
@@ -5,7 +5,13 @@
                 <img src="{{ page.goal.icon }}" alt="{{ page.goal.short | escape }} - {{ page.t.general.goal }} {{ page.goal.number }}" id="goal-{{ page.goal.number }}" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}" />
             </div>
             <div class="col-8 col-md-9 col-lg-10 goal-details">
-                <h1>{{ page.goal.name }}</h1>
+                <h1>
+                    {% if page.goal_heading and page.goal_heading != '' %}
+                        {{ page.goal_heading | t }}
+                    {% else %}
+                        {{ page.goal.name }}
+                    {% endif %}
+                </h1>
             </div>
         </div>
     </div>

--- a/_includes/title-tag.html
+++ b/_includes/title-tag.html
@@ -6,7 +6,11 @@
         {{ page.indicator.name | escape }} - {{ site.title | t | escape }}
     </title>
 {% elsif page.goal %}
+    {% if page.goal_heading and page.goal_heading != '' %}
+    <title>{{ page.goal_heading | t | escape }} - {{ site.title | t | escape }}</title>
+    {% else %}
     <title>{{ page.t.general.goal | escape }} {{ page.goal.number }} - {{ page.goal.short | escape }} - {{ site.title | t | escape }}</title>
+    {% endif %}
 {% elsif page.title and page.title != '' %}
     <title>{{ page.title | t | escape }} - {{ site.title | t | escape }}</title>
 {% else %}

--- a/tests/features/Goal.feature
+++ b/tests/features/Goal.feature
@@ -27,3 +27,8 @@ Feature: Goal page
     Given I am on "/1"
     Then I should not see "Reported online"
     And I should see "Not applicable"
+
+  Scenario: Goals can have custom headings and subheadings
+    Given I am on "/1"
+    Then I should see "My custom heading for Goal 1"
+    And I should see "My custom subheading for Goal 1"

--- a/tests/features/LanguageSwitcher.feature
+++ b/tests/features/LanguageSwitcher.feature
@@ -12,11 +12,11 @@ Feature: Language switcher
     Then I should see "My Spanish frontpage introduction banner title"
 
   Scenario: Lanugage switcher works on a goal page
-    Given I am on "/1"
-    Then I should see "End poverty in all its forms everywhere"
+    Given I am on "/2"
+    Then I should see "End hunger, achieve food security and improved nutrition and promote sustainable agriculture"
     And I click on "the language toggle dropdown"
     And I follow "the first language option"
-    Then I should see "Poner fin a la pobreza en todas sus formas y en todo el mundo"
+    Then I should see "Poner fin al hambre, lograr la seguridad alimentaria y la mejora de la nutrición y promover la agricultura sostenible"
 
   Scenario: Language switcher works on an indicator page
     Given I am on "/1-1-1"

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -30,6 +30,8 @@ create_goals:
   previous_next_links: true
   goals:
     - content: custom.goal_1_content
+      heading: My custom heading for Goal 1
+      content_heading: My custom subheading for Goal 1
     - content: My goal 2 content
 create_indicators:
   previous_next_links: true


### PR DESCRIPTION
Depends on a jekyll-open-sdg-plugins PR: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/149

Testing instructions:

* The "Gemfile" will need to point to the PR mentioned above, eg:

        gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'goal-heading-per-goal'
* The site configuration will need the `heading` and/or `content_heading` in the `create_goals configuration, eg:

        create_goals:
          goals:
            - heading: My custom heading for Goal 1
              content_heading: My custom subheading for Goal 1
 
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-goal-heading-per-goal/)
Fixed issues | Fixes #1859 
Related version | 2.2.0-dev
Bugfix, feature or docs? | Feature
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
