### PR TITLE
Progress status page

### DIFF
--- a/_includes/assets/js/config-schema/schema-site-config-ui.json
+++ b/_includes/assets/js/config-schema/schema-site-config-ui.json
@@ -245,6 +245,10 @@
                     "elements": [
                         {
                             "type": "Control",
+                            "scope": "#/properties/progress_status/properties/progress_tabs"
+                        },
+                        {
+                            "type": "Control",
                             "scope": "#/properties/progress_status/properties/status_heading"
                         },
                         {

--- a/_includes/assets/js/config-schema/schema-site-config.json
+++ b/_includes/assets/js/config-schema/schema-site-config.json
@@ -1082,6 +1082,11 @@
             "title": "Progress status",
             "description": "This setting is used in the 'goal-with-progress' layout. It controls the behavior of progress status functionality.",
             "properties": {
+                "progress_tabs": {
+                    "title": "Progress tab",
+                    "type": "boolean",
+                    "description": "If enabled, show a tab on the 'Reporting Status' page for progress status by goal."
+                },
                 "status_heading": {
                     "title": "Status heading",
                     "type": "string",

--- a/_includes/components/progress/progress-status-by-goal.html
+++ b/_includes/components/progress/progress-status-by-goal.html
@@ -1,0 +1,52 @@
+{%- assign indicators_plural = page.t.general.indicators | downcase -%}
+
+{%- assign status_types = site.progress_status.status_types -%}
+{%- if include.status_types and site[include.status_types] -%}
+    {%- assign status_types = site[include.status_types].status_types -%}
+{%- endif -%}
+
+<h2>{{ include.title }}</h2>
+{%- for goalreport in include.goals -%}
+{%- assign goal = goalreport.goal | strip | sdg_lookup -%}
+<div class="goal reporting-status-item">
+    <div class="frame goal-tiles">
+        <a href="{{ goal.url }}" title="{{ page.t.goal.indicators_for_goal }} {{ goal.number }}" aria-label="{{ page.t.goal.indicators_for_goal }} {{ goal.number }}">
+        <img src="{{ goal.icon }}" alt="{{ goal.short | escape }} - {{ page.t.general.goal }} {{ goal.number }}" width="100" height="100" class="goal-icon-{{ goal.number }} goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+        </a>
+    </div>
+    <div class="details">
+        <h3 class="status-goal">
+            <a href="{{ goal.url }}">{{ goal.short }}</a>
+        </h3>
+        <span class="total">{{ goalreport.totals.total }} {{ include.indicator_count_label | t | default: indicators_plural }}</span>
+        {% if goalreport.totals.total > 0 %}
+        <div class="summary">
+            <div class="statuses">
+                {%- for status_type in status_types -%}
+                {% assign status_stats = goalreport.statuses | where: "status", status_type.value | first %}
+                {% if status_stats %}
+                <div>
+                    <span class="status {{ status_type.value | slugify }}"><span class="status-inner">{{ status_stats.count }}</span></span><strong>{{ status_type.label | t }}</strong><span class="value">{{ status_stats.percentage | round }}%</span>
+                </div>
+                {% endif %}
+                {%- endfor -%}
+                <br style="clear:both;">
+            </div>
+        </div>
+        <div class="goal-stats">
+            {%- for status_type in status_types -%}
+                {% assign status_stats = goalreport.statuses | where: "status", status_type.value | first %}
+                {% if status_stats %}
+                {% assign status_count_precise = status_stats.count | times: 1.0 %}
+                {% assign goalreport_total_precise = goalreport.totals.total  | times: 1.0 %}
+                {% assign percentage_precise = status_count_precise | divided_by: goalreport_total_precise | times: 100 %}
+                <span class="{{ status_type.value | slugify }}" style="width:{{ percentage_precise }}%" title="{{ status_type.label | t }}: {{ status_stats.percentage | round }}%"></span>
+                {% endif %}
+            {%- endfor -%}
+        </div>
+        {% endif %}
+        <div class="divider"></div>
+    </div>
+    <br style="clear:both;">
+</div>
+{%- endfor -%}

--- a/_includes/components/progress/progress-status-by-goal.html
+++ b/_includes/components/progress/progress-status-by-goal.html
@@ -24,11 +24,9 @@
             <div class="statuses">
                 {%- for status_type in status_types -%}
                 {% assign status_stats = goalreport.statuses | where: "status", status_type.value | first %}
-                {% if status_stats %}
                 <div>
                     <span class="status {{ status_type.value | slugify }}"><span class="status-inner">{{ status_stats.count }}</span></span><strong>{{ status_type.label | t }}</strong><span class="value">{{ status_stats.percentage | round }}%</span>
                 </div>
-                {% endif %}
                 {%- endfor -%}
                 <br style="clear:both;">
             </div>

--- a/_includes/components/progress/progress-status-label.html
+++ b/_includes/components/progress/progress-status-label.html
@@ -1,0 +1,17 @@
+{% assign status_css = include.indicator.progress_status | slugify %}
+{% case status_css %}
+    {% when "notapplicable" %}
+        {% assign status_desc = page.t.status.not_applicable %}
+    {% when "notstarted" %}
+        {% assign status_desc = page.t.status.exploring_data_sources %}
+    {% when "inprogress" %}
+        {% assign status_desc = page.t.status.statistics_in_progress %}
+    {% when "complete" %}
+        {% assign status_desc = page.t.status.reported | default: page.t.status.reported_online %}
+{% endcase %}
+{% assign reporting_status_type = site.reporting_status.status_types | where: 'value', include.indicator.reporting_status | first %}
+{% unless reporting_status_type.hide_on_goal_pages %}
+<span class="status {{ status_css }}">
+    <span class="status-inner">{{ reporting_status_type.label | t | default: status_desc }}</span>
+</span>
+{% endunless %}

--- a/_includes/components/progress/progress-status-overall.html
+++ b/_includes/components/progress/progress-status-overall.html
@@ -22,11 +22,9 @@
             <div class="statuses">
             {%- for status_type in status_types -%}
             {% assign status_stats = overall.statuses | where: "status", status_type.value | first %}
-            {% if status_stats %}
             <div>
                 <span class="status {{ status_type.value | slugify }}"><span class="status-inner">{{ status_stats.count }}</span></span><strong>{{ status_type.label | t }}</strong><span class="value">{{ status_stats.percentage | round }}%</span>
             </div>
-            {% endif %}
             {%- endfor -%}
 
             <br style="clear:both;">

--- a/_includes/components/progress/progress-status-overall.html
+++ b/_includes/components/progress/progress-status-overall.html
@@ -1,0 +1,49 @@
+{%- assign overall = include.overall -%}
+{%- assign indicators_plural = page.t.general.indicators | downcase -%}
+
+{%- assign status_types = site.progress_status.status_types -%}
+{%- if include.status_types and site[include.status_types] -%}
+    {%- assign status_types = site[include.status_types].status_types -%}
+{%- endif -%}
+
+<div class="goal goal-overall">
+    {% unless include.hide_wheel %}
+    <div class="frame goal-tiles">
+        <img src="{{ site.baseurl }}/assets/img/SDG Wheel_Transparent-01.png" alt="{{ page.t.general.sdg }}" width="100" height="100" class="goal-icon-image goal-icon-image-{{ site.goal_image_extension }}"/>
+    </div>
+    {% endunless %}
+    <div class="details">
+        <h2 class="status-goal">
+            {{ include.title }}
+        </h2>
+        <span class="total"><span>{{ overall.totals.total }}</span> {{ include.indicator_count_label | t | default: indicators_plural }}</span>
+        {% if overall.totals.total > 0 %}
+        <div class="summary">
+            <div class="statuses">
+            {%- for status_type in status_types -%}
+            {% assign status_stats = overall.statuses | where: "status", status_type.value | first %}
+            {% if status_stats %}
+            <div>
+                <span class="status {{ status_type.value | slugify }}"><span class="status-inner">{{ status_stats.count }}</span></span><strong>{{ status_type.label | t }}</strong><span class="value">{{ status_stats.percentage | round }}%</span>
+            </div>
+            {% endif %}
+            {%- endfor -%}
+
+            <br style="clear:both;">
+            </div>
+        </div>
+        <div class="goal-stats">
+            {%- for status_type in status_types -%}
+            {% assign status_stats = overall.statuses | where: "status", status_type.value | first %}
+            {% if status_stats %}
+            {% assign status_count_precise = status_stats.count | times: 1.0 %}
+            {% assign overall_total_precise = overall.totals.total  | times: 1.0 %}
+            {% assign percentage_precise = status_count_precise | divided_by: overall_total_precise | times: 100 %}
+            <span class="{{ status_type.value | slugify }}" style="width:{{ percentage_precise }}%" title="{{ status_type.label | t }}: {{ status_stats.percentage | round }}%"></span>
+            {% endif %}
+            {%- endfor -%}
+        </div>
+        {% endif %}
+    </div>
+    <br style="clear:both;">
+</div>

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -14,7 +14,7 @@
 {% assign show_progress = false %}
 {% for group in goal_indicators %}
   {% for indicator in group.items %}
-    {% if indicator.progress_status and indicator.progress_status != '' %}
+    {% if indicator.progress_status and indicator.progress_status != '' and indicator.progress_status != 'not_available' %}
       {% assign show_progress = true %}
     {% endif %}
   {% endfor %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -6,6 +6,11 @@
   {% assign reporting_data = site.data[page.language].reporting %}
 {% endif %}
 
+{% assign progress_data = site.data.progress %}
+{% if site.data[page.language].progress %}
+  {% assign progress_data = site.data[page.language].progress %}
+{% endif %}
+
 {% assign disagg_data = site.data.disaggregation %}
 {% if site.data[page.language].disaggregation %}
   {% assign disagg_data = site.data[page.language].disaggregation %}
@@ -20,6 +25,8 @@
 {% if extra_fields %}
   {% assign show_tabs = true %}
 {% elsif site.reporting_status.disaggregation_tabs and disagg_data %}
+  {% assign show_tabs = true %}
+{% elsif site.progress_status.progress_tabs and progress_data %}
   {% assign show_tabs = true %}
 {% endif %}
 <div class="container">
@@ -62,6 +69,12 @@
       {% endif %}
 
     {% endif %}
+
+    {% if site.progress_status.progress_tabs %}
+      <li role="presentation" class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#progressview" aria-controls="progressview" role="tab" {% include autotrack.html preset="tab_reporting_status_progress" category="Tab change" action="Change reporting status view" label="Change reporting status view to progress" %}>Progress status</button>
+      </li>
+    {% endif %}
   </ul>
   {% endif %}
 
@@ -100,6 +113,13 @@
       </div>
       {%- endfor -%}
     {% endif %}
+  {% endif %}
+
+  {% if site.progress_status.progress_tabs and progress_data %}
+    <div role="tabpanel" class="tab-pane" id="progressview">
+      {% include components/progress/progress-status-overall.html overall=progress_data.overall title=page.t.status.disaggregation_status_overall status_types="progress_status" indicator_count_label=site.reporting_status.disaggregation_indicator_count_label %}
+      {% include components/progress/progress-status-by-goal.html goals=progress_data.goals title=page.t.status.status_by_goal status_types="progress_status" indicator_count_label=site.reporting_status.disaggregation_indicator_count_label %}
+    </div>
   {% endif %}
 
   {% if show_tabs %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -72,7 +72,7 @@
 
     {% if site.progress_status.progress_tabs %}
       <li role="presentation" class="nav-item">
-        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#progressview" aria-controls="progressview" role="tab" {% include autotrack.html preset="tab_reporting_status_progress" category="Tab change" action="Change reporting status view" label="Change reporting status view to progress" %}>Progress status</button>
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#progressview" aria-controls="progressview" role="tab" {% include autotrack.html preset="tab_reporting_status_progress" category="Tab change" action="Change reporting status view" label="Change reporting status view to progress" %}>{{ page.t.status.progress_status }}</button>
       </li>
     {% endif %}
   </ul>
@@ -117,8 +117,8 @@
 
   {% if site.progress_status.progress_tabs and progress_data %}
     <div role="tabpanel" class="tab-pane" id="progressview">
-      {% include components/progress/progress-status-overall.html overall=progress_data.overall title=page.t.status.disaggregation_status_overall status_types="progress_status" indicator_count_label=site.reporting_status.disaggregation_indicator_count_label %}
-      {% include components/progress/progress-status-by-goal.html goals=progress_data.goals title=page.t.status.status_by_goal status_types="progress_status" indicator_count_label=site.reporting_status.disaggregation_indicator_count_label %}
+      {% include components/progress/progress-status-overall.html overall=progress_data.overall title=page.t.status.progress_status_overall status_types="progress_status" %}
+      {% include components/progress/progress-status-by-goal.html goals=progress_data.goals title=page.t.status.status_by_goal status_types="progress_status" %}
     </div>
   {% endif %}
 

--- a/_sass/layouts/_reporting_status.scss
+++ b/_sass/layouts/_reporting_status.scss
@@ -62,6 +62,30 @@
                 background-color: $status-backgroundColor-complete;
                 background: $status-backgroundColor-complete;
             }
+            .not-available {
+                background-color: $status-backgroundColor-not-available;
+                background: $status-backgroundColor-not-available;
+            }
+            .deterioration {
+                background-color: $status-backgroundColor-deterioration;
+                background: $status-backgroundColor-deterioration;
+            }
+            .limited-progress {
+                background-color: $status-backgroundColor-limited-progress;
+                background: $status-backgroundColor-limited-progress;
+            }
+            .moderate-progress {
+                background-color: $status-backgroundColor-moderate-progress;
+                background: $status-backgroundColor-moderate-progress;
+            }
+            .substantial-progress {
+                background-color: $status-backgroundColor-substantial-progress;
+                background: $status-backgroundColor-substantial-progress;
+            }
+            .target-achieved {
+                background-color: $status-backgroundColor-target-achieved;
+                background: $status-backgroundColor-target-achieved;
+            }
         }
         .divider {
             height: 15px;
@@ -164,6 +188,30 @@
                 .complete {
                     background-color: $status-backgroundColor-complete-highContrast;
                     background: $status-backgroundColor-complete-highContrast;
+                }
+                .not-available {
+                    background-color: $status-backgroundColor-not-available-highContrast;
+                    background: $status-backgroundColor-not-available-highContrast;
+                }
+                .deterioration {
+                    background-color: $status-backgroundColor-deterioration-highContrast;
+                    background: $status-backgroundColor-deterioration-highContrast;
+                }
+                .limited-progress {
+                    background-color: $status-backgroundColor-limited-progress-highContrast;
+                    background: $status-backgroundColor-limited-progress-highContrast;
+                }
+                .moderate-progress {
+                    background-color: $status-backgroundColor-moderate-progress-highContrast;
+                    background: $status-backgroundColor-moderate-progress-highContrast;
+                }
+                .substantial-progress {
+                    background-color: $status-backgroundColor-substantial-progress-highContrast;
+                    background: $status-backgroundColor-substantial-progress-highContrast;
+                }
+                .target-achieved {
+                    background-color: $status-backgroundColor-target-achieved-highContrast;
+                    background: $status-backgroundColor-target-achieved-highContrast;
                 }
             }
 

--- a/_sass/mixins/_status.scss
+++ b/_sass/mixins/_status.scss
@@ -52,6 +52,68 @@
             background: $status-backgroundColor-inner-notapplicable;
         }
     }
+    &.target-achieved {
+        color: $status-color-target-achieved;
+        border: $status-border-target-achieved;
+        // Both background-color and background are included to allow the
+        // use of patterns.
+        background-color: $status-backgroundColor-target-achieved;
+        background: $status-backgroundColor-target-achieved;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-target-achieved;
+            background: $status-backgroundColor-inner-target-achieved;
+        }
+    }
+    &.limited-progress {
+        color: $status-color-limited-progress;
+        border: $status-border-limited-progress;
+        background-color: $status-backgroundColor-limited-progress;
+        background: $status-backgroundColor-limited-progress;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-limited-progress;
+            background: $status-backgroundColor-inner-limited-progress;
+        }
+    }
+    &.moderate-progress {
+        color: $status-color-moderate-progress;
+        border: $status-border-moderate-progress;
+        background-color: $status-backgroundColor-moderate-progress;
+        background: $status-backgroundColor-moderate-progress;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-moderate-progress;
+            background: $status-backgroundColor-inner-moderate-progress;
+        }
+    }
+    &.substantial-progress {
+        color: $status-color-substantial-progress;
+        border: $status-border-substantial-progress;
+        background-color: $status-backgroundColor-substantial-progress;
+        background: $status-backgroundColor-substantial-progress;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-substantial-progress;
+            background: $status-backgroundColor-inner-substantial-progress;
+        }
+    }
+    &.deterioration{
+        color: $status-color-deterioration;
+        border: $status-border-deterioration;
+        background-color: $status-backgroundColor-deterioration;
+        background: $status-backgroundColor-deterioration;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-deterioration;
+            background: $status-backgroundColor-inner-deterioration;
+        }
+    }
+    &.not-available {
+        color: $status-color-not-available;
+        border: $status-border-not-available;
+        background-color: $status-backgroundColor-not-available;
+        background: $status-backgroundColor-not-available;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-not-available;
+            background: $status-backgroundColor-inner-not-available;
+        }
+    }
 }
 
 @mixin statusHighContrast {
@@ -97,6 +159,72 @@
             background-color: $status-backgroundColor-inner-notapplicable-highContrast !important;
             background: $status-backgroundColor-inner-notapplicable-highContrast !important;
             color: $status-color-notapplicable-highContrast !important;
+        }
+    }
+    &.target-achieved {
+        border: $status-border-target-achieved-highContrast;
+        background-color: $status-backgroundColor-target-achieved-highContrast;
+        background: $status-backgroundColor-target-achieved-highContrast;
+        color: $status-color-target-achieved-highContrast !important;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-target-achieved-highContrast !important;
+            background: $status-backgroundColor-inner-target-achieved-highContrast !important;
+            color: $status-color-target-achieved-highContrast !important;
+        }
+    }
+    &.limited-progress {
+        border: $status-border-limited-progress-highContrast;
+        background-color: $status-backgroundColor-limited-progress-highContrast;
+        background: $status-backgroundColor-limited-progress-highContrast;
+        color: $status-color-limited-progress-highContrast;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-limited-progress-highContrast !important;
+            background: $status-backgroundColor-inner-limited-progress-highContrast !important;
+            color: $status-color-limited-progress-highContrast;
+        }
+    }
+    &.moderate-progress {
+        border: $status-border-moderate-progress-highContrast;
+        background-color: $status-backgroundColor-moderate-progress-highContrast;
+        background: $status-backgroundColor-moderate-progress-highContrast;
+        color: $status-color-moderate-progress-highContrast;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-moderate-progress-highContrast !important;
+            background: $status-backgroundColor-inner-moderate-progress-highContrast !important;
+            color: $status-color-moderate-progress-highContrast;
+        }
+    }
+    &.substantial-progress {
+        border: $status-border-substantial-progress-highContrast;
+        background-color: $status-backgroundColor-substantial-progress-highContrast;
+        background: $status-backgroundColor-substantial-progress-highContrast;
+        color: $status-color-substantial-progress-highContrast;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-substantial-progress-highContrast !important;
+            background: $status-backgroundColor-inner-substantial-progress-highContrast !important;
+            color: $status-color-substantial-progress-highContrast;
+        }
+    }
+    &.deterioration {
+        border: $status-border-deterioration-highContrast;
+        background-color: $status-backgroundColor-deterioration-highContrast;
+        background: $status-backgroundColor-deterioration-highContrast;
+        color: $status-color-deterioration-highContrast !important;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-deterioration-highContrast !important;
+            background: $status-backgroundColor-inner-deterioration-highContrast !important;
+            color: $status-color-deterioration-highContrast !important;
+        }
+    }
+    &.not-available {
+        border: $status-border-not-available-highContrast;
+        background-color: $status-backgroundColor-not-available-highContrast;
+        background: $status-backgroundColor-not-available-highContrast;
+        color: $status-color-not-available-highContrast !important;
+        .status-inner {
+            background-color: $status-backgroundColor-inner-not-available-highContrast !important;
+            background: $status-backgroundColor-inner-not-available-highContrast !important;
+            color: $status-color-not-available-highContrast !important;
         }
     }
 }

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -76,71 +76,66 @@ $status-border-notstarted-highContrast: 1px solid $color-light-highContrast !def
 $status-border-notapplicable-highContrast: 1px solid $color-light-highContrast !default;
 
 $status-color-target-achieved: $color-light !default;
-$status-color-limited-progress: $text-color !default;
-$status-color-moderate-progress: $text-color !default;
 $status-color-substantial-progress: $text-color !default;
+$status-color-moderate-progress: $text-color !default;
+$status-color-limited-progress: $text-color !default;
 $status-color-deterioration: $text-color !default;
 $status-color-not-available: $text-color !default;
-$status-backgroundColor-not-available: repeating-linear-gradient(
+
+$status-backgroundColor-not-available: #FFFFFF !default;
+$status-backgroundColor-target-achieved: #1A1A1A !default;
+$status-backgroundColor-substantial-progress: #666666 !default;
+$status-backgroundColor-moderate-progress: #B3B3B3 !default;
+$status-backgroundColor-limited-progress: #F2F2F2 !default;
+$status-backgroundColor-deterioration: repeating-linear-gradient(
   135deg,
   #757575 0,
   white 10px,
   #757575 10px,
   white 20px
-);
-$status-backgroundColor-deterioration: white !default;
-$status-backgroundColor-limited-progress:
-  radial-gradient(circle, #000 1px, transparent 1px) 0 0 / 10px 10px repeat,
-  radial-gradient(circle, #000 1px, transparent 1px) 5px 5px / 10px 10px repeat,
-  #fff !default;
-$status-backgroundColor-moderate-progress:
-  radial-gradient(circle, #000 1.25px, transparent 1px) 0 -1px / 6px 6px repeat,
-  radial-gradient(circle, #000 1.25px, transparent 1px) 3px 2px / 6px 6px repeat,
-  #fff !default;
-$status-backgroundColor-substantial-progress:
-  radial-gradient(circle, #000 1.5px, transparent 1px) 0 0 / 4px 4px repeat,
-  radial-gradient(circle, #000 1.5px, transparent 1px) 2px 2px / 4px 4px repeat,
-  #fff !default;
-$status-backgroundColor-target-achieved: #2B2B2B !default;
-$status-backgroundColor-inner-target-achieved: $status-backgroundColor-target-achieved !default;
-$status-backgroundColor-inner-limited-progress: rgba(255, 255, 255, 0.9) !default;
-$status-backgroundColor-inner-moderate-progress: rgba(255, 255, 255, 0.9) !default;
-$status-backgroundColor-inner-substantial-progress: rgba(255, 255, 255, 0.9) !default;
-$status-backgroundColor-inner-deterioration: $status-backgroundColor-deterioration !default;
+) !default;
+
 $status-backgroundColor-inner-not-available: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-target-achieved: $status-backgroundColor-target-achieved !default;
+$status-backgroundColor-inner-substantial-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-moderate-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-limited-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-deterioration: rgba(255, 255, 255, 0.9) !default;
 
-$status-color-target-achieved-highContrast: $color-light-highContrast !default;
-$status-color-limited-progress-highContrast: $color-dark-highContrast !default;
-$status-color-moderate-progress-highContrast: $color-dark-highContrast !default;
-$status-color-substantial-progress-highContrast: $color-dark-highContrast !default;
-$status-color-deterioration-highContrast: $color-dark-highContrast !default;
 $status-color-not-available-highContrast: $color-dark-highContrast !default;
-$status-backgroundColor-target-achieved-highContrast: $status-backgroundColor-target-achieved !default;
-$status-backgroundColor-limited-progress-highContrast: $status-backgroundColor-limited-progress !default;
-$status-backgroundColor-moderate-progress-highContrast: $status-backgroundColor-moderate-progress !default;
-$status-backgroundColor-substantial-progress-highContrast: $status-backgroundColor-substantial-progress !default;
-$status-backgroundColor-deterioration-highContrast: $status-backgroundColor-deterioration !default;
+$status-color-target-achieved-highContrast: $color-light-highContrast !default;
+$status-color-substantial-progress-highContrast: $color-dark-highContrast !default;
+$status-color-moderate-progress-highContrast: $color-dark-highContrast !default;
+$status-color-limited-progress-highContrast: $color-dark-highContrast !default;
+$status-color-deterioration-highContrast: $color-dark-highContrast !default;
+
 $status-backgroundColor-not-available-highContrast: $status-backgroundColor-not-available !default;
-$status-backgroundColor-inner-target-achieved-highContrast: $status-backgroundColor-inner-target-achieved !default;
-$status-backgroundColor-inner-limited-progress-highContrast: $status-backgroundColor-inner-limited-progress !default;
-$status-backgroundColor-inner-moderate-progress-highContrast: $status-backgroundColor-inner-moderate-progress !default;
-$status-backgroundColor-inner-substantial-progress-highContrast: $status-backgroundColor-inner-substantial-progress !default;
-$status-backgroundColor-inner-deterioration-highContrast: $status-backgroundColor-inner-deterioration !default;
+$status-backgroundColor-target-achieved-highContrast: $status-backgroundColor-target-achieved !default;
+$status-backgroundColor-substantial-progress-highContrast: $status-backgroundColor-substantial-progress !default;
+$status-backgroundColor-moderate-progress-highContrast: $status-backgroundColor-moderate-progress !default;
+$status-backgroundColor-limited-progress-highContrast: $status-backgroundColor-limited-progress !default;
+$status-backgroundColor-deterioration-highContrast: $status-backgroundColor-deterioration !default;
+
 $status-backgroundColor-inner-not-available-highContrast: $status-backgroundColor-inner-not-available !default;
+$status-backgroundColor-inner-target-achieved-highContrast: $status-backgroundColor-inner-target-achieved !default;
+$status-backgroundColor-inner-substantial-progress-highContrast: $status-backgroundColor-inner-substantial-progress !default;
+$status-backgroundColor-inner-moderate-progress-highContrast: $status-backgroundColor-inner-moderate-progress !default;
+$status-backgroundColor-inner-limited-progress-highContrast: $status-backgroundColor-inner-limited-progress !default;
+$status-backgroundColor-inner-deterioration-highContrast: $status-backgroundColor-inner-deterioration !default;
 
-$status-border-target-achieved: 1px solid transparent !default;
-$status-border-limited-progress: 1px solid $color-dark !default;
-$status-border-moderate-progress: 1px solid transparent !default;
-$status-border-substantial-progress: 1px solid $color-dark !default;
-$status-border-deterioration: 1px solid $color-dark !default;
 $status-border-not-available: 1px solid $color-dark !default;
-$status-border-target-achieved-highContrast: 1px solid transparent !default;
-$status-border-limited-progress-highContrast: 1px solid transparent !default;
-$status-border-moderate-progress-highContrast: 1px solid transparent !default;
-$status-border-substantial-progress-highContrast: 1px solid transparent !default;
-$status-border-deterioration-highContrast: 1px solid $color-light-highContrast !default;
-$status-border-not-available-highContrast: 1px solid $color-light-highContrast !default;
+$status-border-target-achieved: 1px solid transparent !default;
+$status-border-substantial-progress: 1px solid $color-dark !default;
+$status-border-moderate-progress: 1px solid transparent !default;
+$status-border-limited-progress: 1px solid $color-dark !default;
+$status-border-deterioration: 1px solid $color-dark !default;
 
+$status-border-not-available-highContrast: 1px solid $color-light-highContrast !default;
+$status-border-target-achieved-highContrast: 1px solid transparent !default;
+$status-border-substantial-progress-highContrast: 1px solid transparent !default;
+$status-border-moderate-progress-highContrast: 1px solid transparent !default;
+$status-border-limited-progress-highContrast: 1px solid transparent !default;
+$status-border-deterioration-highContrast: 1px solid $color-light-highContrast !default;
 
 $tag-color: $color-light !default;
 $tag-border: 1px solid transparent !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -75,6 +75,73 @@ $status-border-inprogress-highContrast: 1px solid transparent !default;
 $status-border-notstarted-highContrast: 1px solid $color-light-highContrast !default;
 $status-border-notapplicable-highContrast: 1px solid $color-light-highContrast !default;
 
+$status-color-target-achieved: $color-light !default;
+$status-color-limited-progress: $text-color !default;
+$status-color-moderate-progress: $text-color !default;
+$status-color-substantial-progress: $text-color !default;
+$status-color-deterioration: $text-color !default;
+$status-color-not-available: $text-color !default;
+$status-backgroundColor-not-available: repeating-linear-gradient(
+  135deg,
+  #757575 0,
+  white 10px,
+  #757575 10px,
+  white 20px
+);
+$status-backgroundColor-deterioration: white !default;
+$status-backgroundColor-limited-progress:
+  radial-gradient(circle, #000 1px, transparent 1px) 0 0 / 10px 10px repeat,
+  radial-gradient(circle, #000 1px, transparent 1px) 5px 5px / 10px 10px repeat,
+  #fff !default;
+$status-backgroundColor-moderate-progress:
+  radial-gradient(circle, #000 1.25px, transparent 1px) 0 -1px / 6px 6px repeat,
+  radial-gradient(circle, #000 1.25px, transparent 1px) 3px 2px / 6px 6px repeat,
+  #fff !default;
+$status-backgroundColor-substantial-progress:
+  radial-gradient(circle, #000 1.5px, transparent 1px) 0 0 / 4px 4px repeat,
+  radial-gradient(circle, #000 1.5px, transparent 1px) 2px 2px / 4px 4px repeat,
+  #fff !default;
+$status-backgroundColor-target-achieved: #2B2B2B !default;
+$status-backgroundColor-inner-target-achieved: $status-backgroundColor-target-achieved !default;
+$status-backgroundColor-inner-limited-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-moderate-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-substantial-progress: rgba(255, 255, 255, 0.9) !default;
+$status-backgroundColor-inner-deterioration: $status-backgroundColor-deterioration !default;
+$status-backgroundColor-inner-not-available: rgba(255, 255, 255, 0.9) !default;
+
+$status-color-target-achieved-highContrast: $color-light-highContrast !default;
+$status-color-limited-progress-highContrast: $color-dark-highContrast !default;
+$status-color-moderate-progress-highContrast: $color-dark-highContrast !default;
+$status-color-substantial-progress-highContrast: $color-dark-highContrast !default;
+$status-color-deterioration-highContrast: $color-dark-highContrast !default;
+$status-color-not-available-highContrast: $color-dark-highContrast !default;
+$status-backgroundColor-target-achieved-highContrast: $status-backgroundColor-target-achieved !default;
+$status-backgroundColor-limited-progress-highContrast: $status-backgroundColor-limited-progress !default;
+$status-backgroundColor-moderate-progress-highContrast: $status-backgroundColor-moderate-progress !default;
+$status-backgroundColor-substantial-progress-highContrast: $status-backgroundColor-substantial-progress !default;
+$status-backgroundColor-deterioration-highContrast: $status-backgroundColor-deterioration !default;
+$status-backgroundColor-not-available-highContrast: $status-backgroundColor-not-available !default;
+$status-backgroundColor-inner-target-achieved-highContrast: $status-backgroundColor-inner-target-achieved !default;
+$status-backgroundColor-inner-limited-progress-highContrast: $status-backgroundColor-inner-limited-progress !default;
+$status-backgroundColor-inner-moderate-progress-highContrast: $status-backgroundColor-inner-moderate-progress !default;
+$status-backgroundColor-inner-substantial-progress-highContrast: $status-backgroundColor-inner-substantial-progress !default;
+$status-backgroundColor-inner-deterioration-highContrast: $status-backgroundColor-inner-deterioration !default;
+$status-backgroundColor-inner-not-available-highContrast: $status-backgroundColor-inner-not-available !default;
+
+$status-border-target-achieved: 1px solid transparent !default;
+$status-border-limited-progress: 1px solid $color-dark !default;
+$status-border-moderate-progress: 1px solid transparent !default;
+$status-border-substantial-progress: 1px solid $color-dark !default;
+$status-border-deterioration: 1px solid $color-dark !default;
+$status-border-not-available: 1px solid $color-dark !default;
+$status-border-target-achieved-highContrast: 1px solid transparent !default;
+$status-border-limited-progress-highContrast: 1px solid transparent !default;
+$status-border-moderate-progress-highContrast: 1px solid transparent !default;
+$status-border-substantial-progress-highContrast: 1px solid transparent !default;
+$status-border-deterioration-highContrast: 1px solid $color-light-highContrast !default;
+$status-border-not-available-highContrast: 1px solid $color-light-highContrast !default;
+
+
 $tag-color: $color-light !default;
 $tag-border: 1px solid transparent !default;
 $tag-backgroundColor: #707071 !default;

--- a/_sass/variables/_colors.scss
+++ b/_sass/variables/_colors.scss
@@ -82,11 +82,10 @@ $status-color-limited-progress: $text-color !default;
 $status-color-deterioration: $text-color !default;
 $status-color-not-available: $text-color !default;
 
-$status-backgroundColor-not-available: #FFFFFF !default;
-$status-backgroundColor-target-achieved: #1A1A1A !default;
-$status-backgroundColor-substantial-progress: #666666 !default;
-$status-backgroundColor-moderate-progress: #B3B3B3 !default;
-$status-backgroundColor-limited-progress: #F2F2F2 !default;
+$status-backgroundColor-target-achieved: #000000 !default;
+$status-backgroundColor-substantial-progress: #555555 !default;
+$status-backgroundColor-moderate-progress: #8A8A8A !default;
+$status-backgroundColor-limited-progress: #CFCFCF !default;
 $status-backgroundColor-deterioration: repeating-linear-gradient(
   135deg,
   #757575 0,
@@ -94,6 +93,8 @@ $status-backgroundColor-deterioration: repeating-linear-gradient(
   #757575 10px,
   white 20px
 ) !default;
+$status-backgroundColor-not-available: #FFFFFF !default;
+
 
 $status-backgroundColor-inner-not-available: rgba(255, 255, 255, 0.9) !default;
 $status-backgroundColor-inner-target-achieved: $status-backgroundColor-target-achieved !default;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -994,8 +994,8 @@ progress_status:
   status_help: ''
   status_types:
     - value: not_available
-      label: status.progress_not_available
-      alt: status.progress_not_available
+      label: status.progress_not_available_full
+      alt: status.progress_not_available_full
     - value: deterioration
       label: status.deterioration
       image: assets/img/progress/red-gauge.png

--- a/tests/data/indicator-config/1-2-1.yml
+++ b/tests/data/indicator-config/1-2-1.yml
@@ -37,3 +37,4 @@ page_content: >
   setting works)
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/1-2-2.yml
+++ b/tests/data/indicator-config/1-2-2.yml
@@ -26,3 +26,4 @@ page_content: >
   included to show an example of a "notapplicable" indicator.
 reporting_status: notapplicable
 tags: []
+progress_status: moderate_progress

--- a/tests/data/indicator-config/1-3-1.yml
+++ b/tests/data/indicator-config/1-3-1.yml
@@ -41,3 +41,4 @@ proxy_series:
   - Series B
 reporting_status: complete
 tags: []
+progress_status: substantial_progress

--- a/tests/data/indicator-config/1-4-1.yml
+++ b/tests/data/indicator-config/1-4-1.yml
@@ -26,3 +26,4 @@ page_content: >
   double-disaggregation indicator.
 reporting_status: complete
 tags: []
+progress_status: not_available

--- a/tests/data/indicator-config/1-4-2.yml
+++ b/tests/data/indicator-config/1-4-2.yml
@@ -26,3 +26,4 @@ page_content: >
   indicators without disaggregation do not show the left sidebar.
 reporting_status: complete
 tags: []
+progress_status: target_achieved

--- a/tests/data/indicator-config/1-5-1.yml
+++ b/tests/data/indicator-config/1-5-1.yml
@@ -31,3 +31,4 @@ page_content: >
   * SetMinMaxValues.feature
 reporting_status: complete
 tags: []
+progress_status: target_achieved

--- a/tests/data/indicator-config/1-5-2.yml
+++ b/tests/data/indicator-config/1-5-2.yml
@@ -58,3 +58,4 @@ reporting_status: complete
 sort: ''
 standalone: false
 tags: []
+progress_status: target_achieved

--- a/tests/data/indicator-config/1-5-3.yml
+++ b/tests/data/indicator-config/1-5-3.yml
@@ -39,3 +39,4 @@ progress_calculation_options:
     target: 1
     target_year: 2030
     unit: Percent
+progress_status: target_achieved

--- a/tests/data/indicator-config/1-5-4.yml
+++ b/tests/data/indicator-config/1-5-4.yml
@@ -38,3 +38,4 @@ progress_calculation_options:
     target: 9
     target_year: 2030
     unit: Total
+progress_status: target_achieved

--- a/tests/data/indicator-config/2-2-2.yml
+++ b/tests/data/indicator-config/2-2-2.yml
@@ -68,3 +68,4 @@ page_content: >
   that indicator names can be translated using translation keys.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/2-3-1.yml
+++ b/tests/data/indicator-config/2-3-1.yml
@@ -34,3 +34,4 @@ page_content: >
   for manual testing of the stacked bar chart.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/2-3-2.yml
+++ b/tests/data/indicator-config/2-3-2.yml
@@ -34,3 +34,4 @@ page_content: >
   that metadata can be translated using translation keys.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/2-4-1.yml
+++ b/tests/data/indicator-config/2-4-1.yml
@@ -26,3 +26,4 @@ page_content: >
   for manual testing of the binary graph type.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/2-5-1.yml
+++ b/tests/data/indicator-config/2-5-1.yml
@@ -27,3 +27,4 @@ page_content: |
   Use this indicator to manually test the graph line/bar colors.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/2-5-2.yml
+++ b/tests/data/indicator-config/2-5-2.yml
@@ -60,3 +60,4 @@ page_content: |
   chart titles, and series/unit-specific chart types.
 reporting_status: complete
 tags: []
+progress_status: limited_progress

--- a/tests/data/indicator-config/3-1-1.yml
+++ b/tests/data/indicator-config/3-1-1.yml
@@ -26,3 +26,4 @@ page_content: >
   indicator with a single disaggregation.
 reporting_status: complete
 tags: []
+progress_status: moderate_progress

--- a/tests/data/indicator-config/4-1-1.yml
+++ b/tests/data/indicator-config/4-1-1.yml
@@ -26,3 +26,4 @@ page_content: >
   to have an example of a "notstarted" indicator.
 reporting_status: notstarted
 tags: []
+progress_status: substantial_progress

--- a/tests/data/indicator-config/4-2-1.yml
+++ b/tests/data/indicator-config/4-2-1.yml
@@ -26,3 +26,4 @@ page_content: >
   indicators with only a headline do not display the sidebar.
 reporting_status: complete
 tags: []
+progress_status: substantial_progress

--- a/tests/data/indicator-config/4-2-2.yml
+++ b/tests/data/indicator-config/4-2-2.yml
@@ -33,3 +33,4 @@ reporting_status: complete
 sort: ''
 standalone: false
 tags: []
+progress_status: substantial_progress

--- a/tests/data/indicator-config/4-3-1.yml
+++ b/tests/data/indicator-config/4-3-1.yml
@@ -45,3 +45,4 @@ reporting_status: complete
 sort: ''
 standalone: false
 tags: []
+progress_status: substantial_progress

--- a/tests/data/indicator-config/4-4-1.yml
+++ b/tests/data/indicator-config/4-4-1.yml
@@ -25,3 +25,4 @@ page_content: >
   This indicator is used to test issues with observation attributes in combination with headline data.
 reporting_status: complete
 tags: []
+progress_status: substantial_progress

--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -1,5 +1,5 @@
 # These are the Python requirements for building the data.
 git+https://github.com/dougmet/yamlmd
-git+https://github.com/open-sdg/sdg-build@2.5.0-dev
+git+https://github.com/open-sdg/sdg-build@progress-status-page
 frictionless==4.40.8
 pydantic==1.*

--- a/tests/features/ReportingStatus.feature
+++ b/tests/features/ReportingStatus.feature
@@ -9,7 +9,8 @@ Feature: Reporting status page
 
   Scenario: All available goals are listed
     # 4 under "Reporting status" and 4 under "Disaggregation status"
-    Then I should see 8 "goal status" elements
+    # and 4 under "Progress status".
+    Then I should see 12 "goal status" elements
 
   Scenario: Extra fields can be used to group status and are properly translated
     And I click on "the second reporting status tab"

--- a/tests/site/Gemfile
+++ b/tests/site/Gemfile
@@ -4,6 +4,6 @@ gem "jekyll", "3.9.3"
 gem "html-proofer", "3.19.4"
 gem "jekyll-remote-theme"
 gem "deep_merge"
-gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: '2.5.0-dev'
+gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: 'progress-status-page'
 gem "kramdown-parser-gfm"
 gem "webrick"

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -270,26 +270,26 @@ progress_status:
     - value: not_available
       label: status.progress_not_available
       alt: status.progress_not_available
-    - value: deterioration
-      label: status.deterioration
-      image: assets/img/progress/red-gauge.png
-      alt: status.deterioration
-    - value: limited_progress
-      label: status.limited_progress
-      image: assets/img/progress/orange-gauge.png
-      alt: status.limited_progress
-    - value: moderate_progress
-      label: status.moderate_progress
-      image: assets/img/progress/yellow-gauge.png
-      alt: status.moderate_progress
-    - value: substantial_progress
-      label: status.substantial_progress
-      image: assets/img/progress/green-gauge.png
-      alt: status.substantial_progress
     - value: target_achieved
       label: status.target_achieved
       image: assets/img/progress/target-achieved-gauge.png
       alt: status.target_achieved
+    - value: substantial_progress
+      label: status.substantial_progress
+      image: assets/img/progress/green-gauge.png
+      alt: status.substantial_progress
+    - value: moderate_progress
+      label: status.moderate_progress
+      image: assets/img/progress/yellow-gauge.png
+      alt: status.moderate_progress
+    - value: limited_progress
+      label: status.limited_progress
+      image: assets/img/progress/orange-gauge.png
+      alt: status.limited_progress
+    - value: deterioration
+      label: status.deterioration
+      image: assets/img/progress/red-gauge.png
+      alt: status.deterioration
 progressive_web_app:
   enabled: true
   name: My SDG App Name

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -288,8 +288,8 @@ progress_status:
       image: assets/img/progress/red-gauge.png
       alt: status.deterioration
     - value: not_available
-      label: status.progress_not_available
-      alt: status.progress_not_available
+      label: status.progress_not_available_full
+      alt: status.progress_not_available_full
 progressive_web_app:
   enabled: true
   name: My SDG App Name

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -267,9 +267,6 @@ progress_status:
   status_heading: status.progress_status
   status_help: How are we doing against the 2030 targets?
   status_types:
-    - value: not_available
-      label: status.progress_not_available
-      alt: status.progress_not_available
     - value: target_achieved
       label: status.target_achieved
       image: assets/img/progress/target-achieved-gauge.png
@@ -290,6 +287,9 @@ progress_status:
       label: status.deterioration
       image: assets/img/progress/red-gauge.png
       alt: status.deterioration
+    - value: not_available
+      label: status.progress_not_available
+      alt: status.progress_not_available
 progressive_web_app:
   enabled: true
   name: My SDG App Name

--- a/tests/site/_data/site_config.yml
+++ b/tests/site/_data/site_config.yml
@@ -263,6 +263,7 @@ observation_attributes:
   - field: COMMENT_OBS
     label: ''
 progress_status:
+  progress_tabs: true
   status_heading: status.progress_status
   status_help: How are we doing against the 2030 targets?
   status_types:


### PR DESCRIPTION
This adds a new tab to the "Reporting status" page for progress status.

Q | A
--- | ---
Feature branch/test site URL | [Link](http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-progress-status-page/reporting-status/)
Fixed issues | Fixes #ISSUENUMBER
Related version | 2.5.0-dev
Bugfix, feature or docs? |
* [ ] Keeps backward-compatibility
* [ ] Includes tests
* [ ] Updated docs
* [ ] Updated config forms
* [ ] Added CHANGELOG entry

Instructions for testing:

First the site will need to have progress status for a lot of indicators, either through manually setting them in the indicator configuration, or turning on automatic calculation.

Next the site configuration needs to have the "progress_tabs" setting turned on, underneath "progress_status". Example:

```
progress_status:
  progress_tabs: true
  etc...
```

Also in the site repository, _config.yml file, change your remote theme to:

```
remote_theme: open-sdg/open-sdg@progress-status-page
```

Next, the requirements.txt in the data repository needs the line about sdg-build updated to this:

`git+https://github.com/open-sdg/sdg-build@progress-status-page`

Next, the config_data.yml file in the data repository needs to point to the latest translations:

```
  - class: TranslationInputSdgTranslations
    source: https://github.com/open-sdg/sdg-translations.git
    tag: 2.5.0-dev
```

Next, the Gemfile in the site repository needs the line about jekyll-open-sdg-plugins updated to this:

`gem 'jekyll-open-sdg-plugins', git: 'https://github.com/open-sdg/jekyll-open-sdg-plugins.git', branch: 'progress-status-page'`

Optionally, if you would like to display a more detailed version of the "not available" progress status, update the site configuration like accordingly:

```
progress_status:
  status_types:
    - value: target_achieved
      label: status.target_achieved
      image: assets/img/progress/target-achieved-gauge.png
      alt: status.target_achieved
    - value: substantial_progress
      label: status.substantial_progress
      image: assets/img/progress/green-gauge.png
      alt: status.substantial_progress
    - value: moderate_progress
      label: status.moderate_progress
      image: assets/img/progress/yellow-gauge.png
      alt: status.moderate_progress
    - value: limited_progress
      label: status.limited_progress
      image: assets/img/progress/orange-gauge.png
      alt: status.limited_progress
    - value: deterioration
      label: status.deterioration
      image: assets/img/progress/red-gauge.png
      alt: status.deterioration
    - value: not_available
      label: status.progress_not_available_full
      alt: status.progress_not_available_full
```

(ie, change "status.progress_not_available" to "status.progress_not_available_full")