### PR TITLE
Remove observation attributes from edges data

### DIFF
--- a/_includes/assets/js/model/dataHelpers.js
+++ b/_includes/assets/js/model/dataHelpers.js
@@ -116,6 +116,17 @@ function inputEdges(edges) {
       return true;
     });
   }
+  var configuredObservationAttributes = {{ site.observation_attributes | jsonify }};
+  if (configuredObservationAttributes && configuredObservationAttributes.length > 0) {
+    configuredObservationAttributesFlat = configuredObservationAttributes.map(function(att) { return att.field; });
+    edgesData = edgesData.filter(function(edge) {
+      if (configuredObservationAttributesFlat.includes(edge.To) || configuredObservationAttributesFlat.includes(edge.From)) {
+        return false;
+      }
+      return true;
+    });
+  }
+
   return edgesData;
 }
 

--- a/tests/data/data/indicator_4-4-1.csv
+++ b/tests/data/data/indicator_4-4-1.csv
@@ -1,0 +1,4 @@
+Year,Age,COMMENT_OBS,Value
+2008,,estimated,8.5
+2008,17 and under,estimated,12.8
+

--- a/tests/data/indicator-config/4-4-1.yml
+++ b/tests/data/indicator-config/4-4-1.yml
@@ -1,0 +1,27 @@
+copyright: ''
+data_footnote: ''
+data_non_statistical: false
+data_notice_class: ''
+data_notice_heading: ''
+data_notice_text: ''
+data_show_map: true
+data_start_values: []
+embedded_feature_footer: ''
+embedded_feature_html: ''
+embedded_feature_tab_title: ''
+embedded_feature_title: ''
+embedded_feature_url: ''
+footer_fields: []
+graph_annotations: []
+graph_limits: []
+graph_stacked_disaggregation: ''
+graph_title: global_indicators.4-4-1-title
+graph_titles: []
+graph_type: line
+indicator_name: global_indicators.4-4-1-title
+indicator_number: 4.4.1
+national_geographical_coverage: ''
+page_content: >
+  This indicator is used to test issues with observation attributes in combination with headline data.
+reporting_status: complete
+tags: []

--- a/tests/features/ObservationAttributes.feature
+++ b/tests/features/ObservationAttributes.feature
@@ -28,3 +28,10 @@ Feature: Observation attributes
     And I should not see "60 [note 6]"
     And I click on "the second series"
     Then I should see "60 [note 6]"
+
+  Scenario: Disaggregation appears even when observation attributes are used with headline data
+    Given I am on "/4-4-1"
+    And I wait 3 seconds
+    And I click on "the filter drop-down button"
+    And I click on "the first filter option"
+    Then I should see 1 "chart legend item" element

--- a/tests/features/ObservationAttributes.feature
+++ b/tests/features/ObservationAttributes.feature
@@ -34,4 +34,4 @@ Feature: Observation attributes
     And I wait 3 seconds
     And I click on "the filter drop-down button"
     And I click on "the first filter option"
-    Then I should see 1 "chart legend item" element
+    Then I should see 2 "chart legend item" elements

--- a/tests/features/Search.feature
+++ b/tests/features/Search.feature
@@ -54,14 +54,14 @@ Feature: Search
     And I fill in "the search box" with "proportions"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "Results found: 10"
+    Then I should see "Results found: 11"
 
   Scenario: Searching for words also matches their stems in other languages
     Given I am on "/es"
     And I fill in "the search box" with "proporciónes"
     And I send key "Enter" in "the search box" element
     And I wait 5 seconds
-    Then I should see "Results found (translated): 10"
+    Then I should see "Results found (translated): 11"
 
   Scenario: Searching for nothing displays no results
     Given I am on the homepage


### PR DESCRIPTION
Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-observation-attribute-with-headline-bug/1-5-1/)
Fixed issues | Fixes #2097
Related version | 2.3.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
