### PR TITLE
Meta tag functionality

### DIFF
--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,12 +18,9 @@
 
         {% include title-tag.html %}
 
-        <meta name="description" content="">
-        <meta property="og:description" content="">
         {% if site.environment == 'staging' or include.noindex %}
         <meta name="robots" content="noindex, nofollow">
         {% endif %}
-        <link rel="canonical" href="/">
 
         <!--[if IE 9]>
         <script src="{{ site.baseurl }}/assets/js/lib/classList.js"></script>
@@ -57,6 +54,8 @@
         {% if site.analytics.gtm and site.analytics.gtm != '' %}
           {% include components/analytics/ga-gtm.html %}
         {% endif %}
+
+        {% include meta-tags.html %}
 
         <!--[if IE]>
         <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/ie.css">

--- a/_includes/meta-tags.html
+++ b/_includes/meta-tags.html
@@ -1,0 +1,3 @@
+{% for meta in page.meta_tags %}
+    <meta name="{{ meta['name'] | escape }}" content="{{ meta['content'] | t | escape }}">
+{% endfor %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -710,6 +710,34 @@ _Optional_: This setting configures the layers that will be visible on maps on i
 
 _Optional_: This setting configures general options for maps on indicator pages. For more information on this setting, see the [Maps guidance](maps.md).
 
+### menu
+
+**_Required_**: This setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](translation.md).
+
+```nohighlight
+menu:
+  - path: reporting-status/
+    translation_key: menu.reporting_status
+  - path: about/
+    translation_key: menu.about
+  - path: faq/
+    translation_key: menu.faq
+```
+
+Menu items can also be turned into dropdowns by putting additional menu items under a `dropdown` setting. For example, this would move "about/" and "faq/" under a "More information" dropdown:
+
+```nohighlight
+menu:
+  - path: reporting-status/
+    translation_key: menu.reporting_status
+  - translation_key: More information
+    dropdown:
+      - path: faq/
+        translation_key: menu.faq
+      - path: about/
+        translation_key: menu.about
+```
+
 ### metadata_edit_url
 
 **_Required_**: This setting controls the URL of the "Edit Metadata" that appear on the staging site's indicator pages. It should be a full URL. Note that you can include `[id]` in the URL, and it will be dynamically replaced with the indicator's id (dash-delimited).
@@ -770,33 +798,30 @@ metadata_tabs:
     placeholder: There are no publications available for this indicator
 ```
 
-### menu
+### meta_tags
 
-**_Required_**: This setting controls the main navigation menu for the platform. It should contain a list of menu items, each containing a `path` and a [translation key](translation.md).
-
-```nohighlight
-menu:
-  - path: reporting-status/
-    translation_key: menu.reporting_status
-  - path: about/
-    translation_key: menu.about
-  - path: faq/
-    translation_key: menu.faq
-```
-
-Menu items can also be turned into dropdowns by putting additional menu items under a `dropdown` setting. For example, this would move "about/" and "faq/" under a "More information" dropdown:
+_Optional_: This setting can be used to set [meta tags](https://www.w3schools.com/tags/tag_meta.asp) on any of the paths within the site. It should contain a list of items, each containing a `path`, a `name`, and `content`.
 
 ```nohighlight
-menu:
-  - path: reporting-status/
-    translation_key: menu.reporting_status
-  - translation_key: More information
-    dropdown:
-      - path: faq/
-        translation_key: menu.faq
-      - path: about/
-        translation_key: menu.about
+meta_tags:
+  - path: about
+    name: description
+    content: My description text for the About page
+  - path: '1'
+    name: keywords
+    content: my list of keywords for Goal 1
 ```
+
+Note that the homepage should have a `path` of `''`, eg:
+
+```nohighlight
+meta_tags:
+  - path: ''
+    name: description
+    content: My description text for the homepage
+```
+
+If your platform is multilingual, note that the `content` can be a [translation key](translation.md), and the `path` should not contain any language abbreviations.
 
 ### news
 

--- a/tests/features/MetaTags.feature
+++ b/tests/features/MetaTags.feature
@@ -1,0 +1,10 @@
+Feature: Meta tags
+
+  As a search index or third-party service crawling the site
+  I need to see any meta tags
+  So that I can correctly process each page
+
+  Scenario: Pages can have arbitrary meta tags in the HEAD
+    Given I am on "/about"
+    Then I should see "my meta name"
+    And I should see "my meta content"

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -257,6 +257,10 @@ metadata_tabs:
     title: Publications
     description: My publications blurb
     placeholder: No publications available
+meta_tags:
+  - path: about
+    name: my meta name
+    content: my meta content
 news:
   category_links: true
 progress_status:


### PR DESCRIPTION
This depends on a jekyll-open-sdg-plugins PR: https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/150. So it would need a change to the Gemfile like this:

`gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'meta-tags'`

This PR includes documentation on the configuration. Here is an example of using it to add a meta description on the "/about" page:

```
meta_tags:
  - path: about
    name: description
    content: my description content
```

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-meta-tags/)
Fixed issues | Fixes #1860 
Related version | 2.2.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
