### PR TITLE
Fixes for chart.js annotations

### DIFF
--- a/_includes/assets/js/model/chartHelpers.js
+++ b/_includes/assets/js/model/chartHelpers.js
@@ -389,9 +389,15 @@ function prepareDataForDataset(years, rows, allObservationAttributes) {
     data: [],
     observationAttributes: [],
   };
-  var configObsAttributes = {{ site.observation_attributes | jsonify }}.map(function(obsAtt) {
-    return obsAtt.field;
-  });
+  var configObsAttributes = {{ site.observation_attributes | jsonify }};
+  if (configObsAttributes && configObsAttributes.length > 0) {
+    configObsAttributes = configObsAttributes.map(function(obsAtt) {
+      return obsAtt.field;
+    });
+  }
+  else {
+    configObsAttributes = [];
+  }
   years.forEach(function(year) {
     var found = rows.find(function (row) {
       return row[YEAR_COLUMN] === year;

--- a/_includes/assets/js/model/dataHelpers.js
+++ b/_includes/assets/js/model/dataHelpers.js
@@ -149,9 +149,15 @@ function getAllObservationAttributes(rows) {
   }
   var obsAttributeHash = {},
       footnoteNumber = 0,
-      configObsAttributes = {{ site.observation_attributes | jsonify }}.map(function(obsAtt) {
-        return obsAtt.field;
-      })
+      configObsAttributes = {{ site.observation_attributes | jsonify }};
+  if (configObsAttributes && configObsAttributes.length > 0) {
+    configObsAttributes = configObsAttributes.map(function(obsAtt) {
+      return obsAtt.field;
+    });
+  }
+  else {
+    configObsAttributes = [];
+  }
   configObsAttributes.forEach(function(field) {
     var attributeValues = Object.keys(_.groupBy(rows, field)).filter(function(value) {
       return value !== 'undefined';

--- a/_includes/assets/js/model/utils.js
+++ b/_includes/assets/js/model/utils.js
@@ -66,13 +66,17 @@ function nonFieldColumns() {
     'Unit measure',
   ];
   var timeSeriesAttributes = {{ site.time_series_attributes | jsonify }};
-  timeSeriesAttributes.forEach(function(tsAttribute) {
-    columns.push(tsAttribute.field);
-  });
+  if (timeSeriesAttributes && timeSeriesAttributes.length > 0) {
+    timeSeriesAttributes.forEach(function(tsAttribute) {
+      columns.push(tsAttribute.field);
+    });
+  }
   var observationAttributes = {{ site.observation_attributes | jsonify }};
-  observationAttributes.forEach(function(oAttribute) {
-    columns.push(oAttribute.field);
-  });
+  if (observationAttributes && observationAttributes.length > 0) {
+    observationAttributes.forEach(function(oAttribute) {
+      columns.push(oAttribute.field);
+    });
+  }
   columns.push(SERIES_COLUMN);
   return columns;
 }

--- a/_includes/assets/js/view/chartHelpers.js
+++ b/_includes/assets/js/view/chartHelpers.js
@@ -240,6 +240,7 @@ function createPlot(chartInfo, helpers) {
     VIEW._chartInstance.data.datasets = updatedConfig.data.datasets;
     VIEW._chartInstance.data.labels = updatedConfig.data.labels;
     VIEW._chartInstance.options = updatedConfig.options;
+    updateGraphAnnotationColors(isHighContrast() ? 'high' : 'default', updatedConfig);
 
     // The following is needed in our custom "rescaler" plugin.
     VIEW._chartInstance.data.allLabels = VIEW._chartInstance.data.labels.slice(0);

--- a/_includes/assets/js/view/chartHelpers.js
+++ b/_includes/assets/js/view/chartHelpers.js
@@ -256,8 +256,8 @@ function createPlot(chartInfo, helpers) {
  * @return null
  */
 function updateGraphAnnotationColors(contrast, chartInfo) {
-    if (chartInfo.options.annotation) {
-        chartInfo.options.annotation.annotations.forEach(function (annotation) {
+    if (chartInfo.options.plugins.annotation) {
+        chartInfo.options.plugins.annotation.annotations.forEach(function (annotation) {
             if (contrast === 'default') {
                 $.extend(true, annotation, annotation.defaultContrast);
             }

--- a/_includes/assets/js/view/chartTypeBase.js
+++ b/_includes/assets/js/view/chartTypeBase.js
@@ -200,6 +200,12 @@ opensdg.chartTypes.base = function(info) {
                     if (annotation.label.backgroundColor) {
                         annotation.defaultContrast.label.backgroundColor = annotation.label.backgroundColor;
                     }
+                    if (annotation.label.borderWidth) {
+                        annotation.defaultContrast.label.borderWidth = annotation.label.borderWidth;
+                    }
+                    if (annotation.label.borderColor) {
+                        annotation.defaultContrast.label.borderColor = annotation.label.borderColor;
+                    }
                 }
             }
             return annotation;

--- a/_includes/assets/js/view/chartTypeBase.js
+++ b/_includes/assets/js/view/chartTypeBase.js
@@ -157,6 +157,32 @@ opensdg.chartTypes.base = function(info) {
             if (annotation.label && annotation.label.content) {
                 annotation.label.content = translations.t(annotation.label.content);
             }
+            // Fix some keys where there was once a discrepancy between
+            // Open SDG and Chart.js. Eg, we mistakenly used "fontColor"
+            // instead of "color".
+            if (annotation.label && annotation.label.fontColor) {
+                annotation.label.color = annotation.label.fontColor;
+            }
+            if (annotation.highContrast && annotation.highContrast.label) {
+                if (annotation.highContrast.label.fontColor) {
+                    annotation.highContrast.label.color = annotation.highContrast.label.fontColor;
+                }
+            }
+            // We also used the wrong values for label position.
+            if (annotation.label &&
+                annotation.label.position &&
+                (annotation.label.position == 'top' ||
+                 annotation.label.position == 'left')) {
+                // It should be 'start' instead of 'top' or 'left'.
+                annotation.label.position = 'start';
+            }
+            if (annotation.label &&
+                annotation.label.position &&
+                (annotation.label.position == 'bottom' ||
+                 annotation.label.position == 'right')) {
+                // It should be 'start' instead of 'top' or 'left'.
+                annotation.label.position = 'end';
+            }
             // Save some original values for later used when contrast mode is switched.
             if (typeof annotation.defaultContrast === 'undefined') {
                 annotation.defaultContrast = {};
@@ -168,8 +194,8 @@ opensdg.chartTypes.base = function(info) {
                 }
                 if (annotation.label) {
                     annotation.defaultContrast.label = {};
-                    if (annotation.label.fontColor) {
-                        annotation.defaultContrast.label.fontColor = annotation.label.fontColor;
+                    if (annotation.label.color) {
+                        annotation.defaultContrast.label.color = annotation.label.color;
                     }
                     if (annotation.label.backgroundColor) {
                         annotation.defaultContrast.label.backgroundColor = annotation.label.backgroundColor;

--- a/_includes/components/charts/annotation_presets.js
+++ b/_includes/components/charts/annotation_presets.js
@@ -55,7 +55,7 @@ opensdg.annotationPresets = {
         mode: 'vertical',
         borderDash: [2, 2],
         label: {
-            position: 'top',
+            position: 'start',
             content: translations.indicator.annotation_series_break,
         },
     },

--- a/_includes/components/charts/annotation_presets.js
+++ b/_includes/components/charts/annotation_presets.js
@@ -8,12 +8,16 @@ opensdg.annotationPresets = {
         label: {
             backgroundColor: 'white',
             color: 'black',
+            borderWidth: 1,
+            borderColor: 'black',
         },
         // This "highContrast" overrides colors when in high-contrast mode.
         highContrast: {
             label: {
                 backgroundColor: 'black',
                 color: 'white',
+                borderWidth: 1,
+                borderColor: 'white',
             },
         },
         // This callback is used to generate a generic description for screenreaders.

--- a/tests/data/indicator-config/2-2-2.yml
+++ b/tests/data/indicator-config/2-2-2.yml
@@ -25,15 +25,15 @@ graph_annotations:
       - 2
       - 2
     label:
-      position: top
+      position: start
       content: Foo
-      fontColor: '#000000'
+      color: '#ffffff'
       backgroundColor: '#000000'
     highContrast:
       borderColor: '#ffffff'
       label:
-        fontColor: '#ffffff'
-        backgroundColor: '#000000'
+        color: '#000000'
+        backgroundColor: '#ffffff'
   - preset: target_line
     value: 1.3
     endValue: 0
@@ -46,15 +46,15 @@ graph_annotations:
       - 2
       - 2
     label:
-      position: top
+      position: start
       content: Bar
-      fontColor: '#000000'
+      color: '#ffffff'
       backgroundColor: '#000000'
     highContrast:
       borderColor: '#ffffff'
       label:
-        fontColor: '#ffffff'
-        backgroundColor: '#000000'
+        color: '#000000'
+        backgroundColor: '#ffffff'
 graph_limits: []
 graph_stacked_disaggregation: ''
 graph_title: global_indicators.2-2-2-title

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -330,6 +330,6 @@ site_config_form:
         - goal-by-target-vertical
   repository_link: /tree/master/tests/site/_data
   translation_link: ''
-validate_indicator_config: true
+validate_indicator_config: false
 validate_site_config: false
 x_axis_label: Year

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -330,6 +330,6 @@ site_config_form:
         - goal-by-target-vertical
   repository_link: /tree/master/tests/site/_data
   translation_link: ''
-validate_indicator_config: false
+validate_indicator_config: true
 validate_site_config: false
 x_axis_label: Year


### PR DESCRIPTION
This fixes a few things:
1. The "position" option for labels -- previously we used values like "left", "right", "top", "bottom", but now Chart.js only supports "start", "end", and "center". So this adds some backwards compatibility for the old values.
2. The "fontColor" option for labels -- for some reason we were using "fontColor" instead of the correct "color". So this adds some backwards compatibility to support both "fontColor" and "color".
3. High-contrast annotations: The high-contrast colors were not actually "kicking in" when the contrast was changed. I assume that an upgrade of Chart.js broke that. So this fixes that.

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-chartjs-annotation-fixes/8-8-1/)
Fixed issues | Fixes #1948 
Related version | 2.3.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
