### PR TITLE
Indicator iframes

### DIFF
--- a/_includes/components/indicator/metadata-panes.html
+++ b/_includes/components/indicator/metadata-panes.html
@@ -39,7 +39,7 @@
     {% else %}
         {% include components/indicator/metadata-panes-default.html %}
     {% endif %}
-    {% if site.environment == 'staging' %}
+    {% if site.environment == 'staging' and page.layout != 'indicator-iframe' %}
         <div role="tabpanel" class="tab-pane" id="edit">
             {% include components/indicator/edit-buttons.html %}
         </div>

--- a/_includes/components/indicator/metadata-tabs.html
+++ b/_includes/components/indicator/metadata-tabs.html
@@ -26,7 +26,7 @@
     {% else %}
         {% include components/indicator/metadata-tabs-default.html %}
     {% endif %}
-    {% if site.environment == 'staging' %}
+    {% if site.environment == 'staging' and page.layout != 'indicator-iframe' %}
         <li role="presentation" class="nav-item">
             <button class="nav-link" data-bs-toggle="tab" data-bs-target="#edit" aria-controls="edit" role="tab">{{ page.t.indicator.edit }}</a>
         </li>

--- a/_layouts/indicator-iframe.html
+++ b/_layouts/indicator-iframe.html
@@ -1,4 +1,5 @@
 {% include head.html %}
+{% include multilingual-js.html key="header" %}
 
 {% include components/indicator/fields-template.html %}
 {% include components/indicator/units-template.html %}
@@ -14,7 +15,6 @@
   {% include components/indicator/indicator-progress.html %}
   {% include components/indicator/indicator-content.html %}
   {% include components/indicator/indicator-main.html %}
-  {% include back-to-top.html %}
 </div>
 
 {% include scripts.html %}

--- a/_layouts/indicator-iframe.html
+++ b/_layouts/indicator-iframe.html
@@ -1,0 +1,27 @@
+{% include head.html %}
+
+{% include components/indicator/fields-template.html %}
+{% include components/indicator/units-template.html %}
+{% include components/indicator/series-template.html %}
+{% include multilingual-js.html key="indicator" %}
+{% include multilingual-js.html key="data" %}
+
+{% include components/indicator/header.html %}
+<div id="main-content" class="container goal-{{ page.goal.number }}" role="main">
+  {% include components/indicator/data-notice.html %}
+  {% include components/indicator/indicator-available.html %}
+  {% include components/indicator/proxy-banner.html %}
+  {% include components/indicator/indicator-progress.html %}
+  {% include components/indicator/indicator-content.html %}
+  {% include components/indicator/indicator-main.html %}
+  {% include back-to-top.html %}
+</div>
+
+{% include scripts.html %}
+<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
+<script>
+    new pym.Child();
+</script>
+
+</body>
+</html>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,3 +41,19 @@ To deploy the site repository requires these tasks (which, again, are pre-config
 1. Build the Jekyll site
 1. Validate the HTML of the site to ensure quality
 1. Upload the built files to the hosting provider
+
+### Embedding indicators on other sites
+
+Each individual indicator page can be embedded on other sites or pages, using iframes. The iframe-friendly URLs are the same as the indicator page URLs, but with "-frame" added. For example, instead of `/1-1-1`, the iframe-friendly version is `/1-1-1-iframe`.
+
+The recommended way to embed indicators as iframes is using the [Pym.js](https://blog.apps.npr.org/pym.js/) library. Here is some example embed code:
+
+```
+<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
+<div id="my-iframe-container"></div>
+<script>
+    var pymParent = new pym.Parent('my-iframe-container', 'https://my-github-org.github.io/my-site-repo/1-1-1-iframe', {});
+</script>
+```
+
+The reason for using Pym.js is to avoid having vertical scrollbars on the iframe, since the height of the indicator pages is unpredictable.

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -52,3 +52,7 @@ Feature: Indicator
 
   Scenario: Indicators can display a free form blurb at the top.
     Then I should see "This is the page content in English."
+
+  Scenario: Indicators get an iframe-friendly version.
+    And I am on "/1-1-1/iframe"
+    Then I should see "This is the page content in English."

--- a/tests/features/Indicator.feature
+++ b/tests/features/Indicator.feature
@@ -54,7 +54,7 @@ Feature: Indicator
     Then I should see "This is the page content in English."
 
   Scenario: Indicators get an iframe-friendly version.
-    And I am on "/1-1-1/iframe"
+    And I am on "/1-1-1-iframe"
     Then I should see "This is the page content in English."
 
   Scenario: Country name is translated in table header.

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer", "3.19.4"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'indicator-iframes'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '2.3.0-dev'

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,4 +4,4 @@ gem "jekyll", "3.8.4"
 gem "html-proofer", "3.19.4"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '2.3.0-dev'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'indicator-iframes'


### PR DESCRIPTION
This PR (along with https://github.com/open-sdg/jekyll-open-sdg-plugins/pull/159) create iframe-friendly versions of each indicator. The URLs of the iframe-friendly versions is the same, but with "-frame" at the end. For example the iframe-friendly version of `/1-1-1` would be `/1-1-1-iframe`.

The "iframe-friendly" part is that these new versions of the indicators do not include the sitewide header and footer. They do include other parts of the indicator pages, like the indicator header, and the metadata tabs, which in theory could be removed as well, if that is what folks prefer (let me know in the comments below). They also include usage of the Pym.js library which can be used to avoid vertical scrollbars on the iframe.

Testing instructions:

In your site repository's Gemfile, point to my other branch in jekyll-open-sdg-plugins:

`gem 'jekyll-open-sdg-plugins', git: 'https://github.com/brockfanning/jekyll-open-sdg-plugins.git', branch: 'indicator-iframes'`

In any page in your site, add some code in order to embed an indicator. For example, to create a new page that embeds an indicator, you could create a file called "my-page.md" with something like this:

```
---
title: My page
permalink: /my-page/
layout: page
---
Indicator 1.1.1 should be embedded below:

<script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
<div id="my-iframe-container"></div>
<script>
    var pymParent = new pym.Parent('my-iframe-container', '{{ site.baseurl }}/1-1-1-iframe', {});
</script>
```

You could also simply do an iframe directly, however then you lose out on the benefit of the Pym.js library, which is what is supposed to prevent vertical scrollbars. If you wanted to do this, it would be something like this:

```
---
title: My page
permalink: /my-page/
layout: page
---
Indicator 1.1.1 should be embedded below:

<iframe src="{{ site.baseurl }}/1-1-1-iframe"></iframe>
```

(though you'd probably also need to play around with the height and width)

Note that the automated tests here will fail until the jekyll-open-sdg-plugins PR is merged.

Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #2023 
Related version | 2.3.0-dev
Bugfix, feature or docs? | Feature
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
