### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,6 @@ nav:
     - Community:
         - Platform updates: updates.md
         - Change log: changelog.md
-        - Support: support.md
         - Getting Support: support.md
         - Contribution guidelines: contribution.md
         - Code of conduct: conduct.md


### PR DESCRIPTION
Just noticed that both 'Support' and 'Getting Support' both link to the same place. I have removed 'Support' to correct this.
