### PR TITLE
SDG image on reporting status overall row

### DIFF
--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -8,7 +8,7 @@
 
 <div class="goal goal-overall">
     <div class="frame goal-tiles">
-        <img src="https://place-hold.it/250" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }} goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+        <img src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="" width="100" height="100" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
     </div>
     <div class="details">
         <h2 class="status-goal">

--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -7,6 +7,9 @@
 {%- endif -%}
 
 <div class="goal goal-overall">
+    <div class="frame goal-tiles">
+        <img src="https://place-hold.it/250" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }} goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+    </div>
     <div class="details">
         <h2 class="status-goal">
             {{ include.title }}

--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -8,7 +8,7 @@
 
 <div class="goal goal-overall">
     <div class="frame goal-tiles">
-        <img src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="" width="100" height="100" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+        <img src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="{{ page.t.general.sdg }}" width="100" height="100" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
     </div>
     <div class="details">
         <h2 class="status-goal">

--- a/_includes/components/reportingstatus/reporting-status-overall.html
+++ b/_includes/components/reportingstatus/reporting-status-overall.html
@@ -7,9 +7,11 @@
 {%- endif -%}
 
 <div class="goal goal-overall">
+    {% unless include.hide_wheel %}
     <div class="frame goal-tiles">
         <img src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="{{ page.t.general.sdg }}" width="100" height="100" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
     </div>
+    {% endunless %}
     <div class="details">
         <h2 class="status-goal">
             {{ include.title }}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -79,7 +79,7 @@
     {%- for extra_field in reporting_data.extra_fields -%}
     {% assign extra_field_name = extra_field[0] %}
     <div role="tabpanel" class="tab-pane" id="{{ extra_field_name }}view" data-extra-field="true">
-      {% include components/reportingstatus/reporting-status-overall.html overall=reporting_data.overall title=page.t.status.overall_reporting_status status_types="reporting_status" %}
+      {% include components/reportingstatus/reporting-status-overall.html hide_wheel=true overall=reporting_data.overall title=page.t.status.overall_reporting_status status_types="reporting_status" %}
       {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.status_by_field status_types="reporting_status" %}
     </div>
     {%- endfor -%}
@@ -95,7 +95,7 @@
       {%- for extra_field in disagg_data.extra_fields -%}
       {% assign extra_field_name = extra_field[0] %}
       <div role="tabpanel" class="tab-pane" id="{{ extra_field_name }}-disaggregationsview" data-extra-field="true">
-        {% include components/reportingstatus/reporting-status-overall.html overall=disagg_data.overall title=page.t.status.disaggregation_status_overall status_types="disaggregation_status" %}
+        {% include components/reportingstatus/reporting-status-overall.html hide_wheel=true overall=disagg_data.overall title=page.t.status.disaggregation_status_overall status_types="disaggregation_status" %}
         {% include components/reportingstatus/reporting-status-by-field.html extra_field=extra_field title=page.t.status.disaggregation_status_by_field status_types="disaggregation_status" %}
       </div>
       {%- endfor -%}

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -132,10 +132,6 @@
         }
         .goal-overall {
             margin-bottom: 20px;
-
-            .details {
-                width: 100%;
-            }
         }
     }
 

--- a/tests/features/Proxy.feature
+++ b/tests/features/Proxy.feature
@@ -7,12 +7,12 @@ Feature: Proxy indicators
   Scenario: Entire indicators can be advertised as "proxy" indicators
     Given I am on "/1-1-1"
     Then I should see 3 "proxy pill" elements
-    And I should see "This indicator contains some alternative data to those specified by the United Nations (UN). The data displayed are the closest match currently available."
+    And I should see "This indicator contains some alternative data to those specified by the United Nations (UN). This indicator is the most suitable match currently available."
 
   Scenario: Certain serieses within indicators can be advertised as "proxy" serieses
     Given I am on "/1-3-1"
     And I wait 3 seconds
-    Then I should see "This indicator contains some alternative data to those specified by the United Nations (UN). The data displayed are the closest match currently available."
+    Then I should see "This indicator contains some alternative data to those specified by the United Nations (UN). This indicator is the most suitable match currently available."
     Then I should see 3 "proxy pill" elements
     And I click on "the second series"
     And I wait 3 seconds

--- a/tests/features/support/mink.js
+++ b/tests/features/support/mink.js
@@ -27,7 +27,7 @@ const driver = new mink.Mink({
     "the language toggle dropdown": "header .language-toggle-dropdown .dropdown-toggle",
     "the first language option": "header .language-toggle-dropdown .dropdown-menu li:first-child a",
     "the last language option": "header .language-toggle-dropdown .dropdown-menu li:last-child a",
-    "goal status": ".goal .frame",
+    "goal status": ".reporting-status-item .frame",
     "the second reporting status tab": ".nav-tabs.reporting-status-view li:last-child button",
     "the search box": "#indicator_search",
     "disaggregation filter": ".variable-selector",


### PR DESCRIPTION
This PR adds the SDG wheel as a decorative image in the first row of the reporting status and disaggregation status pages. This makes the horizontal bars line up with the others below it. The wheel should only show on the status-by-goal tabs -- not on any status-by-field tabs.

http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-reportingstatus-overall-image/reporting-status/ - feature branch tested 
