### PR TITLE
Use start values when changing series, unless there would be zero results

### DIFF
--- a/_includes/assets/js/indicatorModel.js
+++ b/_includes/assets/js/indicatorModel.js
@@ -234,12 +234,19 @@ var indicatorModel = function (options) {
         this.selectedSeries = startingSeries;
       }
 
-      // Decide on starting field values if not changing series.
+      // Decide on starting field values.
       var startingFields = this.selectedFields;
-      if (this.hasStartValues && !options.changingSeries) {
+      var useMinimumStartingFields = false;
+      if (this.hasStartValues) {
         startingFields = helpers.selectFieldsFromStartValues(this.startValues, this.selectableFields);
+        // Quick test to see if this would result in zero matches, in cases where
+        // the series is being changed and the new series would not show data.
+        if (options.changingSeries && !helpers.hasDataBySelectedFields(this.data, startingFields)) {
+          useMinimumStartingFields = true;
+          startingFields = this.selectedFields;
+        }
       }
-      else {
+      if (!this.hasStartValues || useMinimumStartingFields) {
         if (headline.length === 0) {
           startingFields = helpers.selectMinimumStartingFields(this.data, this.selectableFields, this.selectedUnit);
         }

--- a/_includes/assets/js/model/fieldHelpers.js
+++ b/_includes/assets/js/model/fieldHelpers.js
@@ -513,6 +513,19 @@ function getDataBySelectedFields(rows, selectedFields) {
 }
 
 /**
+ * @param {Array} rows
+ * @param {Array} selectedFields Field items
+ * @return {Array} Rows
+ */
+function hasDataBySelectedFields(rows, selectedFields) {
+  return rows.some(function(row) {
+    return selectedFields.some(function(field) {
+      return field.values.includes(row[field.field]);
+    });
+  });
+}
+
+/**
  * @param {Array} fieldNames
  * @param {Object} dataSchema
  */

--- a/_includes/assets/js/model/helpers.js
+++ b/_includes/assets/js/model/helpers.js
@@ -70,6 +70,7 @@
     getDataByUnit: getDataByUnit,
     getDataBySeries: getDataBySeries,
     getDataBySelectedFields: getDataBySelectedFields,
+    hasDataBySelectedFields: hasDataBySelectedFields,
     getUnitFromStartValues: getUnitFromStartValues,
     getSeriesFromStartValues: getSeriesFromStartValues,
     selectFieldsFromStartValues: selectFieldsFromStartValues,

--- a/tests/data/data/indicator_2-3-1.csv
+++ b/tests/data/data/indicator_2-3-1.csv
@@ -55,3 +55,7 @@ Year,Group,Fruit,Units,Series,Value
 2015,B,Orange,Total,Series B,1030
 2016,A,Orange,Total,Series B,1010
 2016,B,Orange,Total,Series B,1030
+2015,C,,Percent,Series C,300
+2016,C,,Percent,Series C,600
+2015,C,,Total,Series C,1010
+2016,C,,Total,Series C,1010

--- a/tests/data/data/indicator_2-3-1.csv
+++ b/tests/data/data/indicator_2-3-1.csv
@@ -1,29 +1,57 @@
-Year,Group,Fruit,Units,Value
-2015,,,Percent,100
-2016,,,Percent,100
-2015,A,,Percent,30
-2015,B,,Percent,70
-2016,A,,Percent,60
-2016,B,,Percent,40
-2015,A,Apple,Percent,10
-2015,B,Apple,Percent,90
-2016,A,Apple,Percent,80
-2016,B,Apple,Percent,20
-2015,A,Orange,Percent,30
-2015,B,Orange,Percent,70
-2016,A,Orange,Percent,90
-2016,B,Orange,Percent,10
-2015,,,Total,108
-2016,,,Total,109
-2015,A,,Total,101
-2015,B,,Total,103
-2016,A,,Total,101
-2016,B,,Total,103
-2015,A,Apple,Total,101
-2015,B,Apple,Total,103
-2016,A,Apple,Total,101
-2016,B,Apple,Total,103
-2015,A,Orange,Total,101
-2015,B,Orange,Total,103
-2016,A,Orange,Total,101
-2016,B,Orange,Total,103
+Year,Group,Fruit,Units,Series,Value
+2015,,,Percent,Series A,100
+2016,,,Percent,Series A,100
+2015,A,,Percent,Series A,30
+2015,B,,Percent,Series A,70
+2016,A,,Percent,Series A,60
+2016,B,,Percent,Series A,40
+2015,A,Apple,Percent,Series A,10
+2015,B,Apple,Percent,Series A,90
+2016,A,Apple,Percent,Series A,80
+2016,B,Apple,Percent,Series A,20
+2015,A,Orange,Percent,Series A,30
+2015,B,Orange,Percent,Series A,70
+2016,A,Orange,Percent,Series A,90
+2016,B,Orange,Percent,Series A,10
+2015,,,Total,Series A,108
+2016,,,Total,Series A,09
+2015,A,,Total,Series A,101
+2015,B,,Total,Series A,103
+2016,A,,Total,Series A,101
+2016,B,,Total,Series A,103
+2015,A,Apple,Total,Series A,101
+2015,B,Apple,Total,Series A,103
+2016,A,Apple,Total,Series A,101
+2016,B,Apple,Total,Series A,103
+2015,A,Orange,Total,Series A,101
+2015,B,Orange,Total,Series A,103
+2016,A,Orange,Total,Series A,101
+2016,B,Orange,Total,Series A,103
+2015,,,Percent,Series B,1000
+2016,,,Percent,Series B,1000
+2015,A,,Percent,Series B,300
+2015,B,,Percent,Series B,700
+2016,A,,Percent,Series B,600
+2016,B,,Percent,Series B,400
+2015,A,Apple,Percent,Series B,100
+2015,B,Apple,Percent,Series B,900
+2016,A,Apple,Percent,Series B,800
+2016,B,Apple,Percent,Series B,200
+2015,A,Orange,Percent,Series B,300
+2015,B,Orange,Percent,Series B,700
+2016,A,Orange,Percent,Series B,900
+2016,B,Orange,Percent,Series B,100
+2015,,,Total,Series B,1080
+2016,,,Total,Series B,090
+2015,A,,Total,Series B,1010
+2015,B,,Total,Series B,1030
+2016,A,,Total,Series B,1010
+2016,B,,Total,Series B,1030
+2015,A,Apple,Total,Series B,1010
+2015,B,Apple,Total,Series B,1030
+2016,A,Apple,Total,Series B,1010
+2016,B,Apple,Total,Series B,1030
+2015,A,Orange,Total,Series B,1010
+2015,B,Orange,Total,Series B,1030
+2016,A,Orange,Total,Series B,1010
+2016,B,Orange,Total,Series B,1030

--- a/tests/features/StartValues.feature
+++ b/tests/features/StartValues.feature
@@ -1,0 +1,19 @@
+Feature: Start values
+
+  As a site administrator
+  I need to be able to specify the starting values for an indicator
+  So that I can show the end-user the relevant data
+
+  Background:
+    Given I am on "/2-3-1"
+    And I wait 3 seconds
+
+  Scenario: The indicator start values correctly show when the page is loaded
+    Then I should see 7 "chart legend item" elements
+
+  Scenario: The indicator start values correctly show after changing the series
+    And I click on "the second series"
+    And I wait 1 second
+    And I click on "the first series"
+    And I wait 1 second
+    Then I should see 7 "chart legend item" elements

--- a/tests/features/StartValues.feature
+++ b/tests/features/StartValues.feature
@@ -17,3 +17,8 @@ Feature: Start values
     And I click on "the first series"
     And I wait 1 second
     Then I should see 7 "chart legend item" elements
+
+  Scenario: The indicator start values are not used if they would result in 0 data
+    And I click on "the third series"
+    And I wait 1 second
+    Then I should see 2 "chart legend item" elements

--- a/tests/features/StartValues.feature
+++ b/tests/features/StartValues.feature
@@ -21,4 +21,4 @@ Feature: Start values
   Scenario: The indicator start values are not used if they would result in 0 data
     And I click on "the third series"
     And I wait 1 second
-    Then I should see 2 "chart legend item" elements
+    Then I should see 1 "chart legend item" element


### PR DESCRIPTION
This PR is intended to correct a regression caused by #2076. It hopefully covers the scenario that #2076 was addressing as well. This will unfortunately add some processing time when changing the series in an indicator that has starting values - but hopefully it is not noticeable or rare enough that it's OK.

Q | A
--- | ---
Feature branch/test site URL | [Link](add link here)
Fixed issues | Fixes #2154 
Related version | 2.4.0-dev
Bugfix, feature or docs? | Bugfix
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry
