### PR TITLE
Ensure checkboxes don't stay checked when switching units.

### DIFF
--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -151,14 +151,15 @@ function fieldItemStatesForView(fieldItemStates, fieldsByUnit, selectedUnit, dat
   else if (dataHasUnitSpecificFields) {
     states = fieldItemStatesForUnit(fieldItemStates, fieldsByUnit, selectedUnit);
   }
-
+  // Set all values to checked=false because they are going to be
+  // conditionally set to true below, if needed.
+  states.forEach(function(fieldItem) {
+    fieldItem.values.forEach(function(defaultFieldItemValue) {
+      defaultFieldItemValue.checked = false;
+    });
+  });
   if (selectedFields && selectedFields.length > 0) {
     states.forEach(function(fieldItem) {
-      // Set all values to checked=false because they are going to be
-      // conditionally set to true below, if needed.
-      fieldItem.values.forEach(function(defaultFieldItemValue) {
-        defaultFieldItemValue.checked = false;
-      });
       var selectedField = selectedFields.find(function(selectedItem) {
         return selectedItem.field === fieldItem.field;
       });

--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -154,6 +154,11 @@ function fieldItemStatesForView(fieldItemStates, fieldsByUnit, selectedUnit, dat
 
   if (selectedFields && selectedFields.length > 0) {
     states.forEach(function(fieldItem) {
+      // Set all values to checked=false because they are going to be
+      // conditionally set to true below, if needed.
+      fieldItem.values.forEach(function(defaultFieldItemValue) {
+        defaultFieldItemValue.checked = false;
+      });
       var selectedField = selectedFields.find(function(selectedItem) {
         return selectedItem.field === fieldItem.field;
       });

--- a/_includes/assets/js/plugins/leaflet.disaggregationControls.js
+++ b/_includes/assets/js/plugins/leaflet.disaggregationControls.js
@@ -451,9 +451,11 @@
                 validFields = Object.keys(disaggregations[0]),
                 invalidFields = [this.seriesColumn, this.unitsColumn],
                 allDisaggregations = [];
-            this.plugin.configObsAttributes.forEach(function(obsAttribute) {
-                invalidFields.push(obsAttribute.field);
-            });
+            if (this.plugin.configObsAttributes && this.plugin.configObsAttributes.length > 0) {
+                this.plugin.configObsAttributes.forEach(function(obsAttribute) {
+                    invalidFields.push(obsAttribute.field);
+                });
+            }
 
             this.fieldsInOrder.forEach(function(field) {
                 if (!(invalidFields.includes(field)) && validFields.includes(field)) {


### PR DESCRIPTION
Test a variety of indicators to make sure all working properly - ones with multiple series, units and make sure all the settings work and checkboxes update. what happens to the checkboxes as you change settings - anything unexpected?

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-keep-user-selections-on-unit-change/3-3-2/)
Fixed issues | Fixes #2012 
Related version | 2.3.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
