### PR TITLE
Always limit width of disagg controls on map

### DIFF
--- a/_sass/components/_maps.scss
+++ b/_sass/components/_maps.scss
@@ -82,9 +82,7 @@
 
       z-index: 801;
       margin-right: 10px;
-      @media only screen and (min-width: 800px) {
-        max-width: 250px;
-      }
+      max-width: 250px;
       .disaggregation-list {
         background: $backgroundColor;
         padding: 5px;


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-map-disaggregation-max-width/)
Fixed issues | Fixes #ISSUENUMBER
Related version | 2.2.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
