### PR TITLE
Use role=button in several places

### DIFF
--- a/_includes/assets/js/view/utils.js
+++ b/_includes/assets/js/view/utils.js
@@ -65,7 +65,8 @@ function createDownloadButton(table, name, indicatorId, el, selectedSeries, sele
                 'title': translations.indicator.download_csv_title,
                 'aria-label': translations.indicator.download_csv_title,
                 'class': 'btn btn-primary btn-download',
-                'tabindex': 0
+                'tabindex': 0,
+                'role': 'button',
             });
         var blob = new Blob([tableCsv], {
             type: 'text/csv'
@@ -97,7 +98,8 @@ function createDownloadButton(table, name, indicatorId, el, selectedSeries, sele
                 'title': translations.indicator.download_headline_title,
                 'aria-label': translations.indicator.download_headline_title,
                 'class': 'btn btn-primary btn-download',
-                'tabindex': 0
+                'tabindex': 0,
+                'role': 'button',
             }));
     }
 }
@@ -117,7 +119,8 @@ function createSourceButton(indicatorId, el) {
             'title': translations.indicator.download_source_title,
             'aria-label': translations.indicator.download_source_title,
             'class': 'btn btn-primary btn-download',
-            'tabindex': 0
+            'tabindex': 0,
+            'role': 'button',
         }));
 }
 
@@ -142,7 +145,8 @@ function createIndicatorDownloadButtons(indicatorDownloads, indicatorId, el) {
                     'download': href.split('/').pop(),
                     'title': buttonLabelTranslated,
                     'class': 'btn btn-primary btn-download',
-                    'tabindex': 0
+                    'tabindex': 0,
+                    'role': 'button',
                 }));
         }
     }

--- a/_includes/components/contrast-toggle.html
+++ b/_includes/components/contrast-toggle.html
@@ -1,3 +1,3 @@
 <a title="{{ page.t.header.enable_high_contrast }}" aria-label="{{ page.t.header.enable_high_contrast }}"
-    data-contrast-switch-to="" href="javascript:void(0)" {% include autotrack.html preset="switch_contrast"
+    data-contrast-switch-to="" role="button" href="javascript:void(0)" {% include autotrack.html preset="switch_contrast"
     category="Accessibility" action="Change contrast setting" label="high" %}>A</a>

--- a/_includes/components/download-all-data.html
+++ b/_includes/components/download-all-data.html
@@ -1,5 +1,6 @@
 <div class="zip-download-container">
     <a href="{{ page.remote_data_prefix }}/zip/{{ site.data.zip.filename }}"
+       role="button"
        class="btn btn-primary btn-download" aria-describedby="zip-download-info">
         {{ page.t.frontpage.download_all }}
     </a>

--- a/_includes/components/indicator/headline.html
+++ b/_includes/components/indicator/headline.html
@@ -12,9 +12,9 @@
   <div id="datatables">
 
     {% unless no_headline %}
-    <a href="{{ page.remote_data_prefix }}/headline/{{ page.indicator.slug }}.csv" class="btn btn-primary btn-download" download="indicator_{{ page.indicator.slug }}.csv" tabindex="0" role="button">{{ page.t.indicator.download_headline }}</a>
+    <a role="button" href="{{ page.remote_data_prefix }}/headline/{{ page.indicator.slug }}.csv" class="btn btn-primary btn-download" download="indicator_{{ page.indicator.slug }}.csv" tabindex="0" role="button">{{ page.t.indicator.download_headline }}</a>
     {% endunless %}
-    <a href="{{ page.remote_data_prefix }}/data/{{ page.indicator.slug }}.csv" class="btn btn-primary btn-download" download='indicator_{{ page.indicator.slug }}.csv' tabindex='0' role='button'>{{ page.t.indicator.download_source }}</a>
+    <a role="button" href="{{ page.remote_data_prefix }}/data/{{ page.indicator.slug }}.csv" class="btn btn-primary btn-download" download='indicator_{{ page.indicator.slug }}.csv' tabindex='0' role='button'>{{ page.t.indicator.download_source }}</a>
 
     <p class="no-js-disaggregation-hint">{{ page.t.indicator.download_source_for_disaggregations }}</p>
 


### PR DESCRIPTION
Two possible approach would have worked here:
1. Changing several <a> tags to <button> tags
2. Adding role=button to the <a> tags instead

In an ideal world, the first option is preferable, but would have required a lot of code rewriting. This PR does the easier approach of adding role=button in several places.

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-semantic-button-consistency/3-3-3/)
Fixed issues | Fixes #2031 
Related version | 2.3.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
